### PR TITLE
Add support for Angular 11

### DIFF
--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -209,10 +209,15 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
             supportingFiles.add(new SupportingFile("package.mustache", getIndexDirectory(), "package.json"));
             supportingFiles.add(new SupportingFile("tsconfig.mustache", getIndexDirectory(), "tsconfig.json"));
             additionalProperties.put("zonejsVersion", "0.10.2");
-            additionalProperties.put("ngPackagrVersion", "10.0.3");
-            additionalProperties.put("tsickleVersion", "0.39.1");
             additionalProperties.put("rxjsVersion", "6.6.0");
-            additionalProperties.put("tsVersion", ">=3.9.2 <4.0.0");
+
+            if (angularVersion.atLeast("11.0.0")) {
+                additionalProperties.put("tsVersion", "~4.1.0");
+                additionalProperties.put("ngPackagrVersion", "11.0.0");
+            } else {
+                additionalProperties.put("tsVersion", ">=3.9.2 <4.0.0");
+                additionalProperties.put("ngPackagrVersion", "10.0.3");
+            }
         }
     }
 

--- a/boat-scaffold/src/main/templates/boat-angular/package.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/package.mustache
@@ -39,7 +39,6 @@
     "@backbase/foundation-ang": "~{{foundationVersion}}",
     {{/withMocks}}
     "rxjs": "~{{rxjsVersion}}",
-    "tsickle": "^{{tsickleVersion}}",
     "typescript": "{{{tsVersion}}}",
     "zone.js": "^{{zonejsVersion}}"
   }{{#npmRepository}},


### PR DESCRIPTION
This adds support for Angular 11 but we are not ready to default to it yet.

The support doesn't require many changes as the `ngVersion` property is already available, but there are a couple of related dependencies that are also required to be compatible. 

If we intend to maintain support for a number of previous versions this is probably a good candidate for refactoring into a data structure to represent the compatibility table instead of a chain of `if`s.