### PR TITLE
Support building the project on Microsoft Windows.

### DIFF
--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExamplesProcessor.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExamplesProcessor.java
@@ -14,9 +14,9 @@ import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.parser.models.RefFormat;
-import io.swagger.v3.parser.util.PathUtils;
 import io.swagger.v3.parser.util.RefUtils;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -36,13 +36,20 @@ public class ExamplesProcessor {
     ObjectMapper jsonObjectMapper = new ObjectMapper();
 
     private final OpenAPI openAPI;
-    private final Path rootDir;
+    private final URI rootUri;
     private final Map<String, ExampleHolder> cache = new LinkedHashMap<>();
 
     public ExamplesProcessor(OpenAPI openAPI, String inputFile) {
         super();
         this.openAPI = openAPI;
-        this.rootDir = PathUtils.getParentDirectoryOfFile(inputFile);
+
+        try {
+            // Resolve the directory containing the file
+            this.rootUri = URI.create(inputFile).resolve(".");
+        } catch (RuntimeException e) {
+            log.error("Unable to create URI from \"{}\"", inputFile);
+            throw e;
+        }
     }
 
     public void processExamples(OpenAPI openAPI) {
@@ -131,7 +138,7 @@ public class ExamplesProcessor {
     }
 
     private void fixInlineExamples(ExampleHolder exampleHolder, String relativePath, boolean derefenceExamples) {
-        log.debug("fixInlineExamples: '{}', relative path '{}'", exampleHolder, relativePath);
+        log.debug("fixInlineExamples: '{}', relative resolvedUri '{}'", exampleHolder, relativePath);
 
         if (exampleHolder.getRef() == null) {
             log.debug("not fixing (ref not found): {}", exampleHolder);
@@ -144,11 +151,11 @@ public class ExamplesProcessor {
         }
 
         if (refPath.startsWith(COMPONENTS_EXAMPLES)) {
-            log.debug("Ref path already points to examples. Leave it as it is");
+            log.debug("Ref resolvedUri already points to examples. Leave it as it is");
             return;
         }
 
-        Path path;
+        URI resolvedUri;
         Optional<String> fragment;
         if (refPath.contains("#") && !refPath.startsWith("#/components/examples")) {
             fragment = Optional.of(StringUtils.substringAfter(refPath, "#"));
@@ -157,9 +164,9 @@ public class ExamplesProcessor {
             fragment = Optional.empty();
         }
 
-        path = resolvePath(relativePath, refPath);
+        resolvedUri = resolveUri(relativePath, refPath);
         try {
-            String content = readContent(path);
+            String content = readContent(Paths.get(resolvedUri));
 
             if (fragment.isPresent()) {
                 String exampleName = StringUtils.substringAfterLast(fragment.get(), "/");
@@ -171,9 +178,9 @@ public class ExamplesProcessor {
                 if (exampleNode.has("$ref")) {
                     refPath = exampleNode.get("$ref").asText();
                     exampleHolder.replaceRef(refPath);
-                    path = resolvePath(relativePath, refPath);
-                    resolvePath(relativePath, refPath);
-                    content = readContent(path);
+                    resolvedUri = resolveUri(relativePath, refPath);
+                    resolveUri(relativePath, refPath);
+                    content = readContent(Paths.get(resolvedUri));
 
                     exampleHolder.setContent(content);
                     if (exampleName != null) {
@@ -214,14 +221,15 @@ public class ExamplesProcessor {
         return content;
     }
 
-    private Path resolvePath(String relativePath, String refPath) {
-        Path path;
+    private URI resolveUri(String relativePath, String refPath) {
+        URI resolvedUri;
         if (relativePath == null) {
-            path = rootDir.resolve(StringUtils.strip(refPath, "./"));
+            resolvedUri = rootUri.resolve(StringUtils.strip(refPath, "./"));
         } else {
-            path = Paths.get(rootDir.toString(), relativePath, refPath);
+            resolvedUri = rootUri.resolve(checkTrailingSlash(relativePath.replace("\\", "/")))
+                .resolve(refPath.replace("\\", "/"));
         }
-        return path;
+        return resolvedUri;
     }
 
     private void dereferenceExample(ExampleHolder exampleHolder) {
@@ -256,5 +264,13 @@ public class ExamplesProcessor {
         return count == 0 ? s : s + "-" + count;
     }
 
+    /**
+     * Ensures the string ends in a "/". A trailing slash on a pathname identifies the path as pointing to a folder (aka
+     * directory). If a pathname does not have a trailing slash then it points to a file. Use this when we know the
+     * reference forms part of the path before the file resolution.
+     */
+    private String checkTrailingSlash(String uri) {
+        return uri.endsWith("/") ? uri : uri + "/";
+    }
 
 }

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTests.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/BundlerTests.java
@@ -19,6 +19,7 @@ import io.swagger.v3.parser.models.RefFormat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collections;
 import java.util.Map;
@@ -54,12 +55,12 @@ public class BundlerTests {
 
     @Test
     public void testBoatCache() throws OpenAPILoaderException {
-        String file = getClass().getResource("/openapi/bundler-examples-test-api/openapi.yaml").getFile();
+        String file = Paths.get("src/test/resources/openapi/bundler-examples-test-api/openapi.yaml").toAbsolutePath().toString();
         String spec = System.getProperty("spec", file);
         File input = new File(spec);
         OpenAPI openAPI = OpenAPILoader.load(input);
 
-        BoatCache boatCache = new BoatCache(openAPI, null, spec, new ExamplesProcessor(openAPI, spec));
+        BoatCache boatCache = new BoatCache(openAPI, null, spec, new ExamplesProcessor(openAPI, input.toURI().toString()));
         assertThrows(TransformerException.class, () -> boatCache.loadRef("not exists", RefFormat.RELATIVE, Example.class));
 
 
@@ -67,7 +68,7 @@ public class BundlerTests {
 
     @Test
     public void testBundleExamples() throws OpenAPILoaderException, IOException {
-        String file = getClass().getResource("/openapi/bundler-examples-test-api/openapi.yaml").getFile();
+        String file = Paths.get("src/test/resources/openapi/bundler-examples-test-api/openapi.yaml").toAbsolutePath().toString();
         String spec = System.getProperty("spec", file);
         File input = new File(spec);
         OpenAPI openAPI = OpenAPILoader.load(input);

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
@@ -579,8 +579,8 @@ public class GenerateMojo extends AbstractMojo {
                 configurator.setRemoveOperationIdPrefix(removeOperationIdPrefix);
             }
 
-            if (isNotEmpty(inputSpec)) {
-                configurator.setInputSpec(inputSpec);
+            if (inputSpecFile.exists()) {
+                configurator.setInputSpec(inputSpecFile.getAbsoluteFile().toURI().toString());
             }
 
             if (isNotEmpty(gitHost)) {

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/GenerateMojoTests.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/GenerateMojoTests.java
@@ -42,7 +42,7 @@ public class GenerateMojoTests {
 
         String testRoot = mojo.project.getTestCompileSourceRoots().get(testRoots);
 
-        assertThat(testRoot, endsWith("/here-i-am"));
+        assertThat(testRoot, endsWith(File.separator + "here-i-am"));
     }
 
     @Test

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/GeneratorTests.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/GeneratorTests.java
@@ -1,5 +1,6 @@
 package com.backbase.oss.boat;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -40,10 +41,8 @@ public class GeneratorTests {
         mojo.skip = false;
         mojo.skipIfSpecIsUnchanged = false;
         mojo.execute();
-        String[] expectedGeneratedDocs = {"index.html",
-                ".openapi-generator-ignore", ".openapi-generator"};
-        assertArrayEquals(expectedGeneratedDocs, output.list());
 
+        assertThat(output.list()).containsExactlyInAnyOrder("index.html", ".openapi-generator-ignore", ".openapi-generator");
     }
 
     @Test
@@ -74,9 +73,7 @@ public class GeneratorTests {
         mojo.dereferenceComponents = true;
         mojo.execute();
 
-        String[] expectedGeneratedDocs = {"index.html",
-                ".openapi-generator-ignore", ".openapi-generator"};
-        assertArrayEquals(expectedGeneratedDocs, output.list());
+        assertThat(output.list()).containsExactlyInAnyOrder("index.html", ".openapi-generator-ignore", ".openapi-generator");
     }
 
     @Test

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
@@ -79,6 +79,6 @@ public class BoatSpringCodeGenTests {
 
         indent.execute(frag, output);
 
-        assertThat(output.toString(), equalTo("__\n__Good\n__  morning,\n__ Dave\n"));
+        assertThat(output.toString(), equalTo(String.format("__%n__Good%n__  morning,%n__ Dave%n")));
     }
 }

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringTemplatesTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringTemplatesTests.java
@@ -70,7 +70,7 @@ class BoatSpringTemplatesTests {
     }
 
     static class Combination {
-        static final List<String> CASES = asList("flx", "unq", "val", "opt", "req", "lmb", "nul", "wth");
+        static final List<String> CASES = asList("flx", "unq", "val", "opt", "req", "lmb", "nbl", "wth");
 
         final String name;
 
@@ -97,7 +97,7 @@ class BoatSpringTemplatesTests {
             this.useOptional = (mask & 1 << CASES.indexOf("opt")) != 0;
             this.addServletRequest = (mask & 1 << CASES.indexOf("req")) != 0;
             this.useLombokAnnotations = (mask & 1 << CASES.indexOf("lmb")) != 0;
-            this.openApiNullable = (mask & 1 << CASES.indexOf("nul")) != 0;
+            this.openApiNullable = (mask & 1 << CASES.indexOf("nbl")) != 0;
             this.useSetForUniqueItems = (mask & 1 << CASES.indexOf("unq")) != 0;
             this.useWithModifiers = (mask & 1 << CASES.indexOf("wth")) != 0;
             this.reactive = (mask & 1 << CASES.indexOf("flx")) != 0;

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -412,7 +412,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Support using the tools on Windows.

Key changes:

* It happens with the Unix FilesSystemProvider that http URLs parse as a valid java.nio.file.Path this is not the case on Windows, as we are using Path for relative path resolution I have changed this to use URI.
(Consider if this this still supports the required input values, such as any which are not parseable as a URI, all tests pass though).
* nul is a reserved file name on Windows and cannot be created, altered some tests.
* Updated assertions which check to use \n to use %n.