### PR TITLE
Add configuration option to enable the addition of HttpServletRequest objects to API definition methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,15 @@ The project is very much Work In Progress and will be published on maven central
 # Release Notes
 BOAT is still under development and subject to change. 
 
+## 0.1.7
+* Added configurable flag to add HttpServletRequest parameters to codegen'd server stubs.
+
 ## 0.1.6
 * Added documentation on boat-maven-plugin
 * Upgraded YAML Libraries to improve output of YAML files
 * Use standardized swagger YAML output
 * Added Bean Validator in Code Generator
-* Changed Open API Loader to correctly resolve references from reading input location insteaf of string
+* Changed Open API Loader to correctly resolve references from reading input location instead of string
 
 ## 0.1.5
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ For the `spring` generator, the additional configuration options are:
 | `useBeanValidation` | Use BeanValidation API annotations (Default: true) |
 | `performBeanValidation` | Use Bean Validation Impl. to perform BeanValidation (Default: false) |
 | `useClassLevelBeanValidation` | Adds @Validated annotation to API interfaces (Default: false) |
+| `addServletRequest` | Adds ServletRequest objects to API method definitions (Default: false) |
 | `implicitHeaders` | Skip header parameters in the generated API methods using @ApiImplicitParams annotation. (Default: false) |
 | `swaggerDocketConfig` | Generate Spring OpenAPI Docket configuration class. (Default: false) |
 | `apiFirst` | Generate the API from the OAI spec at server compile time (API first approach) (Default: false) |

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/CodeGenMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/CodeGenMojo.java
@@ -76,6 +76,7 @@ public class CodeGenMojo extends AbstractMojo {
     public static final String SERVER_VARIABLES = "server-variables";
     public static final String RESERVED_WORDS_MAPPINGS = "reserved-words-mappings";
     public static final String USE_CLASS_LEVEL_BEANVALIDATION = "useClassLevelBeanValidation";
+    public static final String ADD_SERVLET_REQUEST = "addServletRequest";
 
     /**
      * The build context is only avail when running from within eclipse.
@@ -420,6 +421,11 @@ public class CodeGenMojo extends AbstractMojo {
     protected boolean useClassLevelBeanValidation = false;
 
     /**
+     * Adds a HttpServletRequest object to the API definition method.
+     */
+    protected boolean addServletRequest = false;
+
+    /**
      * The project being built.
      */
     @Parameter(readonly = true, required = true, defaultValue = "${project}")
@@ -635,6 +641,14 @@ public class CodeGenMojo extends AbstractMojo {
                         .parseBoolean((String) configOptions.get(USE_CLASS_LEVEL_BEANVALIDATION));
                 }
                 configurator.addAdditionalProperty(USE_CLASS_LEVEL_BEANVALIDATION, useClassLevelBeanValidation);
+
+                // Configures the addition of ServletRequests to API methods
+                if (configOptions.containsKey(ADD_SERVLET_REQUEST)) {
+                    addServletRequest = Boolean
+                        .parseBoolean((String) configOptions.get(ADD_SERVLET_REQUEST));
+                }
+                configurator.addAdditionalProperty(ADD_SERVLET_REQUEST, addServletRequest);
+
 
                 // Retained for backwards-compataibility with configOptions -> instantiation-types
                 if (instantiationTypes == null && configOptions.containsKey(INSTANTIATION_TYPES)) {

--- a/boat-maven-plugin/src/main/templates/JavaSpring/api.mustache
+++ b/boat-maven-plugin/src/main/templates/JavaSpring/api.mustache
@@ -39,6 +39,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 {{/reactive}}
 
+{{#addServletRequest}}
+import javax.servlet.http.HttpServletRequest;
+{{/addServletRequest}}
 {{#useBeanValidation}}
 import javax.validation.Valid;
 import javax.validation.constraints.*;
@@ -130,7 +133,7 @@ public interface {{classname}} {
         produces = { {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }, {{/hasProduces}}{{#hasConsumes}}
         consumes = { {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} },{{/hasConsumes}}{{/singleContentTypes}}
         method = RequestMethod.{{httpMethod}})
-    {{#jdk8-default-interface}}default {{/jdk8-default-interface}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{#delegate-method}}_{{/delegate-method}}{{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#reactive}}, {{/reactive}}{{/hasMore}}{{/allParams}}{{#reactive}}ServerWebExchange exchange{{/reactive}}){{^jdk8-default-interface}};{{/jdk8-default-interface}}{{#jdk8-default-interface}}{{#unhandledException}} throws Exception{{/unhandledException}} {
+    {{#jdk8-default-interface}}default {{/jdk8-default-interface}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{#delegate-method}}_{{/delegate-method}}{{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#reactive}}, {{/reactive}}{{^reactive}}{{#addServletRequest}}, {{/addServletRequest}}{{/reactive}}{{/hasMore}}{{/allParams}}{{#addServletRequest}}HttpServletRequest httpServletRequest{{#reactive}}, {{/reactive}}{{/addServletRequest}}{{#reactive}}ServerWebExchange exchange{{/reactive}}){{^jdk8-default-interface}};{{/jdk8-default-interface}}{{#jdk8-default-interface}}{{#unhandledException}} throws Exception{{/unhandledException}} {
         {{#delegate-method}}
         return {{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#reactive}}{{#hasParams}}, {{/hasParams}}exchange{{/reactive}});
     }


### PR DESCRIPTION
add configuration option to enable the addition of HttpServletRequest objects to API definition methods

`addServletRequest` will be defaulted to false. When enabled, it will add a HttpServletRequest object to the API interface methods

For a better view of my changes in the Template, an expanded view
```
{{#allParams}}
	{{>queryParams}}
	{{>pathParams}}
	{{>headerParams}}
	{{>bodyParams}}
	{{>formParams}}
	{{#hasMore}},{{/hasMore}}
	{{^hasMore}}
		{{#reactive}}, {{/reactive}}
		{{^reactive}}
			{{#addServletRequest}}, {{/addServletRequest}}
		{{/reactive}}
	{{/hasMore}}
{{/allParams}}
{{#addServletRequest}}
	HttpServletRequest httpServletRequest
	{{#reactive}}, {{/reactive}}
{{/addServletRequest}}
{{#reactive}}ServerWebExchange exchange{{/reactive}}
```