### PR TITLE
Dereference Exotic Examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
           java-version: 11
 
       - name: Get version from POM
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         run: |
           VERSION_PARTS=($(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tr "." "\n"))
           echo "::set-env name=MAJOR::${VERSION_PARTS[0]}"
@@ -42,12 +44,16 @@ jobs:
 
       - name: Setup release version
         if: contains(github.ref, 'master')
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         run: |
           NEW_VERSION="$((MAJOR)).$((MINOR+1)).0"
           echo "::set-env name=NEW_VERSION::${NEW_VERSION}"
 
       - name: Setup PR version
         if: contains(github.ref, '/pull/')
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         run: |
           NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-PR-$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')"
           echo "::set-env name=NEW_VERSION::${NEW_VERSION}"

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ The project is very much Work In Progress and will be published on maven central
 # Release Notes
 BOAT is still under development and subject to change.
 
-## 0.8.1
+## 0.9.0
 * *Maven Plugin*
   * Added `version` parameter to `bundle` goal.
+  * Added `bundleSpecs` parameter to `generate` goal to automatically bundle specs into single file
 * Modernised BOAT Terminal
 * Improved BOAT:Docs Templates
+* Properly dereference examples
 
 ## 0.8.0
 * Improved styling HTML docs

--- a/boat-engine/pom.xml
+++ b/boat-engine/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.8.1-SNAPSHOT</version>
+        <version>0.9.0</version>
     </parent>
     <artifactId>boat-engine</artifactId>
     <packaging>jar</packaging>

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatCache.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatCache.java
@@ -44,7 +44,7 @@ public class BoatCache extends ResolverCache {
             if (refFormat == RELATIVE) {
                 relativePath = Paths.get(ref.substring(0, ref.indexOf("#"))).getParent().toString();
             }
-            examplesProcessor.processContent(response.getContent(), relativePath);
+//            examplesProcessor.processContent(response.getContent(), relativePath);
         }
         return result;
     }

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatCache.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatCache.java
@@ -7,6 +7,11 @@ import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.ResolverCache;
 import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.swagger.v3.parser.models.RefFormat;
