### PR TITLE
Fixe page width going to infinity  on base64 long strings

### DIFF
--- a/boat-scaffold/src/main/templates/boat-docs/css_jsontreeviewer.mustache
+++ b/boat-scaffold/src/main/templates/boat-docs/css_jsontreeviewer.mustache
@@ -134,6 +134,7 @@
 .json-viewer * {
   font-size: 13px;
   font-weight: normal;
+  word-break: break-all;
 }
 
 .json-viewer b {


### PR DESCRIPTION
The json viewer would span the page to close to an infinite width on examples with a property containing any long un-espaced text like a base64.

Just adding word-wrap fixes the issue.

![image](https://user-images.githubusercontent.com/10161067/106257412-c8a82080-621c-11eb-887a-9f75b227db00.png)
 