### PR TITLE
UnAliassing was needed for html generator, but breaks client generators.

### DIFF
--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/Bundler.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/Bundler.java
@@ -22,7 +22,6 @@ public class Bundler implements Transformer {
         // Use the BoatOpenApiResolver...
         BoatOpenAPIResolver openAPIResolver = new BoatOpenAPIResolver(openAPI, null, inputFile.toURI().toString());
         openAPIResolver.resolve();
-        new UnAliasTransformer().transform(openAPI, Collections.emptyMap());
     }
 
 }

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/Bundler.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/Bundler.java
@@ -3,7 +3,6 @@ package com.backbase.oss.boat.transformers;
 import com.backbase.oss.boat.transformers.bundler.BoatOpenAPIResolver;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.io.File;
-import java.util.Collections;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -86,14 +86,6 @@ public class BundlerTest {
             openAPI.getPaths().get("/users").getPut().getResponses().get("403").getContent().get(APPLICATION_JSON)
                 .getExample(), notNullValue());
 
-        Schema aliasedSchema = openAPI.getPaths().get("/users").getPut().getResponses().get("404").getContent().get(
-            APPLICATION_JSON).getSchema();
-        assertThat("Schema referring to aliased simple type is un-aliased",
-            aliasedSchema.get$ref(),
-            nullValue());
-        assertThat("Attributes of aliased schema are copied",
-            aliasedSchema.getPattern(), is("^[0-9].*$"));
-
         log.debug(Yaml.pretty(openAPI));
     }
 

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -1,5 +1,9 @@
 package com.backbase.oss.boat.transformers;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import com.backbase.oss.boat.loader.OpenAPILoader;
 import com.backbase.oss.boat.loader.OpenAPILoaderException;
 import com.backbase.oss.boat.serializer.SerializerUtils;
@@ -10,7 +14,6 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
-import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import java.io.File;
@@ -24,11 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @Slf4j
 public class BundlerTest {


### PR DESCRIPTION
html2 generator was ignoring simple types defined as components/schema - other generators have trouble processing inlined types.