### PR TITLE
Fix/small fixes and features

### DIFF
--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/DereferenceComponentsPropertiesTransformer.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/DereferenceComponentsPropertiesTransformer.java
@@ -2,13 +2,10 @@ package com.backbase.oss.boat.transformers;
 
 import static com.google.common.collect.Maps.newHashMap;
 
-import io.swagger.v3.core.util.RefUtils;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import lombok.extern.slf4j.Slf4j;

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/DereferenceComponentsPropertiesTransformer.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/DereferenceComponentsPropertiesTransformer.java
@@ -23,6 +23,10 @@ public class DereferenceComponentsPropertiesTransformer implements Transformer {
 
     @Override
     public void transform(OpenAPI openAPI, Map<String, Object> options) {
+        if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+            log.debug("nothing to dereference.");
+            return;
+        }
         // Find all the components referenced from paths.
         openAPI.getComponents().getSchemas().entrySet().stream()
             .forEach(e -> deferenceSchema(e.getValue(), openAPI, e.getKey()));

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/DereferenceComponentsPropertiesTransformerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/DereferenceComponentsPropertiesTransformerTest.java
@@ -1,39 +1,25 @@
 package com.backbase.oss.boat.transformers;
 
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.backbase.oss.boat.loader.OpenAPILoader;
 import com.backbase.oss.boat.loader.OpenAPILoaderException;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.junit.Test;
 
 public class DereferenceComponentsPropertiesTransformerTest {
 
     private static final String APPLICATION_JSON = "application/json";
-    private static org.hamcrest.Matcher<String> isComponentExample = new BaseMatcher<String>() {
-
-        @Override
-        public boolean matches(Object item) {
-            return String.valueOf(item).startsWith("#/components/examples/");
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText(" should start with '#/components/examples/'");
-        }
-    };
 
     @Test
     public void testDereferenceComponentsPropertiesApi() throws OpenAPILoaderException {
@@ -41,7 +27,7 @@ public class DereferenceComponentsPropertiesTransformerTest {
         File input = new File("src/test/resources/openapi/decomposer-test-api/openapi.yaml");
         OpenAPI openAPI = OpenAPILoader.load(input);
 
-        new DereferenceComponentsPropertiesTransformer().transform(openAPI, Collections.emptyMap());
+        new DereferenceComponentsPropertiesTransformer().transform(openAPI, emptyMap());
 
         assertThat("SingleReference is not affected.",
             openAPI.getComponents().getSchemas().get("SingleReference").get$ref(),
@@ -79,6 +65,19 @@ public class DereferenceComponentsPropertiesTransformerTest {
             ((ArraySchema)openAPI.getComponents().getSchemas().get("Array")).getItems().get$ref(),
             nullValue());
 
+    }
+
+    @Test
+    public void testNullComponentsShouldNotFailWithNPE() {
+        OpenAPI openAPI = new OpenAPI();
+        new DereferenceComponentsPropertiesTransformer().transform(openAPI, emptyMap());
+    }
+
+    @Test
+    public void testNullComponentSchemasShouldNotFailWithNPE() {
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setComponents(new Components());
+        new DereferenceComponentsPropertiesTransformer().transform(openAPI, emptyMap());
     }
 
     private Schema getProperty(OpenAPI openAPI, String direct, String component) {

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/DereferenceComponentsPropertiesTransformerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/DereferenceComponentsPropertiesTransformerTest.java
@@ -65,6 +65,19 @@ public class DereferenceComponentsPropertiesTransformerTest {
             ((ArraySchema)openAPI.getComponents().getSchemas().get("Array")).getItems().get$ref(),
             nullValue());
 
+        assertThat("Referencing another schema's property schema also works",
+            ((Schema) openAPI.getComponents().getSchemas().get("ReferencingOtherComponentsProperty").getProperties()
+                .get("myCode")).getDescription(),
+                is("directors code"));
+        assertThat("Referencing another schema's property properties schema also works",
+            ((Schema) openAPI.getComponents().getSchemas().get("ReferencingOtherComponentsProperty").getProperties()
+                .get("myNested")).getDescription(),
+            is("nested id"));
+        assertThat("Referencing another schema's items schema also works",
+            ((Schema) openAPI.getComponents().getSchemas().get("ReferencingOtherComponentsProperty").getProperties()
+                .get("myDirect")).getDescription(),
+            is("direct"));
+
     }
 
     @Test

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/DereferenceComponentsPropertiesTransformerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/DereferenceComponentsPropertiesTransformerTest.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class DereferenceComponentsPropertiesTransformerTest {
@@ -83,14 +83,23 @@ public class DereferenceComponentsPropertiesTransformerTest {
     @Test
     public void testNullComponentsShouldNotFailWithNPE() {
         OpenAPI openAPI = new OpenAPI();
-        new DereferenceComponentsPropertiesTransformer().transform(openAPI, emptyMap());
+        try {
+            new DereferenceComponentsPropertiesTransformer().transform(openAPI, emptyMap());
+        } catch (NullPointerException e) {
+            Assert.fail("Unexpected NullPointerException");
+        }
+
     }
 
     @Test
     public void testNullComponentSchemasShouldNotFailWithNPE() {
         OpenAPI openAPI = new OpenAPI();
         openAPI.setComponents(new Components());
-        new DereferenceComponentsPropertiesTransformer().transform(openAPI, emptyMap());
+        try {
+            new DereferenceComponentsPropertiesTransformer().transform(openAPI, emptyMap());
+        } catch (NullPointerException e) {
+            Assert.fail("Unexpected NullPointerException");
+        }
     }
 
     private Schema getProperty(OpenAPI openAPI, String direct, String component) {

--- a/boat-engine/src/test/resources/openapi/decomposer-test-api/openapi.yaml
+++ b/boat-engine/src/test/resources/openapi/decomposer-test-api/openapi.yaml
@@ -32,8 +32,22 @@ components:
       properties:
         code:
           type: string
+          description: directors code
       required:
         - code
+    nesting:
+      type: object
+      properties:
+        internal:
+          type: object
+          properties:
+            nested:
+              type: object
+              description: nested
+              properties:
+                nestedId:
+                  type: string
+                  description: nested id
     DoubleReference:
       $ref: '#/components/schemas/DirectReference'
     ReferencingProperties:
@@ -61,3 +75,12 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/direct'
+    ReferencingOtherComponentsProperty:
+      type: object
+      properties:
+        myCode:
+          $ref: '#/components/schemas/directer/properties/code'
+        myNested:
+          $ref: '#/components/schemas/nesting/properties/internal/properties/nested/properties/nestedId'
+        myDirect:
+          $ref: '#/components/schemas/Array/items'

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/codegen/StaticHtml2Generator.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/codegen/StaticHtml2Generator.java
@@ -1,6 +1,7 @@
 package com.backbase.oss.codegen;
 
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 
 public class StaticHtml2Generator extends org.openapitools.codegen.languages.StaticHtml2Generator {
@@ -9,7 +10,7 @@ public class StaticHtml2Generator extends org.openapitools.codegen.languages.Sta
 
     public CodegenResponse fromResponse(String responseCode, ApiResponse response) {
         CodegenResponse r = super.fromResponse(responseCode,response);
-        r.message = r.message.replace("`", "\\`");
+        r.message = StringUtils.replace(r.message, "`", "\\`");
         return r;
     }
 


### PR DESCRIPTION
- simple fix to check for null value in `openApi.getComponents().getSchemas()`
- ability to resolve references like `#/components/schemas/myObject/items` or `#/components/schemas/myObject/properties/embeddedObject`
- simple fix to avoid npe in StaticHtml2Generation escaping response message.