### PR TITLE
Override runtime dependency for org.yaml:snakeyaml with 1.24 

### DIFF
--- a/boat-engine/pom.xml
+++ b/boat-engine/pom.xml
@@ -92,6 +92,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.24</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>


### PR DESCRIPTION
#19 

`java.lang.NoSuchMethodError: org.yaml.snakeyaml.events.MappingStartEvent`

An 1.15 version of org.yaml:snakeyaml was used in runtime. When it is used as CLI maven-assembly-plugin was copying that dependency when creating **jar-with-dependencies**.

This PR override runtime dependency for org.yaml:snakeyaml with 1.24 version instead of 1.15 version.