+import io.swagger.v3.parser.util.DeserializationUtils;
+import io.swagger.v3.parser.util.PathUtils;
+import io.swagger.v3.parser.util.RefUtils;
+import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -15,11 +20,31 @@ import lombok.extern.slf4j.Slf4j;
 public class BoatCache extends ResolverCache {
 
     private final ExamplesProcessor examplesProcessor;
+    private final Path parentDirectory;
+
+    private String rootPath ;
+    private List<AuthorizationValue> auths;
+    private OpenAPI openApi;
+
 
     public BoatCache(OpenAPI openApi, List<AuthorizationValue> auths, String parentFileLocation,
         ExamplesProcessor examplesProcessor) {
         super(openApi, auths, parentFileLocation);
+        this.rootPath = parentFileLocation;
+        this.openApi = openApi;
         this.examplesProcessor = examplesProcessor;
+        this.auths = auths;
+
+
+        if(parentFileLocation != null) {
+            if(parentFileLocation.startsWith("http")) {
+                parentDirectory = null;
+            } else {
+                parentDirectory = PathUtils.getParentDirectoryOfFile(parentFileLocation);
+            }
+        } else {
+            parentDirectory = new File(".").toPath();
+        }
     }
 
     /**
@@ -34,7 +59,14 @@ public class BoatCache extends ResolverCache {
     public <T> T loadRef(String ref, RefFormat refFormat, Class<T> expectedType) {
 
         log.debug("loadRef {}, {}, {}", ref, refFormat, expectedType);
-        T result = super.loadRef(ref, refFormat, expectedType);
+        T result = null;
+        try {
+            result = super.loadRef(ref, refFormat, expectedType);
+        } catch (Exception exception) {
+            log.debug("Reference: {} is something else than json or yaml", ref);
+            result = parseRef(ref, refFormat, expectedType);
+
+        }
 
         if (result instanceof ApiResponse) {
             // resolve references from here...
@@ -44,8 +76,37 @@ public class BoatCache extends ResolverCache {
             if (refFormat == RELATIVE) {
                 relativePath = Paths.get(ref.substring(0, ref.indexOf("#"))).getParent().toString();
             }
-//            examplesProcessor.processContent(response.getContent(), relativePath);
+            examplesProcessor.processContent(response.getContent(), relativePath);
         }
         return result;
     }
+
+    private <T> T parseRef(String ref, RefFormat refFormat, Class<T> expectedType) {
+        final String[] refParts = ref.split("#/");
+
+        if (refParts.length > 2) {
+            throw new RuntimeException("Invalid ref format: " + ref);
+        }
+
+        final String file = refParts[0];
+        final String definitionPath = refParts.length == 2 ? refParts[1] : null;
+        String contents = getExternalFileCache().get(file);
+
+        if(parentDirectory != null) {
+            contents = RefUtils.readExternalRef(file, refFormat, auths, parentDirectory);
+        }
+        else if(rootPath != null && rootPath.startsWith("http")) {
+            contents = RefUtils.readExternalUrlRef(file, refFormat, auths, rootPath);
+        }
+        else if (rootPath != null) {
+            contents = RefUtils.readExternalClasspathRef(file, refFormat, auths, rootPath);
+        }
+
+        T result = BoatDeserializationUtils.deserialize(contents, file, expectedType);
+        return result;
+    }
+
+
+
+
 }

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatDeserializationUtils.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatDeserializationUtils.java
@@ -1,0 +1,49 @@
+package com.backbase.oss.boat.transformers.bundler;
+
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.oas.models.examples.Example;
+
+public class BoatDeserializationUtils {
+
+    public static <T> T deserialize(Object contents, String fileOrHost, Class<T> expectedType) {
+        T result;
+
+        boolean isJson = false;
+
+        if (contents instanceof String && isJson((String) contents)) {
+            isJson = true;
+        }
+
+        if (expectedType.equals(Example.class)) {
+            Example example = new Example();
+            example.setValue(contents);
+            return (T) example;
+        }
+
+        try {
+            if (contents instanceof String) {
+                if (isJson) {
+                    result = Json.mapper().readValue((String) contents, expectedType);
+                } else {
+                    result = Yaml.mapper().readValue((String) contents, expectedType);
+                }
+            } else {
+                result = Json.mapper().convertValue(contents, expectedType);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("An exception was thrown while trying to deserialize the contents of " + fileOrHost + " into type " + expectedType, e);
+        }
+
+        return result;
+    }
+
+    private static boolean isJson(String contents) {
+        return contents.toString().trim().startsWith("{");
+    }
+
+    private static boolean isXml(String contents) {
+        return contents.toString().trim().startsWith("<");
+    }
+
+}

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatOpenAPIResolver.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/BoatOpenAPIResolver.java
@@ -27,15 +27,15 @@ public class BoatOpenAPIResolver {
     private final ExamplesProcessor examplesProcessor;
 
     public BoatOpenAPIResolver(OpenAPI openApi) {
-        this(openApi, (List)null, (String)null, (OpenAPIResolver.Settings)null);
+        this(openApi, null, null, null);
     }
 
     public BoatOpenAPIResolver(OpenAPI openApi, List<AuthorizationValue> auths) {
-        this(openApi, auths, (String)null, (OpenAPIResolver.Settings)null);
+        this(openApi, auths, null, null);
     }
 
     public BoatOpenAPIResolver(OpenAPI openApi, List<AuthorizationValue> auths, String parentFileLocation) {
-        this(openApi, auths, parentFileLocation, (OpenAPIResolver.Settings)null);
+        this(openApi, auths, parentFileLocation, null);
     }
 
     public BoatOpenAPIResolver(OpenAPI openApi, List<AuthorizationValue> auths, String parentFileLocation, OpenAPIResolver.Settings settings) {
@@ -53,33 +53,38 @@ public class BoatOpenAPIResolver {
         if (this.openApi == null) {
             return null;
         } else {
-            this.examplesProcessor.processExamples(openApi);
-            this.pathProcessor.processPaths();
-            this.componentsProcessor.processComponents();
-            if (this.openApi.getPaths() != null) {
-                Iterator var1 = this.openApi.getPaths().keySet().iterator();
+            OpenAPI openAPI = processOpenAPI();
+            examplesProcessor.processExamples(openAPI);
+            return openAPI;
+        }
+    }
 
-                while(true) {
-                    PathItem pathItem;
-                    do {
-                        if (!var1.hasNext()) {
-                            return this.openApi;
-                        }
+    private OpenAPI processOpenAPI() {
+        this.pathProcessor.processPaths();
+        this.componentsProcessor.processComponents();
+        if (this.openApi.getPaths() != null) {
+            Iterator var1 = this.openApi.getPaths().keySet().iterator();
 
-                        String pathname = (String)var1.next();
-                        pathItem = (PathItem)this.openApi.getPaths().get(pathname);
-                    } while(pathItem.readOperations() == null);
-
-                    Iterator var4 = pathItem.readOperations().iterator();
-
-                    while(var4.hasNext()) {
-                        Operation operation = (Operation)var4.next();
-                        this.operationsProcessor.processOperation(operation);
+            while(true) {
+                PathItem pathItem;
+                do {
+                    if (!var1.hasNext()) {
+                        return this.openApi;
                     }
+
+                    String pathname = (String)var1.next();
+                    pathItem = (PathItem)this.openApi.getPaths().get(pathname);
+                } while(pathItem.readOperations() == null);
+
+                Iterator var4 = pathItem.readOperations().iterator();
+
+                while(var4.hasNext()) {
+                    Operation operation = (Operation)var4.next();
+                    this.operationsProcessor.processOperation(operation);
                 }
-            } else {
-                return this.openApi;
             }
+        } else {
+            return this.openApi;
         }
     }
 

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExamplesProcessor.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExamplesProcessor.java
@@ -9,12 +9,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.examples.Example;
-import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
-import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.models.RefFormat;
 import io.swagger.v3.parser.util.PathUtils;
 import io.swagger.v3.parser.util.RefUtils;
@@ -22,18 +18,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import static com.google.common.collect.Maps.newHashMap;
-import static java.util.Collections.emptyList;
-import static java.util.stream.Stream.of;
 
 @Slf4j
 public class ExamplesProcessor {
@@ -53,21 +45,57 @@ public class ExamplesProcessor {
 
     public void processExamples(OpenAPI openAPI) {
 
+        log.info("Processing examples in Components");
         // dereference the /component/examples first...
         getComponentExamplesFromOpenAPI().entrySet().stream()
             .map(e -> ExampleHolder.of(e.getKey(), e.getValue(), true))
             .forEach(this::fixInlineExamples);
 
-        // dereference the inline examples creating dereferenced /component/examples
-        openAPI.getPaths().entrySet().stream()
-            .flatMap(this::streamOperations)
-            .flatMap(this::streamOperationExamples)
-            .forEach(this::fixInlineExamples);
 
+        openAPI.getPaths()
+            .forEach((path, pathItem) -> {
+                log.info("Processing examples in Path: {}", path);
+                pathItem.readOperationsMap().forEach((httpMethod, operation) -> {
+                    log.info("Processing examples in Operation: {}", httpMethod);
+                    if (operation.getRequestBody() != null) {
+                        operation.getRequestBody().getContent().forEach((contentType, mediaType) -> {
+                            log.info("Processing Request Body examples for Content Type: {}", contentType);
+                            processMediaType(mediaType);
+                        });
+                    }
+                    operation.getResponses().forEach((responseCode, apiResponse) -> {
+                        log.info("Processing Response Body Examples for Response Code: {}", responseCode);
+                        if (apiResponse.getContent() != null) {
+                            apiResponse.getContent().forEach((contentType, mediaType) -> {
+                                log.info("Processing Response Body Examples for Content Type: {}", contentType);
+                                processMediaType(mediaType);
+                            });
+                        }
+                    });
+                });
+            });
     }
 
-    public void processContent(Content content, String relativePath) {
-        streamContentExamples(content).forEach(example -> fixInlineExamples(example, relativePath));
+    public void processMediaType(MediaType mediaType) {
+        if (mediaType.getExamples() != null) {
+            mediaType.getExamples().forEach(((key, example) -> {
+                log.info("Processing Example: {} with value: {} and ref: {} ", key, example.getValue(), example.get$ref());
+                ExampleHolder<?> exampleHolder = ExampleHolder.of(key, example);
+                fixInlineExamples(exampleHolder, null, false);
+                if(exampleHolder.getRef()!=null) {
+                    example.set$ref(exampleHolder.getRef());
+                } else {
+                    example.setValue(exampleHolder.example());
+                }
+                log.info("Finished Processing Example: {} with value: {}", key, exampleHolder);
+            }));
+        }
+        if (mediaType.getExample() != null) {
+            log.info("Processing Example: {} ", mediaType.getExample());
+            ExampleHolder<?> exampleHolder = ExampleHolder.of(null, mediaType.getExample());
+            fixInlineExamples(exampleHolder, null, false);
+            log.info("Finished Processing Example: {}", exampleHolder);
+        }
     }
 
     private Map<String, Example> getComponentExamplesFromOpenAPI() {
@@ -76,112 +104,96 @@ public class ExamplesProcessor {
             openAPI.setComponents(new Components());
         }
         if (openAPI.getComponents().getExamples() == null) {
-            openAPI.getComponents().setExamples(newHashMap());
+            openAPI.getComponents().setExamples(new LinkedHashMap<>());
         }
         return openAPI.getComponents().getExamples();
     }
 
-    private Stream<ExampleHolder> streamOperationExamples(Operation operation) {
-        Content requestContent = nullSafeContent(operation);
-        Collection<ApiResponse> responseResponses = nullSafeApiResponses(operation);
-        return Stream.concat(
-            streamContentExamples(requestContent),
-            responseResponses.stream()
-                .map(ApiResponse::getContent)
-                .filter(Objects::nonNull)
-                .flatMap(this::streamContentExamples)
-        );
-    }
-
-    private Content nullSafeContent(Operation operation) {
-        return operation != null
-            && operation.getRequestBody() != null
-            && operation.getRequestBody().getContent() != null
-            ? operation.getRequestBody().getContent() : new Content();
-    }
-
-    private Collection<ApiResponse> nullSafeApiResponses(Operation operation) {
-        return operation != null
-            && operation.getResponses() != null
-            ? operation.getResponses().values() : emptyList();
-    }
-
-    private Stream<ExampleHolder> streamContentExamples(Content content) {
-        return Stream.of(
-            content.values().stream().map(MediaType::getExample).filter(Objects::nonNull)
-                .map(ExampleHolder::of),
-            content.values().stream().map(MediaType::getExamples).filter(Objects::nonNull)
-                .flatMap(map -> map.entrySet().stream())
-                .map(e -> ExampleHolder.of(e.getKey(), e.getValue(), false)))
-            .flatMap(s -> s);
-    }
-
-    private Stream<Operation> streamOperations(Entry<String, PathItem> item) {
-        log.info("Processing path item {}", item.getKey());
-        PathItem pathItem = item.getValue();
-        return of(pathItem.getGet(), pathItem.getPut(), pathItem.getPost(), pathItem.getDelete());
-    }
-
     private void fixInlineExamples(ExampleHolder exampleHolder) {
-        fixInlineExamples(exampleHolder, null);
+        fixInlineExamples(exampleHolder, null, false);
     }
 
-    private void fixInlineExamples(ExampleHolder exampleHolder, String relativePath) {
+    private void fixInlineExamples(ExampleHolder exampleHolder, String relativePath, boolean derefenceExamples) {
         log.debug("fixInlineExamples: '{}', relative path '{}'", exampleHolder, relativePath);
 
         if (exampleHolder.getRef() == null) {
-            log.debug("not fixing (ref not found): {}", exampleHolder);
+            log.info("not fixing (ref not found): {}", exampleHolder);
             return;
         }
         String refPath = exampleHolder.getRef();
         if (RefUtils.computeRefFormat(refPath) != RefFormat.RELATIVE) {
-            log.debug("not fixing (not relative ref): '{}'", exampleHolder);
+            log.info("not fixing (not relative ref): '{}'", exampleHolder);
             return;
         }
+
+        if(refPath.startsWith("#/components/examples/")) {
+            log.info("Ref path already points to examples. Leave it as it is");
+            return;
+        }
+
         Path path;
         Optional<String> fragment;
-        if (refPath.contains("#")) {
+        if (refPath.contains("#") && !refPath.startsWith("#/components/examples")) {
             fragment = Optional.of(StringUtils.substringAfter(refPath, "#"));
             refPath = StringUtils.strip(StringUtils.substringBefore(refPath, "#"), "./");
         } else {
             fragment = Optional.empty();
         }
 
-
         path = resolvePath(relativePath, refPath);
         try {
-            String content = StringUtils.strip(StringUtils.replaceEach(
-                new String(Files.readAllBytes(path)),
-                new String[]{"\t"},
-                new String[]{"  "}));
+            String content = readContent(path);
 
             if (fragment.isPresent()) {
+                String exampleName = StringUtils.substringAfterLast(fragment.get(), "/");
                 // resolve fragment from json node
                 JsonNode jsonNode = yamlObjectMapper.readTree(content);
                 JsonPointer jsonPointer = JsonPointer.compile(fragment.get());
                 JsonNode exampleNode = jsonNode.at(jsonPointer);
 
-                if(exampleNode.has("$ref")) {
+                if (exampleNode.has("$ref")) {
                     refPath = exampleNode.get("$ref").asText();
+                    exampleHolder.replaceRef(refPath);
                     path = resolvePath(relativePath, refPath);
                     resolvePath(relativePath, refPath);
-                    content = StringUtils.strip(StringUtils.replaceEach(
-                        new String(Files.readAllBytes(path)),
-                        new String[]{"\t"},
-                        new String[]{"  "}));
+                    content = readContent(path);
+
                     exampleHolder.setContent(content);
+                    if (exampleName != null) {
+                        exampleHolder.setExampleName(exampleName);
+                        exampleHolder.replaceRef("#/components/examples/" + exampleName);
+                    }
+
+                    if (getComponentExamplesFromOpenAPI().containsKey(exampleName)) {
+                        log.info("Updating example: {} in components/examples", exampleName);
+                        // Check whether example is already dereferenced
+                    } else {
+                        log.info("Adding Example: {} to components/examples", exampleName);
+                        getComponentExamplesFromOpenAPI().put(exampleName, new Example().value(convertExampleContent(exampleHolder, refPath)));
+                    }
                 } else {
                     exampleHolder.setContent(jsonObjectMapper.writeValueAsString(exampleNode));
                 }
             } else {
                 exampleHolder.setContent(content);
+                dereferenceExample(exampleHolder);
+            }
+            if (derefenceExamples) {
+                dereferenceExample(exampleHolder);
             }
 
-
-            dereferenceExample(exampleHolder);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private String readContent(Path path) throws IOException {
+        String content;
+        content = StringUtils.strip(StringUtils.replaceEach(
+            new String(Files.readAllBytes(path)),
+            new String[]{"\t"},
+            new String[]{"  "}));
+        return content;
     }
 
     private Path resolvePath(String relativePath, String refPath) {
@@ -201,7 +213,7 @@ public class ExamplesProcessor {
             count++;
         }
         String exampleName = makeCountedName(rootName, count);
-        Object content = convertExampleContent(exampleHolder);
+        Object content = convertExampleContent(exampleHolder, exampleHolder.getRef());
         cache.put(exampleName, exampleHolder);
         exampleHolder.replaceRef("#/components/examples/" + exampleName);
         getComponentExamplesFromOpenAPI().put(exampleName, new Example()
@@ -209,9 +221,9 @@ public class ExamplesProcessor {
             .summary(exampleName));
     }
 
-    private Object convertExampleContent(ExampleHolder exampleHolder) {
+    private Object convertExampleContent(ExampleHolder exampleHolder, String refPath) {
         try {
-            if (exampleHolder.getRef().endsWith("json")) {
+            if (exampleHolder.getRef().endsWith("json") || refPath.endsWith("json")) {
                 return Json.mapper().readValue(exampleHolder.getContent(), Object.class);
             }
             return exampleHolder.getContent();

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -3,6 +3,7 @@ package com.backbase.oss.boat.transformers;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.backbase.oss.boat.loader.OpenAPILoader;
 import com.backbase.oss.boat.loader.OpenAPILoaderException;

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -68,6 +68,7 @@ public class BundlerTest {
 
         new Bundler(input).transform(openAPI, Collections.emptyMap());
 
+        log.info(Yaml.pretty(openAPI));
 
         assertThat("Single inline example is replaced with relative ref",
             singleExampleNode(openAPI, "/users", PathItem::getGet, "200", APPLICATION_JSON).get("$ref").asText(),
@@ -75,9 +76,11 @@ public class BundlerTest {
         assertThat("Component example without ref is left alone.",
             openAPI.getComponents().getExamples().get("example-in-components-1").getSummary(),
             is("component-examples with example - should be left alone"));
+
+
         assertThat("Component example that duplicates a inline example, is left alone. But the summary is removed",
-            openAPI.getComponents().getExamples().get("example-number-one").getSummary(),
-            is("example-number-one"));
+            openAPI.getComponents().getExamples().get("example-number-one").getSummary(), nullValue());
+
 
         assertThat("Deep linked examples are dereferenced.",
             singleExampleMap(openAPI, "/users", PathItem::getPost, "400", APPLICATION_JSON).get("$ref").toString(),

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -48,6 +48,17 @@ public class BundlerTest {
     };
 
     @Test
+    public void testBundleExamples() throws OpenAPILoaderException, IOException {
+        String file = getClass().getResource("/openapi/bundler-examples-test-api/openapi.yaml").getFile();
+        String spec = System.getProperty("spec", file);
+        File input = new File(spec);
+        OpenAPI openAPI = OpenAPILoader.load(input);
+
+        new Bundler(input).transform(openAPI, Collections.emptyMap());
+        log.info(Yaml.pretty(openAPI.getComponents().getExamples()));
+    }
+
+    @Test
     public void testBundleApi() throws OpenAPILoaderException, IOException {
         String file = getClass().getResource("/openapi/bundler-examples-test-api/openapi.yaml").getFile();
         String spec = System.getProperty("spec", file);

--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.8.1-SNAPSHOT</version>
+        <version>0.9.0</version>
     </parent>
     <artifactId>boat-maven-plugin</artifactId>
 

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
@@ -45,7 +45,7 @@ public class BundleMojo extends AbstractMojo {
     private String version;
 
     @Parameter(name = "versionFileName", required = false)
-    private boolean versionFileName = true;
+    private boolean versionFileName = false;
 
     /**
      * Skip the execution.

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/BundleMojoTest.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/BundleMojoTest.java
@@ -42,7 +42,7 @@ public class BundleMojoTest {
         mojo.setInput(new File(getClass().getResource("/bundler/folder/one-client-api-v1.yaml").getFile())
             .getParentFile());
         mojo.setOutput(new File("target/test-bundle-folder"));
-
+        mojo.setVersionFileName(true);
         mojo.execute();
 
         Assert.assertTrue(new File("target/test-bundle-folder/one-client-api-v1.3.5.yaml").exists());

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/GeneratorTests.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/GeneratorTests.java
@@ -6,12 +6,15 @@ import io.swagger.v3.oas.models.OpenAPI;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.junit.Test;
 import org.sonatype.plexus.build.incremental.DefaultBuildContext;
 
+@Slf4j
 public class GeneratorTests {
 
     @Test
@@ -51,6 +54,9 @@ public class GeneratorTests {
     public void testBoatDocs() throws MojoExecutionException {
 
         String spec = System.getProperty("spec", getClass().getResource("/oas-examples/petstore.yaml").getFile());
+
+        log.info("Generating docs for: {}", spec);
+
         GenerateDocMojo mojo = new GenerateDocMojo();
         File input = new File(spec);
         File output = new File("target/boat-docs");
@@ -68,6 +74,44 @@ public class GeneratorTests {
         mojo.output = output;
         mojo.skip = false;
         mojo.skipIfSpecIsUnchanged = false;
+        mojo.bundleSpecs = true;
+        mojo.dereferenceComponents = true;
+        mojo.execute();
+    }
+
+    @Test
+    public void testBundledBoatDocs() throws MojoExecutionException, MojoFailureException {
+
+        String spec = System.getProperty("spec", getClass().getResource("/oas-examples/petstore.yaml").getFile());
+
+        log.info("Generating docs for: {}", spec);
+
+
+        BundleMojo bundleMojo = new BundleMojo();
+        bundleMojo.setInput(new File(spec));
+        File dereferenced = new File("target/boat-docs-bundled/dereferenced-openapi.yml");
+        bundleMojo.setOutput(dereferenced);
+        bundleMojo.execute();
+
+
+        GenerateDocMojo mojo = new GenerateDocMojo();
+        File output = new File("target/boat-docs-bundled/");
+        if (!output.exists()) {
+            output.mkdirs();
+        }
+
+        DefaultBuildContext defaultBuildContext = new DefaultBuildContext();
+        defaultBuildContext.enableLogging(new ConsoleLogger());
+
+        mojo.getLog();
+        mojo.buildContext = defaultBuildContext;
+        mojo.project = new MavenProject();
+        mojo.inputSpec = dereferenced.getAbsolutePath();
+        mojo.output = output;
+        mojo.skip = false;
+        mojo.skipIfSpecIsUnchanged = false;
+        mojo.bundleSpecs = false;
+        mojo.dereferenceComponents = false;
         mojo.execute();
     }
 

--- a/boat-quay/boat-quay-lint/pom.xml
+++ b/boat-quay/boat-quay-lint/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>boat-quay</artifactId>
-        <version>0.8.1-SNAPSHOT</version>
+        <version>0.9.0</version>
     </parent>
     <artifactId>boat-quay-lint</artifactId>
     <packaging>jar</packaging>

--- a/boat-quay/boat-quay-rules/pom.xml
+++ b/boat-quay/boat-quay-rules/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>boat-quay</artifactId>
-        <version>0.8.1-SNAPSHOT</version>
+        <version>0.9.0</version>
     </parent>
     <artifactId>boat-quay-rules</artifactId>
     <packaging>jar</packaging>

--- a/boat-quay/pom.xml
+++ b/boat-quay/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.8.1-SNAPSHOT</version>
+        <version>0.9.0</version>
     </parent>
 
 

--- a/boat-scaffold/pom.xml
+++ b/boat-scaffold/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.8.1-SNAPSHOT</version>
+        <version>0.9.0</version>
     </parent>
     <artifactId>boat-scaffold</artifactId>
 

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatCodegenResponse.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatCodegenResponse.java
@@ -1,17 +1,89 @@
 package com.backbase.oss.codegen.doc;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
-import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.openapitools.codegen.CodegenResponse;
 
+@Data
 @Slf4j
-@ToString(callSuper = true)
-@Data()
 public class BoatCodegenResponse extends CodegenResponse {
 
     private List<BoatExample> examples;
 
+    public boolean hasExamples() {
+        return examples != null && !examples.isEmpty();
+    }
 
+    public BoatCodegenResponse(CodegenResponse o, String responseCode, ApiResponse response, OpenAPI openAPI) {
+        this.headers.addAll(o.headers);
+        this.code = o.code;
+        this.is1xx = o.is1xx;
+        this.is2xx = o.is2xx;
+        this.is3xx = o.is3xx;
+        this.is4xx = o.is4xx;
+        this.is5xx = o.is5xx;
+        this.message = o.message;
+        this.hasMore = o.hasMore;
+        this.dataType = o.dataType;
+        this.baseType = o.baseType;
+        this.containerType = o.containerType;
+        this.hasHeaders = o.hasHeaders;
+        this.isString = o.isString;
+        this.isNumeric = o.isNumeric;
+        this.isInteger = o.isInteger;
+        this.isLong = o.isLong;
+        this.isNumber = o.isNumber;
+        this.isFloat = o.isFloat;
+        this.isDouble = o.isDouble;
+        this.isByteArray = o.isByteArray;
+        this.isBoolean = o.isBoolean;
+        this.isDate = o.isDate;
+        this.isDateTime = o.isDateTime;
+        this.isUuid = o.isUuid;
+        this.isEmail = o.isEmail;
+        this.isModel = o.isModel;
+        this.isFreeFormObject = o.isFreeFormObject;
+        this.isAnyType = o.isAnyType;
+        this.isDefault = o.isDefault;
+        this.simpleType = o.simpleType;
+        this.primitiveType = o.primitiveType;
+        this.isMapContainer = o.isMapContainer;
+        this.isListContainer = o.isListContainer;
+        this.isBinary = o.isBinary;
+        this.isFile = o.isFile;
+        this.schema = o.schema;
+        this.jsonSchema = o.jsonSchema;
+        this.vendorExtensions = o.vendorExtensions;
+
+        this.setMaxProperties(o.getMaxProperties());
+        this.setMinProperties(o.getMinProperties());
+        this.setUniqueItems(o.getUniqueItems());
+        this.setMaxItems(o.getMaxItems());
+        this.setMinItems(o.getMinItems());
+        this.setMaxLength(o.getMaxLength());
+        this.setMinLength(o.getMinLength());
+        this.setExclusiveMinimum(o.getExclusiveMinimum());
+        this.setExclusiveMinimum(o.getExclusiveMinimum());
+        this.setMinimum(o.getMinimum());
+        this.setMaximum(o.getMaximum());
+        this.pattern = o.pattern;
+        this.multipleOf = o.multipleOf;
+
+        List<BoatExample> examples = new ArrayList<>();
+        if (response.getContent() != null) {
+            response.getContent().forEach((contentType, mediaType) -> {
+                log.info("Derefenencing again....");
+
+                BoatExampleUtils.convertExamples(mediaType, contentType, examples);
+            });
+            BoatExampleUtils.inlineExamples(responseCode, examples, openAPI);
+
+            this.examples = examples;
+
+        }
+    }
 }

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatCodegenResponse.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatCodegenResponse.java
@@ -1,0 +1,17 @@
+package com.backbase.oss.codegen.doc;
+
+import java.util.List;
+import lombok.Data;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.openapitools.codegen.CodegenResponse;
+
+@Slf4j
+@ToString(callSuper = true)
+@Data()
+public class BoatCodegenResponse extends CodegenResponse {
+
+    private List<BoatExample> examples;
+
+
+}

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatDocsGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatDocsGenerator.java
@@ -11,11 +11,8 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -114,21 +111,7 @@ public class BoatDocsGenerator extends org.openapitools.codegen.languages.Static
         CodegenResponse r = super.fromResponse(responseCode, response);
         r.message = StringUtils.replace(r.message, "`", "\\`");
 
-        List<BoatExample> examples = new ArrayList<>();
-        if(response.getContent() != null) {
-            response.getContent().forEach((contentType, mediaType) -> {
-                log.info("Derefenencing again....");
-
-                BoatExampleUtils.convertExamples(mediaType, contentType, examples);
-            });
-            BoatExampleUtils.inlineExamples(responseCode, examples, openAPI);
-            r.examples = examples.stream().map(boatExample -> {
-                Map<String, Object> example = new LinkedHashMap<>();
-                example.put(boatExample.getKey(), boatExample.getPrettyPrintValue());
-                return example;
-            }).collect(Collectors.toList());
-        }
-        return r;
+        return new BoatCodegenResponse(r, responseCode, response, openAPI);
     }
 
     @Override

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
@@ -1,0 +1,55 @@
+package com.backbase.oss.codegen.doc;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.MediaType;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+public class BoatExampleUtils {
+
+  public static void convertExamples(MediaType mediaType, String contentType,  List<BoatExample> examples) {
+      if (mediaType.getExample() != null) {
+          Object example = mediaType.getExample();
+          BoatExample boatExample = new BoatExample("example", contentType, new Example().value(example));
+          if (example instanceof ObjectNode && ((ObjectNode) example).has("$ref")) {
+              boatExample.getExample().set$ref(((ObjectNode) example).get("$ref").asText());
+          }
+          examples.add(boatExample);
+      }
+      if (mediaType.getExamples() != null) {
+          mediaType.getExamples().forEach((key, example) -> {
+              BoatExample boatExample = new BoatExample(key, contentType, example);
+              examples.add(boatExample);
+          });
+      }
+  }
+
+  public static void inlineExamples(String name, List<BoatExample> examples, OpenAPI openAPI) {
+      examples.stream()
+          .filter(boatExample -> boatExample.getExample().get$ref() != null)
+          .forEach(boatExample -> {
+              String ref = boatExample.getExample().get$ref();
+              if (ref.startsWith("#/components/examples")) {
+                  ref = StringUtils.substringAfterLast(ref, "/");
+                  if (openAPI.getComponents() != null && openAPI.getComponents().getExamples() != null) {
+                      Example example = openAPI.getComponents().getExamples().get(ref);
+                      if (example == null) {
+                          log.warn("Example ref: {}  used in: {}  refers to an example that does not exist", ref, name);
+                      } else {
+                          log.debug("Replacing Example ref: {}  used in: {}  with example from components: {}", ref, name, example);
+                          boatExample.setExample(example);
+                      }
+                  } else {
+                      log.warn("Example ref: {}  used in: {}  refers to an example that does not exist", ref, name);
+                  }
+              } else {
+                  log.warn("Example ref: {} used in: {} refers to an example that does not exist", ref, name);
+              }
+          });
+  }
+
+}

--- a/boat-scaffold/src/main/templates/boat-docs/paramB.mustache
+++ b/boat-scaffold/src/main/templates/boat-docs/paramB.mustache
@@ -53,9 +53,6 @@
                                 result.empty();
                                 result.append(view.render());
                             });
-
-
-
                         </script>
                     </div>
                     <input id='requests-{{baseName}}-{{nickname}}-{{code}}-schema-data' type='hidden' value=''/>

--- a/boat-scaffold/src/main/templates/boat-docs/response.mustache
+++ b/boat-scaffold/src/main/templates/boat-docs/response.mustache
@@ -71,8 +71,9 @@
         {{#hasExamples}}
             <h3>Examples</h3>
             {{#examples}}
-                <div id="examples-{{baseName}}-{{nickname}}-{{code}}-example">
-                    <pre class="prettyprint"><code class="json">{{example}}</code></pre>
+                <div id="examples-{{baseName}}-{{nickname}}-{{code}}-example-{{key}}">
+                    <label>{{name}}</label>
+                    <pre class="prettyprint language-json"><code class="json">{{{prettyPrintValue}}}</code></pre>
                 </div>
             {{/examples}}
         {{/hasExamples}}

--- a/boat-scaffold/src/main/templates/boat-docs/styles.mustache
+++ b/boat-scaffold/src/main/templates/boat-docs/styles.mustache
@@ -757,11 +757,13 @@ json-schema-view[json-schema-view-dark].collapsed .toggle-handle {
   transform: rotate(-90deg);
 }
 
-.requests-wrapper {
+.requests-wrapper.
+.responses-wrapper {
   display: flex;
 }
 
-.requests-wrapper .tab-content {
+.requests-wrapper .tab-content,
+.responses-wrapper .tab-content {
   display: flex;
 }
 .examples-tab-wrapper {
@@ -786,7 +788,8 @@ json-schema-view[json-schema-view-dark].collapsed .toggle-handle {
   display: flex;
 }
 
-.request-body {
+.request-body,
+.response-body{
 width: 100%!important;
 }
 

--- a/boat-terminal/pom.xml
+++ b/boat-terminal/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.8.1-SNAPSHOT</version>
+        <version>0.9.0</version>
     </parent>
 
     <artifactId>boat-terminal</artifactId>

--- a/boat-trail-resources/pom.xml
+++ b/boat-trail-resources/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.8.1-SNAPSHOT</version>
+        <version>0.9.0</version>
     </parent>
     <artifactId>boat-trail-resources</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.backbase.oss</groupId>
     <artifactId>backbase-openapi-tools</artifactId>
-    <version>0.8.1-SNAPSHOT</version>
+    <version>0.9.0</version>
     <packaging>pom</packaging>
     <description>Backbase Open Api Tools will help you converting RAML to OpenAPI plus many more</description>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.8.1-SNAPSHOT</version>
+        <version>0.9.0</version>
     </parent>
 
     <artifactId>tests</artifactId>


### PR DESCRIPTION
Handle API Responses correctly
Avoid stack overflow when parsing Example objects