### PR TITLE
boat:transform and template updates

### DIFF
--- a/boat-engine/src/main/java/com/backbase/oss/boat/loader/OpenAPILoader.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/loader/OpenAPILoader.java
@@ -2,9 +2,12 @@ package com.backbase.oss.boat.loader;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import java.io.File;
+import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -55,6 +58,10 @@ public class OpenAPILoader {
     }
 
     public static OpenAPI load(String url, boolean resolveFully, boolean flatten) throws OpenAPILoaderException {
+        return load(url, resolveFully, flatten, null);
+    }
+
+    public static OpenAPI load(String url, boolean resolveFully, boolean flatten, List<AuthorizationValue> auth) throws OpenAPILoaderException {
         log.debug("Reading OpenAPI from: {} resolveFully: {}", url, resolveFully);
         OpenAPIV3Parser openAPIParser = new OpenAPIV3Parser();
         ParseOptions parseOptions = new ParseOptions();
@@ -64,7 +71,7 @@ public class OpenAPILoader {
         parseOptions.setFlattenComposedSchemas(true);
         parseOptions.setResolveCombinators(true);
 
-        SwaggerParseResult swaggerParseResult = openAPIParser.readLocation(url, null, parseOptions);
+        SwaggerParseResult swaggerParseResult = openAPIParser.readLocation(url, auth, parseOptions);
         if (swaggerParseResult.getOpenAPI() == null) {
             log.error("Could not load OpenAPI from : {} \n{}", url, String.join("\t\n", swaggerParseResult.getMessages()));
             throw new OpenAPILoaderException("Could not load open api from :" + url, swaggerParseResult.getMessages());

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/ExtensionFilter.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/ExtensionFilter.java
@@ -1,31 +1,51 @@
 package com.backbase.oss.boat.transformers;
 
-import static java.util.Optional.ofNullable;
-import static java.util.Spliterators.spliteratorUnknownSize;
-import static java.util.stream.StreamSupport.stream;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Spliterator;
 
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.SneakyThrows;
 
+import static java.util.Collections.emptyList;
+import static java.util.Optional.ofNullable;
+import static java.util.Spliterators.spliteratorUnknownSize;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.StreamSupport.stream;
+
 @SuppressWarnings("java:S3740")
-public class VendorExtensionFilter implements Transformer {
+@Getter
+@Setter
+public class ExtensionFilter implements Transformer {
+
+    private List<String> remove = emptyList();
 
     @Override
     public @NonNull OpenAPI transform(@NonNull OpenAPI openAPI, @NonNull Map<String, Object> options) {
-        return ofNullable(options.get("remove"))
-            .map(remove -> transform(openAPI, (Collection<String>) remove))
-            .orElse(openAPI);
+        List<String> extensions = new ArrayList<>(remove);
+
+        ofNullable(options.get("remove"))
+            .map(t -> (List<String>) t)
+            .ifPresent(extensions::addAll);
+
+        extensions.addAll(
+            extensions.stream()
+                .filter(s -> !s.startsWith("x-"))
+                .map(s -> "x-" + s)
+                .collect(toSet()));
+
+        return extensions.isEmpty() ? openAPI : transform(openAPI, extensions);
     }
 
     @SneakyThrows

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/SetVersion.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/SetVersion.java
@@ -2,17 +2,24 @@ package com.backbase.oss.boat.transformers;
 
 import java.util.Map;
 
-import static java.util.Optional.*;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
-@RequiredArgsConstructor
-public class SpecVersionTransformer implements Transformer {
+import static java.util.Optional.ofNullable;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SetVersion implements Transformer {
 
     @NonNull
-    private final String version;
+    private String version;
 
     @Override
     public OpenAPI transform(OpenAPI openAPI, Map<String, Object> options) {
@@ -25,6 +32,12 @@ public class SpecVersionTransformer implements Transformer {
         return openAPI;
     }
 
-}
+    /**
+     * Default setter, used at creation from POM configuration.
+     */
+    public void set(String version) {
+        setVersion(version);
+    }
 
+}
 

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/ExtensionFilterTests.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/ExtensionFilterTests.java
@@ -17,11 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-class VendorExtensionFilterTests {
+class ExtensionFilterTests {
 
     @Test
     void run() throws Throwable {
-        Transformer trn = new VendorExtensionFilter();
+        Transformer trn = new ExtensionFilter();
 
         OpenAPI api1 = OpenAPILoader.load(new File("src/test/resources/openapi/extension-filter/openapi.yaml"));
         OpenAPI api2 = trn.transform(api1, singletonMap("remove", singleton("x-remove")));

--- a/boat-maven-plugin/README.md
+++ b/boat-maven-plugin/README.md
@@ -3,188 +3,189 @@
 The `boat` plugin has multiple goals:
 
 
-- `export`
+## boat:export
 
-    Generates client/server code from a OpenAPI json/yaml
-    definition. Finds files name `api.raml`, `client-api.raml` or `service-api.raml`. Processes these files (and the 
-    json schemes they refer to) to produce `open-api.yaml` files in the output directory.
+Generates client/server code from a OpenAPI json/yaml definition. Finds files name `api.raml`, `client-api.raml` or `service-api.raml`.
+Processes these files (and the json schemes they refer to) to produce `open-api.yaml` files in the output directory.
 
-- `export-bom`
+## boat:export-bom
 
-    Converts all RAML spec dependencies to OpenAPI Specs. See integration tests for examples
+Converts all RAML spec dependencies to OpenAPI Specs. See integration tests for examples
 
-- `export-dep`
+## boat:export-dep
 
-    Exports project dependencies where the ArtifactId ends with.  See integration tests for examples
-    '-spec'.
+Exports project dependencies where the ArtifactId ends with.  See integration tests for examples '-spec'.
 
-- `generate`
-    
-    Open API Generator based on https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin. All configuration options as 
-    defined on openapi-generator-maven-plugin can be applied here too. 
-    boat-maven-plugin uses slightly modified templates for html, java and webclient that help generate specs and clients that work best in a Backbase projects.
-   
-- `generate-spring-boot-embedded`, `generate` but with opinionated defaults
+## boat:generate
 
-            <configuration>
-                <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
-                <apiPackage>com.backbase.product.api.service.v2</apiPackage>
-                <modelPackage>com.backbase.product.api.service.v2.model</modelPackage>
-            </configuration>
-            
-            Is the same as:
+Open API Generator based on https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin. All configuration options as 
+defined on openapi-generator-maven-plugin can be applied here too. 
 
-              <configuration>
-                <output>${project.build.directory}/generated-sources/openapi</output>
-                <generateSupportingFiles>true</generateSupportingFiles>
-                <generatorName>spring-boat</generatorName>
-                <strictSpec>true</strictSpec>
-                <generateApiTests>false</generateApiTests>
-                <generateModelTests>false</generateModelTests>
-                <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
-                <configOptions>
-                  <library>spring-boot</library>
-                  <dateLibrary>java8</dateLibrary>
-                  <interfaceOnly>true</interfaceOnly>
-                  <skipDefaultInterface>true</skipDefaultInterface>
-                  <useBeanValidation>true</useBeanValidation>
-                  <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
-                  <useTags>true</useTags>
-                  <java8>true</java8>
-                  <useOptional>false</useOptional>
-                  <apiPackage>com.backbase.product.api.service.v2</apiPackage>
-                  <modelPackage>com.backbase.product.api.service.v2.model</modelPackage>
-                </configOptions>
+Boat maven plugin uses slightly modified templates for html, java and webclient that help generate specs and clients that work best in a Backbase projects.
 
-- `generate-rest-template-embedded`, `generate` but with opinionated defaults
+## boat:generate-spring-boot-embedded
 
-            <configuration>
-              <output>${project.build.directory}/generated-sources/openapi</output>
-              <generateSupportingFiles>true</generateSupportingFiles>
-              <generatorName>java</generatorName>
-              <strictSpec>true</strictSpec>
-              <generateApiTests>false</generateApiTests>
-              <generateModelTests>false</generateModelTests>
-              <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
-              <configOptions>
-                <library>resttemplate</library>
-                <dateLibrary>java8</dateLibrary>
-                <interfaceOnly>true</interfaceOnly>
-                <skipDefaultInterface>true</skipDefaultInterface>
-                <useBeanValidation>true</useBeanValidation>
-                <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
-                <useTags>true</useTags>
-                <java8>true</java8>
-                <useOptional>false</useOptional>
-                <apiPackage>com.backbase.goldensample.product.api.client.v2</apiPackage>
-                <modelPackage>com.backbase.goldensample.product.api.client.v2.model</modelPackage>
-              </configOptions>
-            </configuration>
+Same with `generate` but with opinionated defaults for Spring
 
-- `generate-webclient-embedded`, `generate` but with opinionated defaults
+    <configuration>
+        <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
+        <apiPackage>com.backbase.product.api.service.v2</apiPackage>
+        <modelPackage>com.backbase.product.api.service.v2.model</modelPackage>
+    </configuration>
 
-            <configuration>
-              <output>${project.build.directory}/generated-sources/openapi</output>
-              <generateSupportingFiles>true</generateSupportingFiles>
-              <generatorName>java</generatorName>
-              <strictSpec>true</strictSpec>
-              <generateApiTests>false</generateApiTests>
-              <generateModelTests>false</generateModelTests>
-              <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
-              <configOptions>
-                <library>webclient</library>
-                <dateLibrary>java8</dateLibrary>
-                <interfaceOnly>true</interfaceOnly>
-                <skipDefaultInterface>true</skipDefaultInterface>
-                <useBeanValidation>true</useBeanValidation>
-                <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
-                <useTags>true</useTags>
-                <java8>true</java8>
-                <useOptional>false</useOptional>
-                <apiPackage>com.backbase.goldensample.product.api.client.v2</apiPackage>
-                <modelPackage>com.backbase.goldensample.product.api.client.v2.model</modelPackage>
-              </configOptions>
-            </configuration>
+... is the same as:
 
-- `decompose`
+    <configuration>
+        <output>${project.build.directory}/generated-sources/openapi</output>
+        <generateSupportingFiles>true</generateSupportingFiles>
+        <generatorName>spring-boat</generatorName>
+        <strictSpec>true</strictSpec>
+        <generateApiTests>false</generateApiTests>
+        <generateModelTests>false</generateModelTests>
+        <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
+        <configOptions>
+            <library>spring-boot</library>
+            <dateLibrary>java8</dateLibrary>
+            <interfaceOnly>true</interfaceOnly>
+            <skipDefaultInterface>true</skipDefaultInterface>
+            <useBeanValidation>true</useBeanValidation>
+            <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
+            <useTags>true</useTags>
+            <java8>true</java8>
+            <useOptional>false</useOptional>
+            <apiPackage>com.backbase.product.api.service.v2</apiPackage>
+            <modelPackage>com.backbase.product.api.service.v2.model</modelPackage>
+        </configOptions>
+    </configuration>
 
-    Merges any components using allOf references.
+## boat:generate-rest-template-embedded
 
-- `diff`
+Same with `generate` but with opinionated defaults for Rest Template Client
 
-    Calculates a Change log for APIs.
+    <configuration>
+        <output>${project.build.directory}/generated-sources/openapi</output>
+        <generateSupportingFiles>true</generateSupportingFiles>
+        <generatorName>java</generatorName>
+        <strictSpec>true</strictSpec>
+        <generateApiTests>false</generateApiTests>
+        <generateModelTests>false</generateModelTests>
+        <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
+        <configOptions>
+            <library>resttemplate</library>
+            <dateLibrary>java8</dateLibrary>
+            <interfaceOnly>true</interfaceOnly>
+            <skipDefaultInterface>true</skipDefaultInterface>
+            <useBeanValidation>true</useBeanValidation>
+            <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
+            <useTags>true</useTags>
+            <java8>true</java8>
+            <useOptional>false</useOptional>
+            <apiPackage>com.backbase.goldensample.product.api.client.v2</apiPackage>
+            <modelPackage>com.backbase.goldensample.product.api.client.v2.model</modelPackage>
+        </configOptions>
+    </configuration>
 
-- `remove-deprecated`
+## boat:generate-webclient-embedded
 
-    Removes deprecated elements in an OpenAPI spec.
+Same with `generate` but with opinionated defaults for Web Client
 
-- `boat:validate`
+    <configuration>
+        <output>${project.build.directory}/generated-sources/openapi</output>
+        <generateSupportingFiles>true</generateSupportingFiles>
+        <generatorName>java</generatorName>
+        <strictSpec>true</strictSpec>
+        <generateApiTests>false</generateApiTests>
+        <generateModelTests>false</generateModelTests>
+        <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
+        <configOptions>
+            <library>webclient</library>
+            <dateLibrary>java8</dateLibrary>
+            <interfaceOnly>true</interfaceOnly>
+            <skipDefaultInterface>true</skipDefaultInterface>
+            <useBeanValidation>true</useBeanValidation>
+            <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
+            <useTags>true</useTags>
+            <java8>true</java8>
+            <useOptional>false</useOptional>
+            <apiPackage>com.backbase.goldensample.product.api.client.v2</apiPackage>
+            <modelPackage>com.backbase.goldensample.product.api.client.v2.model</modelPackage>
+        </configOptions>
+    </configuration>
 
-    Validates OpenAPI specs.
-    
-    Configuration can point to a specific file, or a directory. When a directory is specified all files with a `.yaml` 
-    extension are validated. `failOnWarning` specifies whether to fail the build when validation violations are found,
-    otherwise, warnings are written to the log for everyone to ignore.
-    
-    ```
+## boat:decompose
+
+Merges any components using allOf references.
+
+## boat:diff
+
+Calculates a Change log for APIs.
+
+## boat:remove-deprecated
+
+Removes deprecated elements in an OpenAPI spec.
+
+## boat:validate
+
+Validates OpenAPI specs.
+
+Configuration can point to a specific file, or a directory. When a directory is specified all files with a `.yaml` 
+extension are validated. `failOnWarning` specifies whether to fail the build when validation violations are found,
+otherwise, warnings are written to the log for everyone to ignore.
+
     <configuration>
         <input>${project.build.outputDirectory}/specs/</input>
         <failOnWarning>true</failOnWarning>
     </configuration>
-    ```
 
-- `boat:lint`
+## boat:lint
 
-   API lint which provides checks for compliance with many of Backbase's API standards
+API lint which provides checks for compliance with many of Backbase's API standards
+
+Available parameters:
+
+    failOnWarning (Default: false)
+        Set this to true to fail in case a warning is found.
+
+    ignoreRules
+        List of rules ids which will be ignored.
+
+    inputSpec
+        Required: true
+        Input spec directory or file.
+
+    output (Default: ${project.build.directory}/boat-lint-reports)
+        Output directory for lint reports.
+
+    showIgnoredRules (Default: false)
+        Set this to true to show the list of ignored rules..
    
-    Available parameters:
-   
-       failOnWarning (Default: false)
-         Set this to true to fail in case a warning is found.
-   
-       ignoreRules
-         List of rules ids which will be ignored.
-   
-       inputSpec
-         Required: true
-         Input spec directory or file.
-   
-       output (Default:
-       ${project.build.directory}/boat-lint-reports)
-         Output directory for lint reports.
-   
-       showIgnoredRules (Default: false)
-         Set this to true to show the list of ignored rules..
-   
-       writeLintReport (Default: true)
-         Set this to true to generate lint report.
- 
-   Example:
-    
-   ```
-   <configuration>
-       <inputSpec>${unversioned-filename-spec-dir}/</inputSpec>
-       <output>${project.build.directory}/boat-lint-reports</output>
-       <writeLintReport>true</writeLintReport>
-       <ignoreRules>${ignored-lint-rules}</ignoreRules>
-       <showIgnoredRules>true</showIgnoredRules>
+    writeLintReport (Default: true)
+        Set this to true to generate lint report.
+
+Example:
+
+    <configuration>
+        <inputSpec>${unversioned-filename-spec-dir}/</inputSpec>
+        <output>${project.build.directory}/boat-lint-reports</output>
+        <writeLintReport>true</writeLintReport>
+        <ignoreRules>${ignored-lint-rules}</ignoreRules>
+        <showIgnoredRules>true</showIgnoredRules>
     </configuration>
-   ```
+
+To see details about this goal:
+
+    mvn help:describe -DgroupId=com.backbase.oss -DartifactId=boat-maven-plugin  -Dgoal=lint -Ddetail`
   
-  To see details about this goal:
   
-`mvn help:describe -DgroupId=com.backbase.oss -DartifactId=boat-maven-plugin  -Dgoal=lint -Ddetail`
-  
-  
-- `boat:bundle`
-    
-    Bundles a spec by resolving external references.
-    
-    Configuration can point to a single in- and output file, or to in- and output directories. When directories are
-    specified, all files specified by the `includes` parameter are bundled.
-    
-    Examples in `json` files are parsed to objects.
-    ```
+## boat:bundle
+
+Bundles a spec by resolving external references.
+
+Configuration can point to a single in- and output file, or to in- and output directories. When directories are
+specified, all files specified by the `includes` parameter are bundled.
+
+Examples in `json` files are parsed to objects.
+
     <configuration>
         <skip>${bundle.skip}</skip>
         <input>${project.basedir}/src/main/resources/</input>
@@ -196,14 +197,11 @@ The `boat` plugin has multiple goals:
         </removeExtensions>
     </configuration>
 
-    ```
-    
-
 For more information, run 
 
-`mvn help:describe -Dplugin=com.backbase.oss:boat-maven-plugin -Ddetail`
+    mvn help:describe -Dplugin=com.backbase.oss:boat-maven-plugin -Dgoal=bundle -Ddetail
 
-## Configuration examples
+Configuration example
 
 ```$xml
    <build>
@@ -243,6 +241,7 @@ For more information, run
 ```
 
 Usage
-```mvn boat:generate```
+
+    mvn boat:generate
 
 Or hook up to your build process by adding ```executions``` configuration.

--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -81,6 +81,11 @@
             <artifactId>plexus-build-api</artifactId>
             <version>0.0.7</version>
         </dependency>
+        <dependency>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-io</artifactId>
+          <version>3.2.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
@@ -9,8 +9,8 @@ import com.backbase.oss.boat.loader.OpenAPILoader;
 import com.backbase.oss.boat.loader.OpenAPILoaderException;
 import com.backbase.oss.boat.serializer.SerializerUtils;
 import com.backbase.oss.boat.transformers.Bundler;
-import com.backbase.oss.boat.transformers.SpecVersionTransformer;
-import com.backbase.oss.boat.transformers.VendorExtensionFilter;
+import com.backbase.oss.boat.transformers.SetVersion;
+import com.backbase.oss.boat.transformers.ExtensionFilter;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.io.File;
 import java.io.IOException;
@@ -110,7 +110,7 @@ public class BundleMojo extends AbstractMojo {
             OpenAPI openAPI = OpenAPILoader.load(inputFile);
 
             if (isNotBlank(version)) {
-                openAPI = new SpecVersionTransformer(version)
+                openAPI = new SetVersion(version)
                     .transform(openAPI);
             }
 
@@ -118,7 +118,7 @@ public class BundleMojo extends AbstractMojo {
                 .transform(openAPI);
 
             if (isNotEmpty(removeExtensions)) {
-                openAPI = new VendorExtensionFilter()
+                openAPI = new ExtensionFilter()
                     .transform(openAPI, singletonMap("remove", removeExtensions));
             }
 

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/TransformMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/TransformMojo.java
@@ -1,0 +1,181 @@
+package com.backbase.oss.boat.transformers;
+
+import com.backbase.oss.boat.loader.OpenAPILoader;
+import com.backbase.oss.boat.serializer.SerializerUtils;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.building.SettingsProblem;
+import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecryptionResult;
+import org.codehaus.plexus.components.io.filemappers.FileMapper;
+import org.codehaus.plexus.components.io.filemappers.SuffixFileMapper;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+/**
+ * Apply transformers to an existing specification.
+ */
+@Mojo(name = "transform", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
+public class TransformMojo extends AbstractMojo {
+
+    /**
+     * Whether to skip the execution of this goal.
+     */
+    @Parameter(property = "boat.transform.skip", alias = "codegen.skip")
+    private boolean skip;
+
+    /**
+     * A list of input specifications.
+     */
+    @Parameter(property = "boat.transform.inputs", required = true)
+    protected List<String> inputs;
+
+    /**
+     * The list of transformers to be applied to each input specification.
+     */
+    @Parameter(required = true)
+    private List<Transformer> pipeline;
+
+    /**
+     * File name mapper used to generate the output file name; defaults to
+     * {@link org.codehaus.plexus.components.io.filemappers.SuffixFileMapper} with a
+     * {@code -transformed} suffix.
+     */
+    @Parameter
+    private FileMapper mapper;
+
+    /**
+     * Additional options passed to transformers.
+     */
+    @Parameter
+    private Map<String, Object> options = new HashMap<>();
+
+    /**
+     * Retrieves authorization from Maven's {@code settings.xml}.
+     */
+    @Parameter(name = "serverId", property = "boat.transform.serverId")
+    private String serverId;
+
+    @Parameter(defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+    @Component
+    private SettingsDecrypter decrypter;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (this.skip) {
+            getLog().info("Skipping Transform Mojo.");
+
+            return;
+        }
+
+        if (mapper == null) {
+            SuffixFileMapper sfm = new SuffixFileMapper();
+
+            sfm.setSuffix("-transformed");
+
+            this.mapper = sfm;
+        }
+
+        try {
+            this.inputs.forEach(this::transform);
+        } catch (final RuntimeException e) {
+            final Throwable cause = e.getCause();
+
+            if (cause instanceof MojoExecutionException) {
+                throw (MojoExecutionException) cause;
+            }
+            if (cause instanceof MojoFailureException) {
+                throw (MojoFailureException) cause;
+            }
+
+            throw new MojoFailureException("Transformation failed", e);
+        }
+    }
+
+    @SneakyThrows
+    private void transform(String input) {
+        OpenAPI openAPI = OpenAPILoader.load(input, false, false, buildAuthorization());
+
+        for (final Transformer t : this.pipeline) {
+            openAPI = t.transform(openAPI, this.options);
+        }
+
+        final File output = new File(this.mapper.getMappedFileName(input));
+
+        output.getParentFile().mkdirs();
+
+        Files.write(output.toPath(),
+            SerializerUtils
+                .toYamlString(openAPI)
+                .getBytes(StandardCharsets.UTF_8),
+            StandardOpenOption.CREATE);
+    }
+
+    private List<AuthorizationValue> buildAuthorization() throws MojoExecutionException {
+        return Optional.ofNullable(readAuthorization())
+            .map(auth -> new AuthorizationValue("Authorization", "header", auth))
+            .map(Arrays::asList)
+            .orElse(null);
+    }
+
+    private String readAuthorization() throws MojoExecutionException {
+        if (isEmpty(this.serverId)) {
+            return null;
+        }
+
+        final Server server = this.session.getSettings().getServer(this.serverId);
+
+        if (server == null) {
+            throw new MojoExecutionException(format("Cannot find serverId \"%s\" in Maven settings", this.serverId));
+        }
+
+        final SettingsDecryptionRequest request = new DefaultSettingsDecryptionRequest(server);
+        final SettingsDecryptionResult result = this.decrypter.decrypt(request);
+
+        // Un-encrypted passwords are passed through, so a problem indicates a real issue.
+        // If there are any ERROR or FATAL problems reported, then decryption failed.
+        for (final SettingsProblem problem : result.getProblems()) {
+            switch (problem.getSeverity()) {
+                case ERROR:
+                case FATAL:
+                    throw new MojoExecutionException(
+                        format("Unable to decrypt serverId \"%s\":%s ", this.serverId, problem));
+
+                default:
+                    getLog().warn(format("Decrypting \"%s\": %s", this.serverId, problem));
+            }
+        }
+
+        final Server resultServer = result.getServer();
+        final String username = resultServer.getUsername();
+        final String password = resultServer.getPassword();
+        final String auth = username + ":" + password;
+
+        return "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+    }
+}
+

--- a/boat-scaffold/src/main/templates/boat-spring/model.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/model.mustache
@@ -42,6 +42,8 @@ import javax.xml.bind.annotation.*;
 import org.springframework.hateoas.RepresentationModel;
 {{/hateoas}}
 {{/parent}}
+{{#vendorExtensions.x-extra-java-imports}}
+{{{vendorExtensions.x-extra-java-imports}}}{{/vendorExtensions.x-extra-java-imports}}
 
 {{#models}}
 {{#model}}

--- a/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
@@ -4,7 +4,9 @@
 @ApiModel(description = "{{{description}}}"){{/description}}
 {{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}{{>additionalModelTypeAnnotations}}
 {{#useLombokAnnotations}}
-@lombok.EqualsAndHashCode(onlyExplicitlyIncluded = true{{#parent}}, callSuper = true{{/parent}}){{/useLombokAnnotations}}
+@lombok.EqualsAndHashCode(onlyExplicitlyIncluded = true, doNotUseGetters = true{{#parent}}, callSuper = true{{/parent}})
+@lombok.ToString(onlyExplicitlyIncluded = true, doNotUseGetters = true{{#parent}}, callSuper = true{{/parent}})
+{{/useLombokAnnotations}}
 {{#vendorExtensions.x-extra-annotation}}
 {{{vendorExtensions.x-extra-annotation}}}{{/vendorExtensions.x-extra-annotation}}
 public {{#vendorExtensions.x-abstract}}abstract {{/vendorExtensions.x-abstract}}class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}{{#hateoas}}extends RepresentationModel<{{classname}}> {{/hateoas}}{{/parent}}{{#serializableModel}}implements Serializable{{/serializableModel}}
@@ -37,6 +39,7 @@ public {{#vendorExtensions.x-abstract}}abstract {{/vendorExtensions.x-abstract}}
     @lombok.Getter(onMethod_ = @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"))
     @lombok.Setter
     @lombok.EqualsAndHashCode.Include
+    @lombok.ToString.Include
     {{#vendorExtensions.x-extra-annotation}}
     {{#indent4}}{{{vendorExtensions.x-extra-annotation}}}{{/indent4}}{{/vendorExtensions.x-extra-annotation}}
     {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}
@@ -148,6 +151,9 @@ public {{#vendorExtensions.x-abstract}}abstract {{/vendorExtensions.x-abstract}}
 
     {{/vars}}
 
+    {{#vendorExtensions.x-extra-java-code}}
+    {{#indent4}}{{{vendorExtensions.x-extra-java-code}}}{{/indent4}}{{/vendorExtensions.x-extra-java-code}}
+
     {{^useLombokAnnotations}}
     @Override
     public boolean equals(java.lang.Object o) {
@@ -172,7 +178,6 @@ public {{#vendorExtensions.x-abstract}}abstract {{/vendorExtensions.x-abstract}}
             {{/hasVars}}super.hashCode(){{/parent}}
         );
     }
-    {{/useLombokAnnotations}}
 
     @Override
     public String toString() {
@@ -194,4 +199,5 @@ public {{#vendorExtensions.x-abstract}}abstract {{/vendorExtensions.x-abstract}}
         }
         return o.toString().replace("\n", "\n        ");
     }
+    {{/useLombokAnnotations}}
 }


### PR DESCRIPTION
1. New `boat:transform` goal to pipeline existing transformers in an execution
   - works with multiple inputs
2. Use vendor extensions to inject arbitrary Java code in models generated by Spring generator