### PR TITLE
Remove `@backbase/foundation-ang` dependency

### DIFF
--- a/boat-scaffold/src/main/templates/boat-angular/apiMocks.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/apiMocks.mustache
@@ -1,16 +1,67 @@
-import { createMocks } from '@backbase/foundation-ang/data-http';
-import { Provider } from '@angular/core';
+import { InjectionToken } from '@angular/core';
+import { CONFIG_TOKEN, {{configurationClassName}} } from '../configuration';
+
+export interface MockData {
+    token: InjectionToken<{{configurationClassName}}>,
+    examples: Array<{
+        urlPattern: string;
+        method: string;
+        responses: Array<{
+            status: number;
+            body?: any;
+       }>;
+    }>;
+}
 
 {{#operations}}
     {{#operation}}
 /**
 * Mocks provider for {{{basePathWithoutHost}}}{{pattern}} URL pattern
 */
-export const {{classname}}{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}MocksProvider: Provider = createMocks([{
-        urlPattern: "{{{basePathWithoutHost}}}{{pattern}}",
-        method: "{{#lambda.uppercase}}{{httpMethod}}{{/lambda.uppercase}}",
-        responses: [
-        {{#responses}}
+export const {{classname}}{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}MockData: MockData = {
+    token: CONFIG_TOKEN,
+    examples: [{
+            urlPattern: "{{{basePathWithoutHost}}}{{pattern}}",
+            method: "{{#lambda.uppercase}}{{httpMethod}}{{/lambda.uppercase}}",
+            responses: [
+            {{#responses}}
+                {{#examples}}
+                    {{#isJson}}
+                    {
+                        status: {{{code}}},
+                        body: {{{prettyPrintValue}}}
+                    },
+                    {{/isJson}}
+                    {{^isJson}}
+                        {
+                        status: {{{code}}},
+                        body: "{{#escapeJavascript}}{{{prettyPrintValue}}}{{/escapeJavascript}}"
+                        },
+                    {{/isJson}}
+                {{/examples}}
+                {{#hasEmptyBody}}
+                    {
+                    status: {{{code}}},
+                    body: ""
+                    },
+                {{/hasEmptyBody}}
+            {{/responses}}
+        ]
+    }]
+};
+    {{/operation}}
+{{/operations}}
+
+export const {{classname}}MockData: MockData = {
+    token: CONFIG_TOKEN,
+    examples: [{{#operations}}
+        {{#operation}}
+        {
+            urlPattern: "{{{basePathWithoutHost}}}{{pattern}}",
+            method: "{{#lambda.uppercase}}{{httpMethod}}{{/lambda.uppercase}}",
+            responses: [
+            {{#responses}}
+
             {{#examples}}
                 {{#isJson}}
                 {
@@ -26,51 +77,17 @@ export const {{classname}}{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}
                 {{/isJson}}
             {{/examples}}
             {{#hasEmptyBody}}
-                {
-                status: {{{code}}},
-                body: ""
-                },
+            {
+              status: {{{code}}},
+              body: ""
+            },
             {{/hasEmptyBody}}
         {{/responses}}
-    ]
-}]);
-    {{/operation}}
-{{/operations}}
-
-export const {{classname}}MocksProvider: Provider = createMocks(
-    [{{#operations}}
-    {{#operation}}
-    {
-        urlPattern: "{{{basePathWithoutHost}}}{{pattern}}",
-        method: "{{#lambda.uppercase}}{{httpMethod}}{{/lambda.uppercase}}",
-        responses: [
-        {{#responses}}
-
-        {{#examples}}
-            {{#isJson}}
-            {
-                status: {{{code}}},
-                body: {{{prettyPrintValue}}}
-            },
-            {{/isJson}}
-            {{^isJson}}
-                {
-                status: {{{code}}},
-                body: "{{#escapeJavascript}}{{{prettyPrintValue}}}{{/escapeJavascript}}"
-                },
-            {{/isJson}}
-        {{/examples}}
-        {{#hasEmptyBody}}
-        {
-          status: {{{code}}},
-          body: ""
-        },
-        {{/hasEmptyBody}}
-    {{/responses}}
-    ]
-},
-    {{/operation}}
-{{/operations}}]
-);
+        ]
+    },
+        {{/operation}}
+    {{/operations}}
+    ],
+};
 
 


### PR DESCRIPTION
This is definitely still a draft but pushing it here in case somebody else gets to it over the break. It's an attempt at removing the dependency using an idea similar to that discussed with @daiscog.

This change does mean that the consuming interface changes a bit, the
app.module (probably in `environment.ts`) is responsible for calling `createMocks` with the exported
data. I tried to consolidate this inside of `createMocksProvider` instead of having multiple `createMocks`s, but wasn't able
to yet.

Also, still need to figure out how to remove the dependency from the module
without breaking lazy loading. Lazy loading causes an issue because the
configuration is lazy loaded but the mock module is not, so the
interceptor is configured before the config is really available. I think we might be able to do this by making the service depend on the mocks service in some way (i.e. cut out the middle manager) but that sounds nasty and I haven't figured out the details.