### PR TITLE
Fix/html2 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ BOAT is still under development and subject to change.
   * Adds support for allOf with Json schema merge all of https://github.com/mokkabonna/json-schema-merge-allof
   * Fixes header x- params being escaped. eg X-Total-Count to XMinusTotalMunisCount
   * Fixes markdown in description not being escaped and breaking javascript.
+  * Fixes missing references to extended simple types (set `unAlias` option to true).
+  * Fixes missing references because confusion over whether to reference name or classname.
 * Moved the code generation into a separate module to be used by other BOAT components.
 * Cleaning up dependencies
-* Added boat:bundle mojo to bundle fragments into a single spec. 
+* Added boat:bundle mojo to bundle fragments into a single spec.
+* boat:bundle unaliases the spec. 
 
 * *Spring Generator*
   * Added `useWithModifiers` to use the `with` prefix for POJO modifiers (defaults to `false`; for compatibility with the old RAML generator must be set to `true`).

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/Bundler.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/Bundler.java
@@ -3,6 +3,7 @@ package com.backbase.oss.boat.transformers;
 import com.backbase.oss.boat.transformers.bundler.BoatOpenAPIResolver;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.io.File;
+import java.util.Collections;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,6 +22,7 @@ public class Bundler implements Transformer {
         // Use the BoatOpenApiResolver...
         BoatOpenAPIResolver openAPIResolver = new BoatOpenAPIResolver(openAPI, null, inputFile.toURI().toString());
         openAPIResolver.resolve();
+        new UnAliasTransformer().transform(openAPI, Collections.emptyMap());
     }
 
 }

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/OpenApiStreamUtil.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/OpenApiStreamUtil.java
@@ -1,0 +1,106 @@
+package com.backbase.oss.boat.transformers;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.of;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class OpenApiStreamUtil {
+
+    /**
+     * Returns a stream of all(*) the Schema in the openAPI.
+     *
+     * (*) Currently includes:
+     * - operation (get, post, put, delete, patch) requests & response bodies.
+     * - components/schemas
+     *
+     * @param openAPI to get the schema of
+     * @return a stream of the schemas in the open api.
+     */
+    static Stream<Schema> streamSchemas(OpenAPI openAPI) {
+
+        // Schema's used in operations request & response bodies as well as proper components.
+        List<Schema> firstLevelSchemas = Stream.of(
+            openAPI.getPaths().values().stream()
+                .flatMap(OpenApiStreamUtil::streamOperations)
+                .flatMap(OpenApiStreamUtil::streamSchemas),
+            openAPI.getComponents().getSchemas().values().stream())
+            .reduce(Stream::concat)
+            .orElseGet(Stream::empty)
+            .collect(toList());
+
+        // traverse down the tree of the list of first level schemas, also keep the first level schemas
+        return (Stream<Schema>) Stream.of(
+            firstLevelSchemas.stream(),
+            firstLevelSchemas.stream()
+                .map(OpenApiStreamUtil::stream)
+                .reduce(Stream::concat)
+                .orElse(Stream.empty()))
+            .reduce(Stream::concat)
+            .orElse(Stream.empty());
+    }
+
+    private static Stream<Schema> streamSchemas(Operation operation) {
+        // Schema's used in operations request & response bodies as well as proper components.
+        return Stream.of(
+            nullSafeContent(operation).values().stream()
+                .map(MediaType::getSchema)
+                .filter(Objects::nonNull),
+            nullSafeApiResponses(operation).stream()
+                .map(ApiResponse::getContent)
+                .filter(Objects::nonNull)
+                .flatMap(OpenApiStreamUtil::streamContentSchemas))
+            .reduce(Stream::concat)
+            .orElseGet(Stream::empty);
+    }
+
+    private static Stream<Schema> stream(Schema schema) {
+        if (schema instanceof ArraySchema) {
+            ArraySchema arraySchema = (ArraySchema) schema;
+            return stream(arraySchema.getItems());
+        } else if (schema.getProperties() != null) {
+            return ((Collection<Schema>)schema.getProperties().values()).stream()
+                .map(OpenApiStreamUtil::stream)
+                .reduce(Stream::concat)
+                .orElse(Stream.empty());
+        } else {
+            return Stream.of(schema);
+        }
+    }
+
+    private static Stream<Schema> streamContentSchemas(Content content) {
+        return content.values().stream().map(MediaType::getSchema);
+    }
+
+    static Stream<Operation> streamOperations(PathItem pathItem) {
+        return of(pathItem.getGet(), pathItem.getPut(), pathItem.getPost(), pathItem.getDelete(), pathItem.getPatch());
+    }
+
+    static Content nullSafeContent(Operation operation) {
+        return operation != null
+            && operation.getRequestBody() != null
+            && operation.getRequestBody().getContent() != null
+            ? operation.getRequestBody().getContent() : new Content();
+    }
+
+    static Collection<ApiResponse> nullSafeApiResponses(Operation operation) {
+        return operation != null
+            && operation.getResponses() != null
+            ? operation.getResponses().values() : emptyList();
+    }
+
+}

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/OpenApiStreamUtil.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/OpenApiStreamUtil.java
@@ -83,7 +83,7 @@ public class OpenApiStreamUtil {
     }
 
     private static Stream<Schema> streamContentSchemas(Content content) {
-        return content.values().stream().map(MediaType::getSchema);
+        return content.values().stream().map(MediaType::getSchema).filter(Objects::nonNull);
     }
 
     static Stream<Operation> streamOperations(PathItem pathItem) {

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/UnAliasTransformer.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/UnAliasTransformer.java
@@ -37,6 +37,7 @@ public class UnAliasTransformer implements Transformer {
             RefUtils.extractSimpleName(schema.get$ref()).getLeft());
         if (referredSchema == null) {
             log.warn("Referred schema {} not found in {}", schema.get$ref(), schema.getName());
+            return;
         }
         if (!isAliasOfSimpleTypes(referredSchema)) {
             return;

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/UnAliasTransformer.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/UnAliasTransformer.java
@@ -1,0 +1,97 @@
+package com.backbase.oss.boat.transformers;
+
+import com.google.common.collect.ImmutableSet;
+import io.swagger.v3.core.util.RefUtils;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class UnAliasTransformer implements Transformer {
+
+    private static final Set<String> NON_ALIAS_TYPES = ImmutableSet.<String>builder().add(
+        "object", "array", "map").build();
+
+    @Override
+    public void transform(OpenAPI openAPI, Map<String, Object> options) {
+
+        OpenApiStreamUtil.streamSchemas(openAPI)
+            .forEach(schema -> unAliasType(schema, openAPI));
+    }
+
+    private void unAliasType(Schema schema, OpenAPI openAPI) {
+        log.info("Processing {}, ref {}", schema.getName(), schema.get$ref());
+        if (schema.get$ref() == null) {
+            return;
+        }
+        if (!schema.get$ref().startsWith("#/components/schemas")) {
+            log.warn("Only unalias dereferenced schema. Cannot process reference {} in {}",
+                schema.get$ref(), schema.getName());
+            return;
+        }
+        Schema referredSchema = openAPI.getComponents().getSchemas().get(
+            RefUtils.extractSimpleName(schema.get$ref()).getLeft());
+        if (referredSchema == null) {
+            log.warn("Referred schema {} not found in {}", schema.get$ref(), schema.getName());
+        }
+        if (!isAliasOfSimpleTypes(referredSchema)) {
+            return;
+        }
+        unAlias(schema, referredSchema);
+    }
+
+    private static void unAlias(Schema schema, Schema alias) {
+        log.info("{} refers to alias type {}", schema.getName(), schema.get$ref());
+        schema.set$ref(null);
+        schema.setType(alias.getType());
+        dontOverride(schema::getName, schema::setName, alias::getName);
+        dontOverride(schema::getTitle, schema::setTitle, alias::getTitle);
+        dontOverride(schema::getMultipleOf, schema::setMultipleOf, alias::getMultipleOf);
+        dontOverride(schema::getMaximum, schema::setMaximum, alias::getMaximum);
+        dontOverride(schema::getExclusiveMaximum, schema::setExclusiveMaximum, alias::getExclusiveMaximum);
+        dontOverride(schema::getMinimum, schema::setMinimum, alias::getMinimum);
+        dontOverride(schema::getExclusiveMinimum, schema::setExclusiveMinimum, alias::getExclusiveMinimum);
+        dontOverride(schema::getMaxLength, schema::setMaxLength, alias::getMaxLength);
+        dontOverride(schema::getMinLength, schema::setMinLength, alias::getMinLength);
+        dontOverride(schema::getPattern, schema::setPattern, alias::getPattern);
+        dontOverride(schema::getMaxItems, schema::setMaxItems, alias::getMaxItems);
+        dontOverride(schema::getMinItems, schema::setMinItems, alias::getMinItems);
+        dontOverride(schema::getUniqueItems, schema::setUniqueItems, alias::getUniqueItems);
+        dontOverride(schema::getMaxProperties, schema::setMaxProperties, alias::getMaxProperties);
+        dontOverride(schema::getMinProperties, schema::setMinProperties, alias::getMinProperties);
+        dontOverride(schema::getRequired, schema::setRequired, alias::getRequired);
+        dontOverride(schema::getNot, schema::setNot, alias::getNot);
+
+        dontOverride(schema::getNot, schema::setNot, alias::getNot); 
+        dontOverride(schema::getProperties, schema::setProperties, alias::getProperties); 
+        dontOverride(schema::getAdditionalProperties, schema::setAdditionalProperties, alias::getAdditionalProperties); 
+        dontOverride(schema::getDescription, schema::setDescription, alias::getDescription); 
+        dontOverride(schema::getFormat, schema::setFormat, alias::getFormat); 
+        dontOverride(schema::getNullable, schema::setNullable, alias::getNullable); 
+        dontOverride(schema::getReadOnly, schema::setReadOnly, alias::getReadOnly); 
+        dontOverride(schema::getWriteOnly, schema::setWriteOnly, alias::getWriteOnly); 
+        dontOverride(schema::getExample, schema::setExample, alias::getExample); 
+        dontOverride(schema::getExternalDocs, schema::setExternalDocs, alias::getExternalDocs); 
+        dontOverride(schema::getDeprecated, schema::setDeprecated, alias::getDeprecated); 
+        dontOverride(schema::getXml, schema::setXml, alias::getXml); 
+        dontOverride(schema::getExtensions, schema::setExtensions, alias::getExtensions); 
+        dontOverride(schema::getEnum, schema::setEnum, alias::getEnum);
+        dontOverride(schema::getDiscriminator, schema::setDiscriminator, alias::getDiscriminator); 
+        dontOverride(schema::getExampleSetFlag, schema::setExampleSetFlag, alias::getExampleSetFlag);
+    }
+
+    private static <T> void dontOverride(Supplier<T> oGet, Consumer<T> oSet, Supplier<T> aGet) {
+        if (oGet.get() != null) {
+            return;
+        }
+        oSet.accept(aGet.get());
+    }
+
+    private static Boolean isAliasOfSimpleTypes(Schema schema) {
+        return !NON_ALIAS_TYPES.contains(schema.getType());
+    }
+}

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/UnAliasTransformer.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/UnAliasTransformer.java
@@ -66,8 +66,6 @@ public class UnAliasTransformer implements Transformer {
         dontOverride(schema::getMinProperties, schema::setMinProperties, alias::getMinProperties);
         dontOverride(schema::getRequired, schema::setRequired, alias::getRequired);
         dontOverride(schema::getNot, schema::setNot, alias::getNot);
-
-        dontOverride(schema::getNot, schema::setNot, alias::getNot); 
         dontOverride(schema::getProperties, schema::setProperties, alias::getProperties); 
         dontOverride(schema::getAdditionalProperties, schema::setAdditionalProperties, alias::getAdditionalProperties); 
         dontOverride(schema::getDescription, schema::setDescription, alias::getDescription); 

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -2,7 +2,8 @@ package com.backbase.oss.boat.transformers;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.backbase.oss.boat.loader.OpenAPILoader;
 import com.backbase.oss.boat.loader.OpenAPILoaderException;
@@ -11,6 +12,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.media.Schema;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -20,6 +22,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 public class BundlerTest {
@@ -71,6 +74,13 @@ public class BundlerTest {
             openAPI.getPaths().get("/users").getPut().getResponses().get("401").getContent().get(APPLICATION_JSON)
                 .getExamples().get("named-bad-example").get$ref(), isComponentExample);
 
+        Schema aliasedSchema = openAPI.getPaths().get("/users").getPut().getResponses().get("404").getContent().get(
+            APPLICATION_JSON).getSchema();
+        assertThat("Schema referring to aliased simple type is un-aliased",
+            aliasedSchema.get$ref(),
+            nullValue());
+        assertThat("Attributes of aliased schema are copied",
+            aliasedSchema.getPattern(), is("^[0-9].*$"));
     }
 
     private ObjectNode singleExampleNode(OpenAPI openAPI, String path, Function<PathItem, Operation> operation,

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
@@ -79,6 +79,12 @@ paths:
                 named-bad-example:
                   value:
                     $ref: ./examples/user-post-response.json
+        '404':
+          description: Refering to a simple-type alias
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AliasForString'
     patch:
       summary: Single example
       requestBody:
@@ -162,6 +168,11 @@ components:
         rank: 99
     WithExampleResponse:
       $ref: 'schemas/post-user-response.json'
+    AliasForString:
+      type: string
+      pattern: ^[0-9].*$
+      minLength: 1
+      maxLength: 30
   examples:
     example-in-components:
       $ref: ./examples/user-post-response.json

--- a/boat-scaffold/src/main/templates/htmlDocs2/index.mustache
+++ b/boat-scaffold/src/main/templates/htmlDocs2/index.mustache
@@ -143,7 +143,11 @@
     var defs = {}
     {{#models}}
     {{#model}}
+    <!-- Sometimes classname is referred.. -->
+    defs["{{classname}}"] = {{{modelJson}}};
+    <!-- Sometimes name is referred.. -->
     defs["{{name}}"] = {{{modelJson}}};
+    <!-- maybe we should just buy some cows and a field... -->
     {{/model}}
     {{/models}}
 


### PR DESCRIPTION
Documentation generation related fixes:
- references to simple types are not included in the model when compiling the template: missing types like Uuid. Added a UnaliasTransformer that removes these references and inlines the attributes of the extended simple type.
- Static html sometimes refers to schema `name`, sometimes to `classname` (probably assumes they will be the same) add both refs in js.