### PR TITLE
Included relatively linked examples referenced from a relatively link…

### DIFF
--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatCache.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatCache.java
@@ -1,10 +1,13 @@
 package com.backbase.oss.boat.transformers.bundler;
 
+import static io.swagger.v3.parser.models.RefFormat.RELATIVE;
+
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.ResolverCache;
 import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.swagger.v3.parser.models.RefFormat;
+import java.nio.file.Paths;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,7 +39,12 @@ public class BoatCache extends ResolverCache {
         if (result instanceof ApiResponse) {
             // resolve references from here...
             ApiResponse response = (ApiResponse) result;
-            examplesProcessor.processContent(response.getContent());
+
+            String relativePath = null;
+            if (refFormat == RELATIVE) {
+                relativePath = Paths.get(ref.substring(0, ref.indexOf("#"))).getParent().toString();
+            }
+            examplesProcessor.processContent(response.getContent(), relativePath);
         }
         return result;
     }

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -74,6 +74,10 @@ public class BundlerTest {
             openAPI.getPaths().get("/users").getPut().getResponses().get("401").getContent().get(APPLICATION_JSON)
                 .getExamples().get("named-bad-example").get$ref(), isComponentExample);
 
+        assertThat("Relative path works",
+            openAPI.getPaths().get("/users").getPut().getResponses().get("403").getContent().get(APPLICATION_JSON)
+                .getExample(), notNullValue());
+
         Schema aliasedSchema = openAPI.getPaths().get("/users").getPut().getResponses().get("404").getContent().get(
             APPLICATION_JSON).getSchema();
         assertThat("Schema referring to aliased simple type is un-aliased",
@@ -99,10 +103,10 @@ public class BundlerTest {
             .getExample();
     }
 
-    // @Test - not really a test.
+    @Test // - not really a test.
     public void testDraftsApi() throws OpenAPILoaderException, IOException {
 
-        File input = new File("/Users/jasper/git/paym/payment-order-presentation-spec/src/main/resources/payment-batch-client-api-v2.yaml");
+        File input = new File("/Users/jasper/git/jasper/collect-specs/projects/payment-order-a2a-id-provider-spec/src/main/resources/payment-order-a2a-id-provider-service-api-v1.yaml");
         OpenAPI openAPI = OpenAPILoader.load(input);
 
         new Bundler(input).transform(openAPI, Collections.emptyMap());

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -103,7 +103,7 @@ public class BundlerTest {
             .getExample();
     }
 
-    @Test // - not really a test.
+    // @Test - not really a test.
     public void testDraftsApi() throws OpenAPILoaderException, IOException {
 
         File input = new File("/Users/jasper/git/jasper/collect-specs/projects/payment-order-a2a-id-provider-spec/src/main/resources/payment-order-a2a-id-provider-service-api-v1.yaml");

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/lib/common-types.yaml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/lib/common-types.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.1
+
+info:
+  title: OpenAPI SSDK
+  description: Common items to use in schemas.
+  version: 0.0.1
+
+paths: {}
+
+components:
+  # ------------------------------------------------
+  # Common responses.
+  # ------------------------------------------------
+  responses:
+    400BadRequest:
+      description: If one or more request parameters don't comply with the specification
+      content:
+        application/json:
+          schema:
+            $ref: 'schema/bad-request-error.yaml'
+          example:
+            $ref: 'examples/bad-request-validation-error.json'

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
@@ -79,6 +79,8 @@ paths:
                 named-bad-example:
                   value:
                     $ref: ./examples/user-post-response.json
+        '403':
+          $ref: ./lib/common-types.yaml#/components/responses/400BadRequest
         '404':
           description: Refering to a simple-type alias
           content:


### PR DESCRIPTION
Included relatively linked examples referenced from a relatively linked resource when bundling.

Spec references resource in `./lib`, resource references example in `./lib/examples` using relative link './examples`... look for the example in `./lib/examples` instead of `./examples`