### PR TITLE
boat-maven-plugin bundler dereferences examples (and other fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The project is very much Work In Progress and will be published on maven central
 BOAT is still under development and subject to change.
 
 ## 0.2.6
-* Ensure RAML traits that are converted to OAS extenions are all using lower case. 
+* Ensure RAML traits that are converted to OAS extensions are all using lower case. 
 
 ## 0.2.5 
 * Fixed a bug how duplicate names are generated if RAML source has duplicate names for references. The parent resource name is now prepended to the schema name without removing the last character of the parent resource name

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/Bundler.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/Bundler.java
@@ -1,7 +1,7 @@
 package com.backbase.oss.boat.transformers;
 
+import com.backbase.oss.boat.transformers.bundler.BoatOpenAPIResolver;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.parser.OpenAPIResolver;
 import java.io.File;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -9,14 +9,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Bundler implements Transformer {
 
+    private final File inputFile;
+
+    public Bundler(File inputFile) {
+        super();
+        this.inputFile = inputFile;
+    }
 
     @Override
     public void transform(OpenAPI openAPI, Map<String, Object> options) {
-
-        File inputFile = (File) options.get("input");
-
-        OpenAPIResolver openAPIResolver = new OpenAPIResolver(openAPI, null, inputFile.toURI().toString());
+        // Use the BoatOpenApiResolver...
+        BoatOpenAPIResolver openAPIResolver = new BoatOpenAPIResolver(openAPI, null, inputFile.toURI().toString());
         openAPIResolver.resolve();
-
     }
+
 }

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatCache.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatCache.java
@@ -1,0 +1,43 @@
+package com.backbase.oss.boat.transformers.bundler;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.parser.ResolverCache;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
+import io.swagger.v3.parser.models.RefFormat;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class BoatCache extends ResolverCache {
+
+    private final ExamplesProcessor examplesProcessor;
+
+    public BoatCache(OpenAPI openApi, List<AuthorizationValue> auths, String parentFileLocation,
+        ExamplesProcessor examplesProcessor) {
+        super(openApi, auths, parentFileLocation);
+        this.examplesProcessor = examplesProcessor;
+    }
+
+    /**
+     * When loading references resources that contain links themselves, also resolve these references.
+     * @param ref
+     * @param refFormat
+     * @param expectedType
+     * @param <T>
+     * @return
+     */
+    @Override
+    public <T> T loadRef(String ref, RefFormat refFormat, Class<T> expectedType) {
+
+        log.debug("loadRef {}, {}, {}", ref, refFormat, expectedType);
+        T result = super.loadRef(ref, refFormat, expectedType);
+
+        if (result instanceof ApiResponse) {
+            // resolve references from here...
+            ApiResponse response = (ApiResponse) result;
+            examplesProcessor.processContent(response.getContent());
+        }
+        return result;
+    }
+}

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatOpenAPIResolver.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatOpenAPIResolver.java
@@ -1,0 +1,86 @@
+package com.backbase.oss.boat.transformers.bundler;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.parser.OpenAPIResolver;
+import io.swagger.v3.parser.ResolverCache;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
+import io.swagger.v3.parser.processors.ComponentsProcessor;
+import io.swagger.v3.parser.processors.OperationProcessor;
+import io.swagger.v3.parser.processors.PathsProcessor;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Same as io.swagger.v3.parser.OpenAPIResolver but allowing us to get to the ResolverCache
+ */
+public class BoatOpenAPIResolver {
+
+    private final OpenAPI openApi;
+    private final ResolverCache cache;
+    private final ComponentsProcessor componentsProcessor;
+    private final PathsProcessor pathProcessor;
+    private final OperationProcessor operationsProcessor;
+    private OpenAPIResolver.Settings settings;
+
+    private final ExamplesProcessor examplesProcessor;
+
+    public BoatOpenAPIResolver(OpenAPI openApi) {
+        this(openApi, (List)null, (String)null, (OpenAPIResolver.Settings)null);
+    }
+
+    public BoatOpenAPIResolver(OpenAPI openApi, List<AuthorizationValue> auths) {
+        this(openApi, auths, (String)null, (OpenAPIResolver.Settings)null);
+    }
+
+    public BoatOpenAPIResolver(OpenAPI openApi, List<AuthorizationValue> auths, String parentFileLocation) {
+        this(openApi, auths, parentFileLocation, (OpenAPIResolver.Settings)null);
+    }
+
+    public BoatOpenAPIResolver(OpenAPI openApi, List<AuthorizationValue> auths, String parentFileLocation, OpenAPIResolver.Settings settings) {
+        this.settings = new OpenAPIResolver.Settings();
+        this.openApi = openApi;
+        this.settings = settings != null ? settings : new OpenAPIResolver.Settings();
+        this.examplesProcessor = new ExamplesProcessor(openApi, parentFileLocation);
+        this.cache = new BoatCache(openApi, auths, parentFileLocation, examplesProcessor);
+        this.componentsProcessor = new ComponentsProcessor(openApi, this.cache);
+        this.pathProcessor = new PathsProcessor(this.cache, openApi, this.settings);
+        this.operationsProcessor = new OperationProcessor(this.cache, openApi);
+    }
+
+    public OpenAPI resolve() {
+        if (this.openApi == null) {
+            return null;
+        } else {
+            this.examplesProcessor.processExamples(openApi);
+            this.pathProcessor.processPaths();
+            this.componentsProcessor.processComponents();
+            if (this.openApi.getPaths() != null) {
+                Iterator var1 = this.openApi.getPaths().keySet().iterator();
+
+                while(true) {
+                    PathItem pathItem;
+                    do {
+                        if (!var1.hasNext()) {
+                            return this.openApi;
+                        }
+
+                        String pathname = (String)var1.next();
+                        pathItem = (PathItem)this.openApi.getPaths().get(pathname);
+                    } while(pathItem.readOperations() == null);
+
+                    Iterator var4 = pathItem.readOperations().iterator();
+
+                    while(var4.hasNext()) {
+                        Operation operation = (Operation)var4.next();
+                        this.operationsProcessor.processOperation(operation);
+                    }
+                }
+            } else {
+                return this.openApi;
+            }
+        }
+    }
+
+}

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExampleHolder.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExampleHolder.java
@@ -1,0 +1,142 @@
+package com.backbase.oss.boat.transformers.bundler;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.swagger.v3.oas.models.examples.Example;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+public abstract class ExampleHolder<T> {
+
+    private static final String FIXING_INVALID_EXAMPLE_WARNING = "%1$s is an invalid example. \n"
+        + "You've got:\n"
+        + "%1$s:\n"
+        + "  value:\n"
+        + "    $ref: %2$s\n"
+        + "Only the whole example can be a reference object:\n"
+        + "%1$s:\n"
+        + "  $ref: %2$s";
+    private static final String REF_KEY = "$ref";
+
+    private static class ExampleExampleHolder extends ExampleHolder<Example> {
+        private final boolean componentExample;
+        private ExampleExampleHolder(String name, Example example, boolean componentExample) {
+            super(name, example);
+            this.componentExample = componentExample;
+            if (example.get$ref() == null
+                && example.getValue() instanceof ObjectNode
+                && ((ObjectNode)example.getValue()).get(REF_KEY) != null) {
+                String ref = ((ObjectNode)example.getValue()).get(REF_KEY).asText();
+                log.warn(String.format(FIXING_INVALID_EXAMPLE_WARNING, name, ref));
+                example.set$ref(ref);
+                example.setValue(null);
+            }
+        }
+        @Override
+        String getRef() {
+            return example().get$ref();
+        }
+        @Override
+        void replaceRef(String ref) {
+            if (componentExample) {
+                example().set$ref(null);
+            } else {
+                example().set$ref(ref);
+            }
+        }
+    }
+
+    private static class ObjectNodeExampleHolder extends ExampleHolder<ObjectNode> {
+        private ObjectNodeExampleHolder(ObjectNode objectNode) {
+            super(null, objectNode);
+            if (objectNode.get(REF_KEY) == null
+                && objectNode.get("value") != null
+                && objectNode.get("value").get(REF_KEY) != null) {
+                String ref = objectNode.get("value").get(REF_KEY).asText();
+                log.warn(String.format(FIXING_INVALID_EXAMPLE_WARNING, "?", ref));
+                objectNode.set(REF_KEY, objectNode.get("value").get(REF_KEY));
+                objectNode.set("value", null);
+            }
+
+        }
+        @Override
+        String getRef() {
+            return example().get(REF_KEY).asText();
+        }
+        @Override
+        void replaceRef(String ref) {
+            example().put(REF_KEY, ref);
+        }
+    }
+
+    private static class MapExampleHolder extends ExampleHolder<Map> {
+
+        private MapExampleHolder(Map map) {
+            super(null, map);
+        }
+
+        @Override
+        String getRef() {
+            return (String) example().get("$ref");
+        }
+
+        @Override
+        void replaceRef(String ref) {
+            example().put(REF_KEY, ref);
+        }
+    }
+
+    private final String name;
+    private final T example;
+    private String content;
+
+    private ExampleHolder(String name, T example) {
+        super();
+        this.name = name;
+        this.example = example;
+    }
+
+    protected T example() {
+        return example;
+    }
+
+    abstract String getRef();
+    abstract void replaceRef(String ref);
+
+    public static ExampleHolder<Example> of(String name, Example example, boolean isComponentExample) {
+        return new ExampleExampleHolder(name, example, isComponentExample);
+    }
+    public static ExampleHolder<? extends Object> of(Object o) {
+        if (o instanceof ObjectNode) {
+            return new ObjectNodeExampleHolder((ObjectNode) o);
+        } else if (o instanceof Map) {
+            return new MapExampleHolder((Map) o);
+        }
+        else throw new RuntimeException("Unknown type backing example " + o.getClass().getName());
+    }
+
+    @Override
+    public String toString() {
+        return "ExampleHolder{"
+            + "name='" + name + '\''
+            + ", example=" + example
+            + '}';
+    }
+
+    public String getExampleName() {
+        return name != null ? name
+            : StringUtils.replaceEach(getRef(),
+                new String[] {"./", "examples/", ".json", ".", "/"},
+                new String[]{"", "", "", "", "-"});
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+}

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExamplesProcessor.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExamplesProcessor.java
@@ -1,0 +1,174 @@
+package com.backbase.oss.boat.transformers.bundler;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Stream.of;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.parser.models.RefFormat;
+import io.swagger.v3.parser.util.PathUtils;
+import io.swagger.v3.parser.util.RefUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+public class ExamplesProcessor {
+
+    private final OpenAPI openAPI;
+    private final Path rootDir;
+    private final Map<String, ExampleHolder> cache = newHashMap();
+
+    public ExamplesProcessor(OpenAPI openAPI, String inputFile) {
+        super();
+        this.openAPI = openAPI;
+        this.rootDir = PathUtils.getParentDirectoryOfFile(inputFile);
+    }
+
+    public void processExamples(OpenAPI openAPI) {
+
+        // dereference the /component/examples first...
+        getComponentExamplesFromOpenAPI().entrySet().stream()
+            .map(e -> ExampleHolder.of(e.getKey(), e.getValue(), true))
+            .forEach(this::fixInlineExamples);
+
+        // dereference the inline examples creating dereferenced /component/examples
+        openAPI.getPaths().entrySet().stream()
+            .flatMap(this::streamOperations)
+            .flatMap(this::streamOperationExamples)
+            .forEach(this::fixInlineExamples);
+
+    }
+
+    public void processContent(Content content) {
+        streamContentExamples(content).forEach(this::fixInlineExamples);
+    }
+
+    private Map<String, Example> getComponentExamplesFromOpenAPI() {
+        // Apparently this is needed.
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
+        if (openAPI.getComponents().getExamples() == null) {
+            openAPI.getComponents().setExamples(newHashMap());
+        }
+        return openAPI.getComponents().getExamples();
+    }
+
+    private Stream<ExampleHolder> streamOperationExamples(Operation operation) {
+        Content requestContent = nullSafeContent(operation);
+        Collection<ApiResponse> responseResponses = nullSafeApiResponses(operation);
+        return Stream.concat(
+            streamContentExamples(requestContent),
+            responseResponses.stream()
+                .map(ApiResponse::getContent)
+                .filter(Objects::nonNull)
+                .flatMap(this::streamContentExamples)
+        );
+    }
+
+    private Content nullSafeContent(Operation operation) {
+        return operation != null
+            && operation.getRequestBody() != null
+            && operation.getRequestBody().getContent() != null
+            ? operation.getRequestBody().getContent() : new Content();
+    }
+
+    private Collection<ApiResponse> nullSafeApiResponses(Operation operation) {
+        return operation != null
+            && operation.getResponses() != null
+            ? operation.getResponses().values() : emptyList();
+    }
+
+    private Stream<ExampleHolder> streamContentExamples(Content content) {
+        return Stream.of(
+            content.values().stream().map(MediaType::getExample).filter(Objects::nonNull)
+                .map(ExampleHolder::of),
+            content.values().stream().map(MediaType::getExamples).filter(Objects::nonNull)
+                .flatMap(map -> map.entrySet().stream())
+                .map(e -> ExampleHolder.of(e.getKey(), e.getValue(), false)))
+            .flatMap(s -> s);
+    }
+
+    private Stream<Operation> streamOperations(Entry<String, PathItem> item) {
+        log.info("Processing path item {}", item.getKey());
+        PathItem pathItem = item.getValue();
+        return of(pathItem.getGet(), pathItem.getPut(), pathItem.getPost(), pathItem.getDelete());
+    }
+
+    private void fixInlineExamples(ExampleHolder exampleHolder) {
+        log.debug("fixInlineExamples: '{}'", exampleHolder);
+
+        if (exampleHolder.getRef() == null) {
+            log.debug("not fixing (ref not found): {}", exampleHolder);
+            return;
+        }
+        String refPath = exampleHolder.getRef();
+        if (RefUtils.computeRefFormat(refPath) != RefFormat.RELATIVE) {
+            log.debug("not fixing (not relative ref): '{}'", exampleHolder);
+            return;
+        }
+        try {
+            Path path = rootDir.resolve(StringUtils.strip(refPath, "./"));
+            String content = StringUtils.strip(StringUtils.replaceEach(
+                new String(Files.readAllBytes(path)),
+                new String[] {"\t"},
+                new String[] {"  "}));
+            exampleHolder.setContent(content);
+            dereferenceExample(exampleHolder);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void dereferenceExample(ExampleHolder exampleHolder) {
+        String rootName = exampleHolder.getExampleName();
+        int count = 0;
+        while (existsButNotMatching(cache.get(makeCountedName(rootName, count)), exampleHolder)) {
+            count++;
+        }
+        String exampleName = makeCountedName(rootName, count);
+        Object content = convertExampleContent(exampleHolder);
+        cache.put(exampleName, exampleHolder);
+        exampleHolder.replaceRef("#/components/examples/" + exampleName);
+        getComponentExamplesFromOpenAPI().put(exampleName, new Example()
+            .value(content)
+            .summary(exampleName));
+    }
+
+    private Object convertExampleContent(ExampleHolder exampleHolder) {
+        try {
+            if (exampleHolder.getRef().endsWith("json")) {
+                return Json.mapper().readValue(exampleHolder.getContent(), Object.class);
+            }
+            return exampleHolder.getContent();
+        } catch (JsonProcessingException | RuntimeException e) {
+            throw new RuntimeException("Failed to process example content for " + exampleHolder, e);
+        }
+    }
+
+    private boolean existsButNotMatching(ExampleHolder cached, ExampleHolder exampleHolder) {
+        return cached != null && !Objects.equals(cached.getContent(), exampleHolder.getContent());
+    }
+
+    private String makeCountedName(String s, int count) {
+        return count == 0 ? s : s + "-" + count;
+    }
+
+}

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -1,0 +1,105 @@
+package com.backbase.oss.boat.transformers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import com.backbase.oss.boat.loader.OpenAPILoader;
+import com.backbase.oss.boat.loader.OpenAPILoaderException;
+import com.backbase.oss.boat.serializer.SerializerUtils;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.Test;
+
+public class BundlerTest {
+
+    private static final String APPLICATION_JSON = "application/json";
+    private static org.hamcrest.Matcher<java.lang.String> isComponentExample = new BaseMatcher<String>() {
+
+        @Override
+        public boolean matches(Object item) {
+            return String.valueOf(item).startsWith("#/components/examples/");
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText(" should start with '#/components/examples/'");
+        }
+    };
+
+    @Test
+    public void testBundleApi() throws OpenAPILoaderException, IOException {
+
+        File input = new File("src/test/resources/openapi/bundler-examples-test-api/openapi.yaml");
+        OpenAPI openAPI = OpenAPILoader.load(input);
+
+        new Bundler(input).transform(openAPI, Collections.emptyMap());
+
+        System.out.println(SerializerUtils.toYamlString(openAPI));
+        assertThat("Single inline example is replaced with relative ref",
+            singleExampleNode(openAPI, "/users", PathItem::getGet, "200", APPLICATION_JSON).get("$ref").asText(),
+            isComponentExample);
+        assertThat("Component example without ref is left alone.",
+            openAPI.getComponents().getExamples().get("example-in-components-1").getSummary(),
+            is("component-examples with example - should be left alone"));
+        assertThat("Component example that duplicates a inline example, is left alone. But the summary is removed",
+            openAPI.getComponents().getExamples().get("example-number-one").getSummary(),
+            is("example-number-one"));
+
+        assertThat("Deep linked examples are dereferenced.",
+            singleExampleMap(openAPI, "/users", PathItem::getPost, "400", APPLICATION_JSON).get("$ref").toString(),
+            isComponentExample);
+        assertThat("The deep linked example is in /components/examples",
+            openAPI.getComponents().getExamples().get("lib-bad-request-validation-error"), notNullValue());
+
+        assertThat("Single bad example is fixed",
+            singleExampleNode(openAPI, "/users", PathItem::getPut, "400", APPLICATION_JSON).get("$ref").asText(),
+            isComponentExample);
+
+        assertThat("Multiple bad examples are fixed",
+            openAPI.getPaths().get("/users").getPut().getResponses().get("401").getContent().get(APPLICATION_JSON)
+                .getExamples().get("named-bad-example").get$ref(), isComponentExample);
+
+    }
+
+    private ObjectNode singleExampleNode(OpenAPI openAPI, String path, Function<PathItem, Operation> operation,
+            String response, String contentType) {
+        return (ObjectNode) singleExample(openAPI, path, operation, response, contentType);
+    }
+
+    private Map singleExampleMap(OpenAPI openAPI, String path, Function<PathItem, Operation> operation,
+        String response, String contentType) {
+        return (Map) singleExample(openAPI, path, operation, response, contentType);
+    }
+
+    private Object singleExample(OpenAPI openAPI, String path, Function<PathItem, Operation> operation,
+        String response, String contentType) {
+        return operation.apply(openAPI.getPaths().get(path)).getResponses().get(response).getContent().get(contentType)
+            .getExample();
+    }
+
+    // @Test - not really a test.
+    public void testDraftsApi() throws OpenAPILoaderException, IOException {
+
+        File input = new File("/Users/jasper/git/paym/payment-order-presentation-spec/src/main/resources/payment-batch-client-api-v2.yaml");
+        OpenAPI openAPI = OpenAPILoader.load(input);
+
+        new Bundler(input).transform(openAPI, Collections.emptyMap());
+
+        File output = new File("/Users/jasper/git/tp/backbase-openapi-tools/boat-engine/target/out.yaml");
+        output.delete();
+        Files.write(output.toPath(), SerializerUtils.toYamlString(openAPI).getBytes(), StandardOpenOption.CREATE);
+    }
+
+}

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-request-2.json
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-request-2.json
@@ -1,0 +1,4 @@
+{
+  "name": "Robin",
+  "role": "Intern"
+}

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-request.json
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-request.json
@@ -1,0 +1,4 @@
+{
+  "name": "Alex",
+  "role": "Manager"
+}

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-response-2.json
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-response-2.json
@@ -1,0 +1,6 @@
+{
+  "id": "85494da1-2332-4a42-9a1a-a6534be2bce0",
+  "name": "Robin",
+  "role": "Intern",
+  "rank": 2
+}

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-response.json
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-response.json
@@ -1,0 +1,7 @@
+{
+  "id": "11bd3ca6-5a26-4d97-a3f1-c59df4d6c02f",
+  "name": "Alex",
+  "role": "Manager",
+  "rank": 12,
+  "optional-param": "012"
+}

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-response.xml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-response.xml
@@ -1,0 +1,7 @@
+<user>
+  <id>11bd3ca6-5a26-4d97-a3f1-c59df4d6c02f</id>
+  <name>Alex</name>
+  <role>Manager</role>
+  <rank>12</rank>
+  <optional-param>012</optional-param>
+</user>

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/lib/examples/bad-request-validation-error.json
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/lib/examples/bad-request-validation-error.json
@@ -1,0 +1,13 @@
+{
+	"message": "Bad Request",
+	"errors": [
+		{
+			"message": "Value Exceeded. Must be between {min} and {max}.",
+			"key": "common.api.shoe-size",
+			"context": {
+				"max": "50",
+				"min": "1"
+			}
+		}
+	]
+}

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/lib/schema/bad-request-error.yaml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/lib/schema/bad-request-error.yaml
@@ -1,0 +1,13 @@
+title: BadRequestError
+type: object
+properties:
+  message:
+    description: Any further information
+    type: string
+  errors:
+    description: Detailed error information
+    type: array
+    items:
+      $ref: error-item.yaml
+required:
+  - message

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/lib/schema/error-item.yaml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/lib/schema/error-item.yaml
@@ -1,0 +1,16 @@
+title: ErrorItem
+type: object
+properties:
+  message:
+    description: Any further information.
+    type: string
+  key:
+    description: '{capability-name}.api.{api-key-name}. For generated validation
+            errors this is the path in the document the error resolves to. e.g. object
+            name + ''.'' + field'
+    type: string
+  context:
+    description: Context can be anything used to construct localised messages.
+    type: object
+    additionalProperties:
+      type: string

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
@@ -1,0 +1,176 @@
+openapi: 3.0.3
+info:
+  title: Exampled API
+  description: No description available
+  version: v1
+servers:
+  - url: /serviceName/client-api/v1
+    description: The server
+tags:
+  - name: examples
+paths:
+  /users:
+    summary: Requests and responses have a singe example - 'all' operations
+    get:
+      summary: Get, does not support request body.
+      responses:
+        '200':
+          description: A user object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPostResponse'
+              example:
+                $ref: ./examples/user-post-response.json
+    post:
+      summary: Single example
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserPostRequest'
+            example:
+              $ref: ./examples/user-post-request.json
+      responses:
+        '200':
+          description: A user object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPostResponse'
+              example:
+                $ref: ./examples/user-post-response.json
+        '400':
+          $ref: ./schemas/components.yaml#/components/schemas/BadRequestResponse
+    put:
+      summary: Single example
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserPostRequest'
+            example:
+              $ref: ./examples/user-post-request.json
+      responses:
+        '200':
+          description: A user object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPostResponse'
+              example:
+                $ref: ./examples/user-post-response.json
+        '400':
+          description: Fixing an invalid example reference
+          content:
+            application/json:
+              schema:
+                $ref: ./lib/schema/bad-request-error.yaml
+              example:
+                value:
+                  $ref: ./examples/user-post-response.json
+        '401':
+          description: Fixing an invalid example reference
+          content:
+            application/json:
+              schema:
+                $ref: ./lib/schema/bad-request-error.yaml
+              examples:
+                named-bad-example:
+                  value:
+                    $ref: ./examples/user-post-response.json
+    patch:
+      summary: Single example
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserPostRequest'
+            example:
+              $ref: ./examples/user-post-request.json
+      responses:
+        '200':
+          description: A user object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPostResponse'
+              example:
+                $ref: ./examples/user-post-response.json
+  /multi-users:
+    summary: An endpoint that has multiple examples for both request and response bodies. Also, multiple media types
+    post:
+      summary: Multiple examples
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserPostRequest'
+            examples:
+              example-number-one:
+                $ref: ./examples/user-post-request.json
+              example-number-two:
+                $ref: ./examples/user-post-request-2.json
+      responses:
+        '200':
+          description: A user object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPostResponse'
+              examples:
+                example-number-one:
+                  $ref: ./examples/user-post-response.json
+                example-number-two:
+                  $ref: ./examples/user-post-response-2.json
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/UserPostResponse'
+              examples:
+                example-number-one:
+                  $ref: ./examples/user-post-response.xml
+  /example-in-component:
+    post:
+      summary: Examples in schema cannot contain a ref
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WithExampleRequest'
+      responses:
+        '200':
+          description: A user object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WithExampleResponse'
+              examples:
+                in-component:
+                  $ref: '#/components/examples/example-in-components'
+                in-component-1:
+                  $ref: '#/components/examples/example-in-components-1'
+components:
+  schemas:
+    UserPostRequest:
+      $ref: 'schemas/post-user-request.json'
+    UserPostResponse:
+      $ref: 'schemas/post-user-response.json'
+    WithExampleRequest:
+      $ref: 'schemas/post-user-request.json'
+      example:
+        name: "Eddie"
+        rank: 99
+    WithExampleResponse:
+      $ref: 'schemas/post-user-response.json'
+  examples:
+    example-in-components:
+      $ref: ./examples/user-post-response.json
+    example-in-components-1:
+      summary: component-examples with example - should be left alone
+      value:
+        id: "1"
+        name: "Michel"
+        rank: 22
+    example-number-one:
+      summary: component-examples with reference, matching the name of a path examples - also, summary ignored.
+      $ref: ./examples/user-post-request.json

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/schemas/components.yaml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/schemas/components.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+components:
+  schemas:
+    BadRequestResponse:
+      description: Bad request response
+      content:
+        application/json:
+          schema:
+            $ref: '../lib/schema/bad-request-error.yaml'
+          example:
+            $ref: '../lib/examples/bad-request-validation-error.json'

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/schemas/post-user-request.json
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/schemas/post-user-request.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "this models a simple item.",
+  "properties": {
+    "name": {
+      "name": "string"
+    },
+    "description": {
+      "role": "string"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/schemas/post-user-response.json
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/schemas/post-user-response.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "this models a simple item.",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "rank": {
+      "type": "integer"
+    },
+    "optional-param": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/boat-maven-plugin/README.md
+++ b/boat-maven-plugin/README.md
@@ -121,6 +121,34 @@ The `boat` plugin has multiple goals:
 - `boat:validate`
 
     Validates OpenAPI specs.
+    
+    Configuration can point to a specific file, or a directory. When a directory is specified all files with a `.yaml` 
+    extension are validated. `failOnWarning` specifies whether to fail the build when validation violations are found,
+    otherwise, warnings are written to the log for everyone to ignore.
+    
+    ```
+    <configuration>
+        <input>${project.build.outputDirectory}/specs/</input>
+        <failOnWarning>true</failOnWarning>
+    </configuration>
+    ```
+
+- `boat:bundle`
+    
+    Bundles a spec by resolving external references.
+    
+    Configuration can point to a single in- and output file, or to in- and output directories. When directories are
+    specified, all file with a `.yaml` extension are bundled.
+    
+    Examples in `json` files are parsed to objects.
+    ```
+    <configuration>
+        <input>${project.basedir}/src/main/resources/</input>
+        <output>${project.build.outputDirectory}/specs/</output>
+    </configuration>
+
+    ```
+    
 
 For more information, run 
 

--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -8,7 +8,6 @@
         <artifactId>backbase-openapi-tools</artifactId>
         <version>0.2.6</version>
     </parent>
-
     <artifactId>boat-maven-plugin</artifactId>
 
     <packaging>maven-plugin</packaging>
@@ -40,8 +39,6 @@
             <artifactId>boat-diff</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-
 
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -87,6 +84,18 @@
             <artifactId>plexus-build-api</artifactId>
             <version>0.0.7</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.11.3</version>
+        </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.11.3</version>
+      </dependency>
 
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
@@ -6,6 +6,7 @@ import com.backbase.oss.boat.serializer.SerializerUtils;
 import com.backbase.oss.boat.transformers.Bundler;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
@@ -36,19 +37,47 @@ public class BundleMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         log.info("Bundling OpenAPI: {} to: {}", input, output);
 
-        OpenAPI openAPI = null;
-        try {
-            openAPI = OpenAPILoader.load(input);
-            new Bundler().transform(openAPI, Collections.singletonMap("input", input));
+        if (input.isDirectory() && output.getName().endsWith(".yaml")) {
+            throw new MojoFailureException("Both input and output need to be either a directory or a file.");
+        }
 
-            File directory = output.getParentFile();
+        File[] inputFiles;
+        File[] outputFiles;
+        if (input.isDirectory()) {
+            inputFiles = input.listFiles(new FileFilter() {
+                @Override
+                public boolean accept(File pathname) {
+                    return pathname.getName().endsWith(".yaml");
+                }
+            });
+            outputFiles = new File[inputFiles.length];
+            for (int i = 0; i < inputFiles.length; i++) {
+                outputFiles[i] = new File(output, inputFiles[i].getName());
+            }
+            log.info("Found " + inputFiles.length + " specs to bundle.");
+        } else {
+            inputFiles = new File[] {input};
+            outputFiles = new File[] {output};
+        }
+
+        for (int i = 0; i < inputFiles.length; i++) {
+            bundleOpenAPI(inputFiles[i], outputFiles[i]);
+        }
+
+    }
+
+    private void bundleOpenAPI(File inputFile, File outputFile) throws MojoExecutionException {
+        try {
+            OpenAPI openAPI = OpenAPILoader.load(inputFile);
+            new Bundler(inputFile).transform(openAPI, Collections.emptyMap());
+
+            File directory = outputFile.getParentFile();
             if (!directory.exists()) {
                 directory.mkdirs();
             }
-            Files.write(output.toPath(), SerializerUtils.toYamlString(openAPI).getBytes(), StandardOpenOption.CREATE);
+            Files.write(outputFile.toPath(), SerializerUtils.toYamlString(openAPI).getBytes(), StandardOpenOption.CREATE);
         } catch (OpenAPILoaderException | IOException e) {
-            throw new MojoExecutionException("Error transforming OpenAPI: {}" + input, e);
+            throw new MojoExecutionException("Error transforming OpenAPI: {}" + inputFile, e);
         }
-
     }
 }


### PR DESCRIPTION
`boat:bundle` now also picks up examples.
`boat:bundle` can be used to process multiple specs in one execution.
`boat:validate` can be used to validate multiple specs in one execution.
