### PR TITLE
The URL pattern is used for the mock path, not the template string

### DIFF
--- a/boat-scaffold/src/main/templates/boat-angular/apiMocks.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/apiMocks.mustache
@@ -1,13 +1,13 @@
 import { createMocks } from '@backbase/foundation-ang/data-http';
 import { Provider } from '@angular/core';
 
-{{#operations}}
-    {{#operation}}
+{{#pathOperations}}
+    {{#operations}}
 /**
 * Mocks provider for {{{basePathWithoutHost}}}{{pattern}} URL pattern
 */
 export const {{classname}}{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}MocksProvider: Provider = createMocks([{
-        urlPattern: "{{{basePathWithoutHost}}}{{path}}",
+        urlPattern: "{{{basePathWithoutHost}}}{{pattern}}",
         method: "{{#lambda.uppercase}}{{httpMethod}}{{/lambda.uppercase}}",
         responses: [
         {{#responses}}
@@ -28,14 +28,14 @@ export const {{classname}}{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}
         {{/responses}}
     ]
 }]);
-    {{/operation}}
-{{/operations}}
+    {{/operations}}
+{{/pathOperations}}
 
 export const {{classname}}MocksProvider: Provider = createMocks(
-    [{{#operations}}
-    {{#operation}}
+    [{{#pathOperations}}
+    {{#operations}}
     {
-        urlPattern: "{{{basePathWithoutHost}}}{{path}}",
+        urlPattern: "{{{basePathWithoutHost}}}{{pattern}}",
         method: "{{#lambda.uppercase}}{{httpMethod}}{{/lambda.uppercase}}",
         responses: [
         {{#responses}}
@@ -63,8 +63,8 @@ export const {{classname}}MocksProvider: Provider = createMocks(
     {{/responses}}
     ]
 },
-    {{/operation}}
-{{/operations}}]
+    {{/operations}}
+{{/pathOperations}}]
 );
 
 


### PR DESCRIPTION
If I understand correctly, [this](https://github.com/Backbase/backbase-openapi-tools/blob/e7b8d578d61bae2e958a9e4c987d110369bd707d/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java#L306-L323) is creating a data structure parallel to the ["operations"](https://github.com/Backbase/backbase-openapi-tools/blob/e7b8d578d61bae2e958a9e4c987d110369bd707d/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java#L286) but with some customizations. I can't see anywhere else in the project this structure is used though, so I'm a little wary.

I'm iterating over this data structure to access the custom "pattern" key. I *think* the rest of  the structure is the same and the template appears to be rendering correctly.

The alternative is probably to do the same as we've done with `BoatCodegenResponse` and extend `CodegenOperations`