### PR TITLE
Remove invalid value. after resolving example.

### DIFF
--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExampleHolder.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExampleHolder.java
@@ -63,7 +63,7 @@ public abstract class ExampleHolder<T> {
                 String ref = objectNode.get("value").get(REF_KEY).asText();
                 log.warn(String.format(FIXING_INVALID_EXAMPLE_WARNING, "?", ref));
                 objectNode.set(REF_KEY, objectNode.get("value").get(REF_KEY));
-                objectNode.set("value", null);
+                objectNode.remove("value");
             }
 
         }

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExamplesProcessor.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExamplesProcessor.java
@@ -95,6 +95,7 @@ public class ExamplesProcessor {
                 fixInlineExamples(exampleHolder, relativePath, derefenceExamples);
                 if (exampleHolder.getRef() != null) {
                     example.set$ref(exampleHolder.getRef());
+                    example.setValue(null);
                 } else {
                     example.setValue(exampleHolder.example());
                 }

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -13,6 +13,7 @@ import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.responses.ApiResponse;
@@ -99,6 +100,12 @@ public class BundlerTest {
         assertThat("Relative path works",
             openAPI.getPaths().get("/users").getPut().getResponses().get("403").getContent().get(APPLICATION_JSON)
                 .getExample(), notNullValue());
+
+        Example exampleNoThree = openAPI.getPaths().get("/multi-users").getPost().getRequestBody().getContent()
+            .get(APPLICATION_JSON).getExamples().get("example-number-three");
+        assertThat("value.$ref is cleaned up", exampleNoThree.get$ref(),
+            is("#/components/examples/example-number-three"));
+        assertThat("value.$ref is cleaned up", exampleNoThree.getValue(), nullValue());
 
         log.debug(Yaml.pretty(openAPI));
     }

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTest.java
@@ -70,8 +70,17 @@ public class BundlerTest {
 
         log.info(Yaml.pretty(openAPI));
 
-        assertThat("Single inline example is replaced with relative ref",
+        assertThat("Single inline example is replaced with relative ref (get)",
             singleExampleNode(openAPI, "/users", PathItem::getGet, "200", APPLICATION_JSON).get("$ref").asText(),
+            isComponentExample);
+        assertThat("Single inline example is replaced with relative ref (put)",
+            singleExampleNode(openAPI, "/users", PathItem::getPut, "200", APPLICATION_JSON).get("$ref").asText(),
+            isComponentExample);
+        assertThat("Single inline example is replaced with relative ref (post)",
+            singleExampleNode(openAPI, "/users", PathItem::getPost, "200", APPLICATION_JSON).get("$ref").asText(),
+            isComponentExample);
+        assertThat("Single inline example is replaced with relative ref (patch)",
+            singleExampleNode(openAPI, "/users", PathItem::getPatch, "200", APPLICATION_JSON).get("$ref").asText(),
             isComponentExample);
         assertThat("Component example without ref is left alone.",
             openAPI.getComponents().getExamples().get("example-in-components-1").getSummary(),

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-request-3.json
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/examples/user-post-request-3.json
@@ -1,0 +1,4 @@
+{
+  "name": "Robin",
+  "role": "Intern"
+}

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
@@ -119,6 +119,9 @@ paths:
                 $ref: ./examples/user-post-request.json
               example-number-two:
                 $ref: ./examples/user-post-request-2.json
+              example-number-three:
+                value:
+                  $ref: ./examples/user-post-request-3.json
       responses:
         '200':
           description: A user object.


### PR DESCRIPTION
When the spec has this
```
                example:
                  value:
                    $ref: examples/client-api/v2/contacts-get.json
```
Avoid generating
```
                example:
                  value:
                    $ref: examples/client-api/v2/contacts-get.json
                  $ref: '#/components/examples/example'
```
instead generate
```
                example:
                  $ref: '#/components/examples/example'
```