### PR TITLE
fix: Improve documentation when `mvn help:describe` 

### DIFF
--- a/boat-maven-plugin/README.md
+++ b/boat-maven-plugin/README.md
@@ -22,7 +22,7 @@ The `boat` plugin has multiple goals:
     
     Open API Generator based on https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin. All configuration options as 
     defined on openapi-generator-maven-plugin can be applied here too. 
-    boat-maven-plugin uses slightly modified templates for html, java and webclient that help genereate specs and clients that work best in a Backbase projects.
+    boat-maven-plugin uses slightly modified templates for html, java and webclient that help generate specs and clients that work best in a Backbase projects.
    
 - `generate-spring-boot-embedded`, `generate` but with opinionated defaults
 
@@ -133,6 +133,49 @@ The `boat` plugin has multiple goals:
     </configuration>
     ```
 
+- `boat:lint`
+
+   API lint which provides checks for compliance with many of Backbase's API standards
+   
+    Available parameters:
+   
+       failOnWarning (Default: false)
+         Set this to true to fail in case a warning is found.
+   
+       ignoreRules
+         List of rules ids which will be ignored.
+   
+       inputSpec
+         Required: true
+         Input spec directory or file.
+   
+       output (Default:
+       ${project.build.directory}/boat-lint-reports)
+         Output directory for lint reports.
+   
+       showIgnoredRules (Default: false)
+         Set this to true to show the list of ignored rules..
+   
+       writeLintReport (Default: true)
+         Set this to true to generate lint report.
+ 
+   Example:
+    
+   ```
+   <configuration>
+       <inputSpec>${unversioned-filename-spec-dir}/</inputSpec>
+       <output>${project.build.directory}/boat-lint-reports</output>
+       <writeLintReport>true</writeLintReport>
+       <ignoreRules>${ignored-lint-rules}</ignoreRules>
+       <showIgnoredRules>true</showIgnoredRules>
+    </configuration>
+   ```
+  
+  To see details about this goal:
+  
+`mvn help:describe -DgroupId=com.backbase.oss -DartifactId=boat-maven-plugin  -Dgoal=lint -Ddetail`
+  
+  
 - `boat:bundle`
     
     Bundles a spec by resolving external references.

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/AbstractLintMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/AbstractLintMojo.java
@@ -5,6 +5,7 @@ import com.backbase.oss.boat.quay.model.BoatLintReport;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.maven.plugin.AbstractMojo;
@@ -18,12 +19,28 @@ import org.apache.maven.plugins.annotations.Parameter;
  */
 public abstract class AbstractLintMojo extends AbstractMojo {
 
+    /**
+     * Input spec directory or file.
+     */
     @Parameter(name = "inputSpec", property = "inputSpec", required = true)
     protected File inputSpec;
 
+    /**
+     * Set this to <code>true</code> to fail in case a warning is found.
+     */
     @Parameter(name = "failOnWarning", defaultValue = "false")
     protected boolean failOnWarning;
 
+
+    /**
+     * Set this to <code>true</code> to show the list of ignored rules..
+     */
+    @Parameter(name = "showIgnoredRules", defaultValue = "false")
+    protected boolean showIgnoredRules;
+
+    /**
+     * List of rules ids which will be ignored.
+     */
     @Parameter(name = "ignoreRules")
     protected String[] ignoreRules = new String[]{"219", "105", "M008", " M009", " M010", " M011", " H001", " H002", " S005", " S006", " S007"};
 
@@ -51,9 +68,11 @@ public abstract class AbstractLintMojo extends AbstractMojo {
 
     private BoatLintReport lintOpenAPI(File inputFile) throws MojoExecutionException {
         try {
+            if(showIgnoredRules) {
+                log.info("These rules will be ignored: {}", Arrays.toString(ignoreRules));
+            }
             BoatLinter boatLinter = new BoatLinter(ignoreRules);
             return boatLinter.lint(inputFile);
-
         } catch (IOException e) {
             throw new MojoExecutionException("Error transforming OpenAPI: " + inputFile, e);
         }

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
@@ -30,7 +30,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 @Mojo(name = "bundle", requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
 @Slf4j
-/*
+/**
   Bundles all references in the OpenAPI specification into one file.
  */
 @Getter

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateRestTemplateEmbeddedMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateRestTemplateEmbeddedMojo.java
@@ -3,6 +3,9 @@ package com.backbase.oss.boat;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
+/**
+ * Generating Client using Spring Rest Template.
+ */
 @Mojo(name = "generate-rest-template-embedded", threadSafe = true)
 public class GenerateRestTemplateEmbeddedMojo extends AbstractGenerateMojo {
 

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateSpringBootEmbeddedMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateSpringBootEmbeddedMojo.java
@@ -3,6 +3,9 @@ package com.backbase.oss.boat;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
+/**
+ * Generating Server Stubs using Spring Boot.
+ */
 @Mojo(name = "generate-spring-boot-embedded", threadSafe = true)
 public class GenerateSpringBootEmbeddedMojo extends AbstractGenerateMojo {
 

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateWebClientEmbeddedMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateWebClientEmbeddedMojo.java
@@ -3,6 +3,9 @@ package com.backbase.oss.boat;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
+/**
+ * Generating Server Stubs using Web Client Boot.
+ */
 @Mojo(name = "generate-webclient-embedded", threadSafe = true)
 public class GenerateWebClientEmbeddedMojo extends AbstractGenerateMojo {
 

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/LintMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/LintMojo.java
@@ -15,14 +15,20 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @SuppressWarnings("FieldMayBeFinal")
 @Mojo(name = "lint", requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
 @Slf4j
-/*
-  Lint Specification
+/**
+ * API lint which provides checks for compliance with many of Backbase's API standards.
  */
 public class LintMojo extends AbstractLintMojo {
 
+    /**
+     * Output directory for lint reports.
+     */
     @Parameter(name = "output", defaultValue = "${project.build.directory}/boat-lint-reports")
     public File output;
 
+    /**
+     * Set this to <code>true</code> to generate lint report.
+     */
     @Parameter(name = "writeLintReport", defaultValue = "true")
     private boolean writeLintReport;
 


### PR DESCRIPTION
- Adding new goal `lint` on the README.md file.
- Improve documentation of goals when using 

`mvn help:describe -DgroupId=com.backbase.oss -DartifactId=boat-maven-plugin -Ddetail `

_`help:describe` takes documentation from Javadoc on Mojo classes and parameters._ 
 