### PR TITLE
Generate filename using open api info.version

### DIFF
--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
@@ -12,8 +12,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collections;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -26,6 +27,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /*
   Bundles all references in the OpenAPI specification into one file.
  */
+@Getter
+@Setter
 public class BundleMojo extends AbstractMojo {
 
     @Parameter(name = "input", required = true)
@@ -54,7 +57,7 @@ public class BundleMojo extends AbstractMojo {
         log.info("Bundling OpenAPI: {} to: {}", input, output);
 
         if (input.isDirectory() && output.getName().endsWith(".yaml")) {
-            throw new MojoFailureException("Both input and output need to be either a directory or a file.");
+            throw new MojoExecutionException("Both input and output need to be either a directory or a file.");
         }
 
         File[] inputFiles;

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/BundleMojoTest.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/BundleMojoTest.java
@@ -2,12 +2,53 @@ package com.backbase.oss.boat;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import java.io.File;
 import lombok.SneakyThrows;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class BundleMojoTest {
+
+    @Test
+    @SneakyThrows
+    public void testInputDirectoryAndOutputFile() {
+        BundleMojo mojo = new BundleMojo();
+        mojo.setInput(new File("."));
+        mojo.setOutput(new File("target/testInputDirectoryAndOutputFile.yaml"));
+
+        Assert.assertThrows(MojoExecutionException.class, () -> mojo.execute());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testSkip() {
+        BundleMojo mojo = new BundleMojo();
+        mojo.setSkip(true);
+        mojo.setInput(new File("target/testInputDirectoryAndOutputFile.yaml"));
+
+        try {
+            mojo.execute();
+        } catch (MojoExecutionException e) {
+            Assert.fail("Expecting skip execution but fails on input file not found.");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    public void testBundleFolder() {
+        BundleMojo mojo = new BundleMojo();
+
+        mojo.setInput(new File(getClass().getResource("/bundler/folder/one-client-api-v1.yaml").getFile())
+            .getParentFile());
+        mojo.setOutput(new File("target/test-bundle-folder"));
+
+        mojo.execute();
+
+        Assert.assertTrue(new File("target/test-bundle-folder/one-client-api-v1.3.5.yaml").exists());
+        Assert.assertTrue(new File("target/test-bundle-folder/one-client-api-v2.0.0.yaml").exists());
+        Assert.assertTrue(new File("target/test-bundle-folder/another-client-api-v1.7.9.yaml").exists());
+    }
 
     @Test
     @SneakyThrows

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/BundleMojoTest.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/BundleMojoTest.java
@@ -1,0 +1,60 @@
+package com.backbase.oss.boat;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import lombok.SneakyThrows;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BundleMojoTest {
+
+    @Test
+    @SneakyThrows
+    public void testVersionFileName() {
+        BundleMojo mojo = new BundleMojo();
+
+        Assert.assertEquals(
+            "payment-order-client-api-v2.0.0.yaml",
+            mojo.versionFileName("payment-order-client-api-v2.yaml", createOpenApiWithVersion("2.0.0")));
+    }
+
+    @Test
+    @SneakyThrows
+    public void testNoInfoInApi() {
+        BundleMojo mojo = new BundleMojo();
+
+        Assert.assertThrows(MojoExecutionException.class, () ->
+            mojo.versionFileName("payment-order-client-api-v2.yaml", new OpenAPI()));
+    }
+
+    @Test
+    @SneakyThrows
+    public void testNoVersionInfoInApi() {
+        BundleMojo mojo = new BundleMojo();
+
+        Assert.assertThrows(MojoExecutionException.class, () ->
+            mojo.versionFileName("payment-order-client-api-v2.yaml", createOpenApiWithVersion(null)));
+    }
+
+    @Test
+    @SneakyThrows
+    public void testInvalidVersionInApi() {
+        BundleMojo mojo = new BundleMojo();
+
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setInfo(new Info());
+        Assert.assertThrows(MojoExecutionException.class, () ->
+            mojo.versionFileName("payment-order-client-api-v2.yaml", createOpenApiWithVersion("3.0.0")));
+    }
+
+
+    private OpenAPI createOpenApiWithVersion(String version) {
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setInfo(new Info());
+        openAPI.getInfo().setVersion(version);
+        return openAPI;
+    }
+
+
+}

--- a/boat-maven-plugin/src/test/resources/bundler/folder/another-client-api-v1.yaml
+++ b/boat-maven-plugin/src/test/resources/bundler/folder/another-client-api-v1.yaml
@@ -1,0 +1,29 @@
+openapi: "3.0.0"
+info:
+  version: 1.7.9
+  title: Another
+  license:
+    name: MIT
+paths:
+  '/client-api/v1/other-ones':
+    get:
+      summary: List all other ones
+      operationId: listOtherOnes
+      responses:
+        '200':
+          description: A paged array of other ones
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OtherOnes"
+components:
+  schemas:
+    OtherOnes:
+      type: object
+      properties:
+        -id:
+          type: string
+          description: The id of this one.
+        -oneId:
+          type: string
+          description: The id of the original One

--- a/boat-maven-plugin/src/test/resources/bundler/folder/one-client-api-v1.yaml
+++ b/boat-maven-plugin/src/test/resources/bundler/folder/one-client-api-v1.yaml
@@ -1,0 +1,26 @@
+openapi: "3.0.0"
+info:
+  version: 1.3.5
+  title: Another
+  license:
+    name: MIT
+paths:
+  '/client-api/v1/ones':
+    get:
+      summary: List all ones
+      operationId: listOnes
+      responses:
+        '200':
+          description: A paged array of ones
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ones"
+components:
+  schemas:
+    Ones:
+      type: object
+      properties:
+        -id:
+          type: string
+          description: The id of this one.

--- a/boat-maven-plugin/src/test/resources/bundler/folder/one-client-api-v2.yaml
+++ b/boat-maven-plugin/src/test/resources/bundler/folder/one-client-api-v2.yaml
@@ -1,0 +1,26 @@
+openapi: "3.0.3"
+info:
+  version: 2.0.0
+  title: Another
+  license:
+    name: MIT
+paths:
+  '/client-api/v2/ones':
+    get:
+      summary: List all ones
+      operationId: listOnes
+      responses:
+        '200':
+          description: A paged array of ones
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/V2Ones"
+components:
+  schemas:
+    V2Ones:
+      type: object
+      properties:
+        -code:
+          type: string
+          description: The id of this one but named code which is a breaking change.


### PR DESCRIPTION
Bundler can now generate filename(s) that reflect the full semver version in the file name.
For instance `payment-order-client-api-v2.yaml` -> `payment-order-client-api-v2.1.48.yaml`

Includes checking the major version number in the file name matches the one in the api.