### PR TITLE
Corrected the main class for BoatTerminal

### DIFF
--- a/boat-terminal/pom.xml
+++ b/boat-terminal/pom.xml
@@ -43,7 +43,7 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
-                            <mainClass>com.backbase.oss.BoatTerminal</mainClass>
+                            <mainClass>com.backbase.oss.boat.BoatTerminal</mainClass>
                         </manifest>
                     </archive>
 


### PR DESCRIPTION
This issue was found when running BoatTerminal as follows:
```
java -jar target/boat-terminal-0.0.1-SNAPSHOT-jar-with-dependencies.jar \
  -f src/test/resources/api.raml
```

The following error occurred:

`Error: Could not find or load main class com.backbase.oss.BoatTerminal`

This fixes the error.