### PR TITLE
Correct the import and use of @Qualifier in ApiClient template

### DIFF
--- a/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/ApiClient.mustache
+++ b/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/ApiClient.mustache
@@ -9,6 +9,9 @@ import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+{{#restTemplateBeanName}}
+import org.springframework.beans.factory.annotation.Qualifier;
+{{/restTemplateBeanName}}
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -129,7 +132,7 @@ public class ApiClient {
 {{/useJacksonConversion}}
 
     @Autowired
-    public ApiClient({{#restTemplateBeanName}}@Qualifier({{restTemplateBeanName}}) {{/restTemplateBeanName}}RestTemplate restTemplate) {
+    public ApiClient({{#restTemplateBeanName}}@Qualifier("{{restTemplateBeanName}}") {{/restTemplateBeanName}}RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
         init();
     }


### PR DESCRIPTION
When providing configuration like so: 

```
<configuration
...
    <additionalProperties>
        restTemplateBeanName=interServiceRestTemplate
    </additionalProperties>
</configuration>
```

There are compilation errors, this PR resolves them.
* Missing import
* Missing quotemarks for qualifier. Providing quotemarks in pom config escapes to `&quot;` so it's best to solve here.

![image](https://user-images.githubusercontent.com/24349901/101763901-51d18f80-3ad7-11eb-888e-c152698241aa.png)
