### PR TITLE
boat:transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The project is very much Work In Progress and will be published on maven central
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.14.3
+
+* *Maven Plugin*
+  * Added new goal `boat:transform`; see the description in the [plugin documentation](boat-maven-plugin/README.md#boattransform).
+
 ## 0.14.2
 * *Angular Generator*
   * Added support for Angular version ranges in peer dependencies
@@ -39,6 +44,7 @@ BOAT is still under development and subject to change.
     * Check prefix for paths should contain version.
   * Enabled rules.
     * Use Standard HTTP Status Codes.
+
 ## 0.12.0
 * *General*
   * Improved code quality
@@ -140,12 +146,10 @@ BOAT is still under development and subject to change.
 * ability to resolve references like #/components/schemas/myObject/items or #/components/schemas/myObject/properties/embeddedObject
 * simple fix to avoid npe in StaticHtml2Generation escaping response message.
 
-
 ## 0.5.0
 
 * Add DereferenceComponentsPropertiesTransformer (that does a bit extra)
 * Fix recursive referencing in UnAliasTransformer
-
 
 ## 0.4.0
 * Added bundle skip

--- a/boat-engine/src/main/java/com/backbase/oss/boat/loader/OpenAPILoader.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/loader/OpenAPILoader.java
@@ -2,9 +2,12 @@ package com.backbase.oss.boat.loader;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import java.io.File;
+import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -55,6 +58,10 @@ public class OpenAPILoader {
     }
 
     public static OpenAPI load(String url, boolean resolveFully, boolean flatten) throws OpenAPILoaderException {
+        return load(url, resolveFully, flatten, null);
+    }
+
+    public static OpenAPI load(String url, boolean resolveFully, boolean flatten, List<AuthorizationValue> auth) throws OpenAPILoaderException {
         log.debug("Reading OpenAPI from: {} resolveFully: {}", url, resolveFully);
         OpenAPIV3Parser openAPIParser = new OpenAPIV3Parser();
         ParseOptions parseOptions = new ParseOptions();
@@ -64,7 +71,7 @@ public class OpenAPILoader {
         parseOptions.setFlattenComposedSchemas(true);
         parseOptions.setResolveCombinators(true);
 
-        SwaggerParseResult swaggerParseResult = openAPIParser.readLocation(url, null, parseOptions);
+        SwaggerParseResult swaggerParseResult = openAPIParser.readLocation(url, auth, parseOptions);
         if (swaggerParseResult.getOpenAPI() == null) {
             log.error("Could not load OpenAPI from : {} \n{}", url, String.join("\t\n", swaggerParseResult.getMessages()));
             throw new OpenAPILoaderException("Could not load open api from :" + url, swaggerParseResult.getMessages());

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/ExtensionFilter.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/ExtensionFilter.java
@@ -1,31 +1,51 @@
 package com.backbase.oss.boat.transformers;
 
-import static java.util.Optional.ofNullable;
-import static java.util.Spliterators.spliteratorUnknownSize;
-import static java.util.stream.StreamSupport.stream;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Spliterator;
 
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.SneakyThrows;
 
+import static java.util.Collections.emptyList;
+import static java.util.Optional.ofNullable;
+import static java.util.Spliterators.spliteratorUnknownSize;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.StreamSupport.stream;
+
 @SuppressWarnings("java:S3740")
-public class VendorExtensionFilter implements Transformer {
+@Getter
+@Setter
+public class ExtensionFilter implements Transformer {
+
+    private List<String> remove = emptyList();
 
     @Override
     public @NonNull OpenAPI transform(@NonNull OpenAPI openAPI, @NonNull Map<String, Object> options) {
-        return ofNullable(options.get("remove"))
-            .map(remove -> transform(openAPI, (Collection<String>) remove))
-            .orElse(openAPI);
+        List<String> extensions = new ArrayList<>(remove);
+
+        ofNullable(options.get("remove"))
+            .map(Collection.class::cast)
+            .ifPresent(extensions::addAll);
+
+        extensions.addAll(
+            extensions.stream()
+                .filter(s -> !s.startsWith("x-"))
+                .map(s -> "x-" + s)
+                .collect(toSet()));
+
+        return extensions.isEmpty() ? openAPI : transform(openAPI, extensions);
     }
 
     @SneakyThrows

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/SetVersion.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/SetVersion.java
@@ -2,17 +2,24 @@ package com.backbase.oss.boat.transformers;
 
 import java.util.Map;
 
-import static java.util.Optional.*;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
-@RequiredArgsConstructor
-public class SpecVersionTransformer implements Transformer {
+import static java.util.Optional.ofNullable;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SetVersion implements Transformer {
 
     @NonNull
-    private final String version;
+    private String version;
 
     @Override
     public OpenAPI transform(OpenAPI openAPI, Map<String, Object> options) {
@@ -25,6 +32,12 @@ public class SpecVersionTransformer implements Transformer {
         return openAPI;
     }
 
-}
+    /**
+     * Default setter, used at creation from POM configuration.
+     */
+    public void set(String version) {
+        setVersion(version);
+    }
 
+}
 

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/ExtensionFilterTests.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/ExtensionFilterTests.java
@@ -17,11 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 
 @Slf4j
-class VendorExtensionFilterTests {
+class ExtensionFilterTests {
 
     @Test
     void run() throws Throwable {
-        Transformer trn = new VendorExtensionFilter();
+        Transformer trn = new ExtensionFilter();
 
         OpenAPI api1 = OpenAPILoader.load(new File("src/test/resources/openapi/extension-filter/openapi.yaml"));
         OpenAPI api2 = trn.transform(api1, singletonMap("remove", singleton("x-remove")));

--- a/boat-maven-plugin/README.md
+++ b/boat-maven-plugin/README.md
@@ -3,188 +3,189 @@
 The `boat` plugin has multiple goals:
 
 
-- `export`
+## boat:export
 
-    Generates client/server code from a OpenAPI json/yaml
-    definition. Finds files name `api.raml`, `client-api.raml` or `service-api.raml`. Processes these files (and the 
-    json schemes they refer to) to produce `open-api.yaml` files in the output directory.
+Generates client/server code from a OpenAPI json/yaml definition. Finds files name `api.raml`, `client-api.raml` or `service-api.raml`.
+Processes these files (and the json schemes they refer to) to produce `open-api.yaml` files in the output directory.
 
-- `export-bom`
+## boat:export-bom
 
-    Converts all RAML spec dependencies to OpenAPI Specs. See integration tests for examples
+Converts all RAML spec dependencies to OpenAPI Specs. See integration tests for examples
 
-- `export-dep`
+## boat:export-dep
 
-    Exports project dependencies where the ArtifactId ends with.  See integration tests for examples
-    '-spec'.
+Exports project dependencies where the ArtifactId ends with.  See integration tests for examples '-spec'.
 
-- `generate`
-    
-    Open API Generator based on https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin. All configuration options as 
-    defined on openapi-generator-maven-plugin can be applied here too. 
-    boat-maven-plugin uses slightly modified templates for html, java and webclient that help generate specs and clients that work best in a Backbase projects.
-   
-- `generate-spring-boot-embedded`, `generate` but with opinionated defaults
+## boat:generate
 
-            <configuration>
-                <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
-                <apiPackage>com.backbase.product.api.service.v2</apiPackage>
-                <modelPackage>com.backbase.product.api.service.v2.model</modelPackage>
-            </configuration>
-            
-            Is the same as:
+Open API Generator based on https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin. All configuration options as 
+defined on openapi-generator-maven-plugin can be applied here too. 
 
-              <configuration>
-                <output>${project.build.directory}/generated-sources/openapi</output>
-                <generateSupportingFiles>true</generateSupportingFiles>
-                <generatorName>spring-boat</generatorName>
-                <strictSpec>true</strictSpec>
-                <generateApiTests>false</generateApiTests>
-                <generateModelTests>false</generateModelTests>
-                <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
-                <configOptions>
-                  <library>spring-boot</library>
-                  <dateLibrary>java8</dateLibrary>
-                  <interfaceOnly>true</interfaceOnly>
-                  <skipDefaultInterface>true</skipDefaultInterface>
-                  <useBeanValidation>true</useBeanValidation>
-                  <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
-                  <useTags>true</useTags>
-                  <java8>true</java8>
-                  <useOptional>false</useOptional>
-                  <apiPackage>com.backbase.product.api.service.v2</apiPackage>
-                  <modelPackage>com.backbase.product.api.service.v2.model</modelPackage>
-                </configOptions>
+Boat maven plugin uses slightly modified templates for html, java and webclient that help generate specs and clients that work best in a Backbase projects.
 
-- `generate-rest-template-embedded`, `generate` but with opinionated defaults
+## boat:generate-spring-boot-embedded
 
-            <configuration>
-              <output>${project.build.directory}/generated-sources/openapi</output>
-              <generateSupportingFiles>true</generateSupportingFiles>
-              <generatorName>java</generatorName>
-              <strictSpec>true</strictSpec>
-              <generateApiTests>false</generateApiTests>
-              <generateModelTests>false</generateModelTests>
-              <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
-              <configOptions>
-                <library>resttemplate</library>
-                <dateLibrary>java8</dateLibrary>
-                <interfaceOnly>true</interfaceOnly>
-                <skipDefaultInterface>true</skipDefaultInterface>
-                <useBeanValidation>true</useBeanValidation>
-                <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
-                <useTags>true</useTags>
-                <java8>true</java8>
-                <useOptional>false</useOptional>
-                <apiPackage>com.backbase.goldensample.product.api.client.v2</apiPackage>
-                <modelPackage>com.backbase.goldensample.product.api.client.v2.model</modelPackage>
-              </configOptions>
-            </configuration>
+Same with `generate` but with opinionated defaults for Spring
 
-- `generate-webclient-embedded`, `generate` but with opinionated defaults
+    <configuration>
+        <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
+        <apiPackage>com.backbase.product.api.service.v2</apiPackage>
+        <modelPackage>com.backbase.product.api.service.v2.model</modelPackage>
+    </configuration>
 
-            <configuration>
-              <output>${project.build.directory}/generated-sources/openapi</output>
-              <generateSupportingFiles>true</generateSupportingFiles>
-              <generatorName>java</generatorName>
-              <strictSpec>true</strictSpec>
-              <generateApiTests>false</generateApiTests>
-              <generateModelTests>false</generateModelTests>
-              <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
-              <configOptions>
-                <library>webclient</library>
-                <dateLibrary>java8</dateLibrary>
-                <interfaceOnly>true</interfaceOnly>
-                <skipDefaultInterface>true</skipDefaultInterface>
-                <useBeanValidation>true</useBeanValidation>
-                <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
-                <useTags>true</useTags>
-                <java8>true</java8>
-                <useOptional>false</useOptional>
-                <apiPackage>com.backbase.goldensample.product.api.client.v2</apiPackage>
-                <modelPackage>com.backbase.goldensample.product.api.client.v2.model</modelPackage>
-              </configOptions>
-            </configuration>
+... is the same as:
 
-- `decompose`
+    <configuration>
+        <output>${project.build.directory}/generated-sources/openapi</output>
+        <generateSupportingFiles>true</generateSupportingFiles>
+        <generatorName>spring-boat</generatorName>
+        <strictSpec>true</strictSpec>
+        <generateApiTests>false</generateApiTests>
+        <generateModelTests>false</generateModelTests>
+        <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
+        <configOptions>
+            <library>spring-boot</library>
+            <dateLibrary>java8</dateLibrary>
+            <interfaceOnly>true</interfaceOnly>
+            <skipDefaultInterface>true</skipDefaultInterface>
+            <useBeanValidation>true</useBeanValidation>
+            <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
+            <useTags>true</useTags>
+            <java8>true</java8>
+            <useOptional>false</useOptional>
+            <apiPackage>com.backbase.product.api.service.v2</apiPackage>
+            <modelPackage>com.backbase.product.api.service.v2.model</modelPackage>
+        </configOptions>
+    </configuration>
 
-    Merges any components using allOf references.
+## boat:generate-rest-template-embedded
 
-- `diff`
+Same with `generate` but with opinionated defaults for Rest Template Client
 
-    Calculates a Change log for APIs.
+    <configuration>
+        <output>${project.build.directory}/generated-sources/openapi</output>
+        <generateSupportingFiles>true</generateSupportingFiles>
+        <generatorName>java</generatorName>
+        <strictSpec>true</strictSpec>
+        <generateApiTests>false</generateApiTests>
+        <generateModelTests>false</generateModelTests>
+        <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
+        <configOptions>
+            <library>resttemplate</library>
+            <dateLibrary>java8</dateLibrary>
+            <interfaceOnly>true</interfaceOnly>
+            <skipDefaultInterface>true</skipDefaultInterface>
+            <useBeanValidation>true</useBeanValidation>
+            <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
+            <useTags>true</useTags>
+            <java8>true</java8>
+            <useOptional>false</useOptional>
+            <apiPackage>com.backbase.goldensample.product.api.client.v2</apiPackage>
+            <modelPackage>com.backbase.goldensample.product.api.client.v2.model</modelPackage>
+        </configOptions>
+    </configuration>
 
-- `remove-deprecated`
+## boat:generate-webclient-embedded
 
-    Removes deprecated elements in an OpenAPI spec.
+Same with `generate` but with opinionated defaults for Web Client
 
-- `boat:validate`
+    <configuration>
+        <output>${project.build.directory}/generated-sources/openapi</output>
+        <generateSupportingFiles>true</generateSupportingFiles>
+        <generatorName>java</generatorName>
+        <strictSpec>true</strictSpec>
+        <generateApiTests>false</generateApiTests>
+        <generateModelTests>false</generateModelTests>
+        <inputSpec>${project.basedir}/../api/product-service-api/src/main/resources/openapi.yaml</inputSpec>
+        <configOptions>
+            <library>webclient</library>
+            <dateLibrary>java8</dateLibrary>
+            <interfaceOnly>true</interfaceOnly>
+            <skipDefaultInterface>true</skipDefaultInterface>
+            <useBeanValidation>true</useBeanValidation>
+            <useClassLevelBeanValidation>false</useClassLevelBeanValidation>
+            <useTags>true</useTags>
+            <java8>true</java8>
+            <useOptional>false</useOptional>
+            <apiPackage>com.backbase.goldensample.product.api.client.v2</apiPackage>
+            <modelPackage>com.backbase.goldensample.product.api.client.v2.model</modelPackage>
+        </configOptions>
+    </configuration>
 
-    Validates OpenAPI specs.
-    
-    Configuration can point to a specific file, or a directory. When a directory is specified all files with a `.yaml` 
-    extension are validated. `failOnWarning` specifies whether to fail the build when validation violations are found,
-    otherwise, warnings are written to the log for everyone to ignore.
-    
-    ```
+## boat:decompose
+
+Merges any components using allOf references.
+
+## boat:diff
+
+Calculates a Change log for APIs.
+
+## boat:remove-deprecated
+
+Removes deprecated elements in an OpenAPI spec.
+
+## boat:validate
+
+Validates OpenAPI specs.
+
+Configuration can point to a specific file, or a directory. When a directory is specified all files with a `.yaml` 
+extension are validated. `failOnWarning` specifies whether to fail the build when validation violations are found,
+otherwise, warnings are written to the log for everyone to ignore.
+
     <configuration>
         <input>${project.build.outputDirectory}/specs/</input>
         <failOnWarning>true</failOnWarning>
     </configuration>
-    ```
 
-- `boat:lint`
+## boat:lint
 
-   API lint which provides checks for compliance with many of Backbase's API standards
+API lint which provides checks for compliance with many of Backbase's API standards
+
+Available parameters:
+
+    failOnWarning (Default: false)
+        Set this to true to fail in case a warning is found.
+
+    ignoreRules
+        List of rules ids which will be ignored.
+
+    inputSpec
+        Required: true
+        Input spec directory or file.
+
+    output (Default: ${project.build.directory}/boat-lint-reports)
+        Output directory for lint reports.
+
+    showIgnoredRules (Default: false)
+        Set this to true to show the list of ignored rules..
    
-    Available parameters:
-   
-       failOnWarning (Default: false)
-         Set this to true to fail in case a warning is found.
-   
-       ignoreRules
-         List of rules ids which will be ignored.
-   
-       inputSpec
-         Required: true
-         Input spec directory or file.
-   
-       output (Default:
-       ${project.build.directory}/boat-lint-reports)
-         Output directory for lint reports.
-   
-       showIgnoredRules (Default: false)
-         Set this to true to show the list of ignored rules..
-   
-       writeLintReport (Default: true)
-         Set this to true to generate lint report.
- 
-   Example:
-    
-   ```
-   <configuration>
-       <inputSpec>${unversioned-filename-spec-dir}/</inputSpec>
-       <output>${project.build.directory}/boat-lint-reports</output>
-       <writeLintReport>true</writeLintReport>
-       <ignoreRules>${ignored-lint-rules}</ignoreRules>
-       <showIgnoredRules>true</showIgnoredRules>
+    writeLintReport (Default: true)
+        Set this to true to generate lint report.
+
+Example:
+
+    <configuration>
+        <inputSpec>${unversioned-filename-spec-dir}/</inputSpec>
+        <output>${project.build.directory}/boat-lint-reports</output>
+        <writeLintReport>true</writeLintReport>
+        <ignoreRules>${ignored-lint-rules}</ignoreRules>
+        <showIgnoredRules>true</showIgnoredRules>
     </configuration>
-   ```
+
+To see details about this goal:
+
+    mvn help:describe -DgroupId=com.backbase.oss -DartifactId=boat-maven-plugin  -Dgoal=lint -Ddetail`
   
-  To see details about this goal:
   
-`mvn help:describe -DgroupId=com.backbase.oss -DartifactId=boat-maven-plugin  -Dgoal=lint -Ddetail`
-  
-  
-- `boat:bundle`
-    
-    Bundles a spec by resolving external references.
-    
-    Configuration can point to a single in- and output file, or to in- and output directories. When directories are
-    specified, all files specified by the `includes` parameter are bundled.
-    
-    Examples in `json` files are parsed to objects.
-    ```
+## boat:bundle
+
+Bundles a spec by resolving external references.
+
+Configuration can point to a single in- and output file, or to in- and output directories. When directories are
+specified, all files specified by the `includes` parameter are bundled.
+
+Examples in `json` files are parsed to objects.
+
     <configuration>
         <skip>${bundle.skip}</skip>
         <input>${project.basedir}/src/main/resources/</input>
@@ -196,14 +197,11 @@ The `boat` plugin has multiple goals:
         </removeExtensions>
     </configuration>
 
-    ```
-    
-
 For more information, run 
 
-`mvn help:describe -Dplugin=com.backbase.oss:boat-maven-plugin -Ddetail`
+    mvn help:describe -Dplugin=com.backbase.oss:boat-maven-plugin -Dgoal=bundle -Ddetail
 
-## Configuration examples
+Configuration example
 
 ```$xml
    <build>
@@ -243,6 +241,83 @@ For more information, run
 ```
 
 Usage
-```mvn boat:generate```
+
+    mvn boat:generate
 
 Or hook up to your build process by adding ```executions``` configuration.
+
+## boat:transform
+
+Apply transformers to an existing specification.
+
+Available parameters:
+
+    inputs
+      Required: true
+      User property: boat.transform.inputs
+      A list of input specifications.
+
+    mappers
+      File name mappers used to generate the output file name, instances of
+      org.codehaus.plexus.components.io.filemappers.FileMapper.
+      The following mappers can be used without needing to specify the FQCN of
+      the implementation.
+      
+      regexp:
+        org.codehaus.plexus.components.io.filemappers.RegExpFileMapper
+      merge:
+        org.codehaus.plexus.components.io.filemappers.MergeFileMapper
+      prefix:
+        org.codehaus.plexus.components.io.filemappers.PrefixFileMapper
+      suffix:
+        org.codehaus.plexus.components.io.filemappers.SuffixFileMapper
+      
+      The parameter defaults to
+      
+       <mappers>
+            <suffix>-transformed</suffix>
+       </mappers>
+
+    options
+      Additional options passed to transformers.
+
+    output (Default: ${project.build.directory})
+      User property: boat.transform.output
+      Target directory of the transformed specifications.
+
+    pipeline
+      Required: true
+      The list of transformers to be applied to each input specification.
+
+    serverId
+      User property: boat.transform.serverId
+      Retrieves authorization from Maven's settings.xml.
+
+    skip
+      Alias: codegen.skip
+      User property: boat.transform.skip
+      Whether to skip the execution of this goal.
+
+Configuration example
+
+```$xml
+    <configuration>
+        <inputs>
+            <input>${project.build.directory}/openapi.yaml</input>
+        </inputs>
+        <mappers>
+            <merge>${spec.name}-${spec.version}.yaml</merge>
+        </mappers>
+        <pipeline>
+            <setVersion>${spec.version}</setVersion>
+            <extensionFilter>
+                <remove>
+                    <extension>abstract</extension>
+                    <extension>implements</extension>
+                    <extension>extra-annotation</extension>
+                    <extension>extra-java-code</extension>
+                </remove>
+            </extensionFilter>
+        </pipeline>
+    </configuration>
+```

--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -81,6 +82,11 @@
             <artifactId>plexus-build-api</artifactId>
             <version>0.0.7</version>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-io</artifactId>
+            <version>3.2.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -111,13 +117,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
@@ -9,8 +9,8 @@ import com.backbase.oss.boat.loader.OpenAPILoader;
 import com.backbase.oss.boat.loader.OpenAPILoaderException;
 import com.backbase.oss.boat.serializer.SerializerUtils;
 import com.backbase.oss.boat.transformers.Bundler;
-import com.backbase.oss.boat.transformers.SpecVersionTransformer;
-import com.backbase.oss.boat.transformers.VendorExtensionFilter;
+import com.backbase.oss.boat.transformers.SetVersion;
+import com.backbase.oss.boat.transformers.ExtensionFilter;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.io.File;
 import java.io.IOException;
@@ -110,7 +110,7 @@ public class BundleMojo extends AbstractMojo {
             OpenAPI openAPI = OpenAPILoader.load(inputFile);
 
             if (isNotBlank(version)) {
-                openAPI = new SpecVersionTransformer(version)
+                openAPI = new SetVersion(version)
                     .transform(openAPI);
             }
 
@@ -118,7 +118,7 @@ public class BundleMojo extends AbstractMojo {
                 .transform(openAPI);
 
             if (isNotEmpty(removeExtensions)) {
-                openAPI = new VendorExtensionFilter()
+                openAPI = new ExtensionFilter()
                     .transform(openAPI, singletonMap("remove", removeExtensions));
             }
 

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/Merge.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/Merge.java
@@ -1,0 +1,22 @@
+package com.backbase.oss.boat.transformers;
+
+import lombok.NoArgsConstructor;
+import org.codehaus.plexus.components.io.filemappers.MergeFileMapper;
+
+/**
+ * Merge mapper, easy to configure in {@code pom.xml}
+ */
+@NoArgsConstructor
+public class Merge extends MergeFileMapper {
+
+    public Merge(String value) {
+        set(value);
+    }
+
+    /**
+     * Default setter, used at creation from POM configuration.
+     */
+    public void set(String value) {
+        setTargetName(value);
+    }
+}

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/Prefix.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/Prefix.java
@@ -1,0 +1,22 @@
+package com.backbase.oss.boat.transformers;
+
+import lombok.NoArgsConstructor;
+import org.codehaus.plexus.components.io.filemappers.PrefixFileMapper;
+
+/**
+ * Prefix mapper, easy to configure in {@code pom.xml}
+ */
+@NoArgsConstructor
+public class Prefix extends PrefixFileMapper {
+
+    public Prefix(String value) {
+        set(value);
+    }
+
+    /**
+     * Default setter, used at creation from POM configuration.
+     */
+    public void set(String value) {
+        setPrefix(value);
+    }
+}

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/Regex.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/Regex.java
@@ -1,0 +1,16 @@
+package com.backbase.oss.boat.transformers;
+
+import lombok.NoArgsConstructor;
+import org.codehaus.plexus.components.io.filemappers.RegExpFileMapper;
+
+/**
+ * Regex mapper, easy to configure in {@code pom.xml}
+ */
+@NoArgsConstructor
+public class Regex extends RegExpFileMapper {
+
+    public Regex(String pattern, String replacement) {
+        setPattern(pattern);
+        setReplacement(replacement);
+    }
+}

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/Suffix.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/Suffix.java
@@ -1,0 +1,20 @@
+package com.backbase.oss.boat.transformers;
+
+import org.codehaus.plexus.components.io.filemappers.SuffixFileMapper;
+
+/**
+ * Suffix mapper, easy to configure in {@code pom.xml}
+ */
+public class Suffix extends SuffixFileMapper {
+
+    public Suffix(String value) {
+        set(value);
+    }
+
+    /**
+     * Default setter, used at creation from POM configuration.
+     */
+    public void set(String value) {
+        setSuffix(value);
+    }
+}

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/TransformMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/transformers/TransformMojo.java
@@ -1,0 +1,226 @@
+package com.backbase.oss.boat.transformers;
+
+import com.backbase.oss.boat.loader.OpenAPILoader;
+import com.backbase.oss.boat.serializer.SerializerUtils;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.building.SettingsProblem;
+import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecryptionResult;
+import org.codehaus.plexus.components.io.filemappers.FileMapper;
+
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+/**
+ * Apply transformers to an existing specification.
+ */
+@Mojo(name = "transform", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
+public class TransformMojo extends AbstractMojo {
+
+    /**
+     * Whether to skip the execution of this goal.
+     */
+    @Parameter(property = "boat.transform.skip", alias = "codegen.skip")
+    boolean skip;
+
+    /**
+     * A list of input specifications.
+     */
+    @Parameter(property = "boat.transform.inputs", required = true)
+    final List<String> inputs = new ArrayList<>();
+
+    /**
+     * Target directory of the transformed specifications.
+     */
+    @Parameter(property = "boat.transform.output", defaultValue = "${project.build.directory}")
+    File output;
+
+    /**
+     * The list of transformers to be applied to each input specification.
+     */
+    @Parameter(required = true)
+    final List<Transformer> pipeline = new ArrayList<>();
+
+    /**
+     * File name mappers used to generate the output file name, instances of
+     * {@code org.codehaus.plexus.components.io.filemappers.FileMapper}.
+     *
+     * <p>
+     * The following mappers can be used without needing to specify the FQCN of the implementation.
+     * <dl>
+     * <dt><b>regexp</b></dt>
+     * <dd>{@code org.codehaus.plexus.components.io.filemappers.RegExpFileMapper}</dd></dt>
+     * <dt><b>merge</b></dt>
+     * <dd>{@code org.codehaus.plexus.components.io.filemappers.MergeFileMapper}</dd></dt>
+     * <dt><b>prefix</b></dt>
+     * <dd>{@code org.codehaus.plexus.components.io.filemappers.PrefixFileMapper}</dd></dt>
+     * <dt><b>suffix</b></dt>
+     * <dd>{@code org.codehaus.plexus.components.io.filemappers.SuffixFileMapper}</dd></dt>
+     * </dl>
+     * </p>
+     *
+     * The parameter defaults to <code>
+     * <pre>
+     *  &lt;mappers&gt;
+     *    &lt;suffix&gt;-transformed&lt;/suffix&gt;
+     *  &lt;/mappers&gt;
+     * </pre>
+     * </code>
+     *
+     * @see org.codehaus.plexus.components.io.filemappers.FileMapper
+     */
+    @Parameter
+    final List<FileMapper> mappers = new ArrayList<>();
+
+    /**
+     * Additional options passed to transformers.
+     */
+    @Parameter
+    final Map<String, Object> options = new HashMap<>();
+
+    /**
+     * Retrieves authorization from Maven's {@code settings.xml}.
+     */
+    @Parameter(name = "serverId", property = "boat.transform.serverId")
+    String serverId;
+
+    @Parameter(defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+    @Component
+    private SettingsDecrypter decrypter;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (this.skip) {
+            getLog().info("Skipping Transform Mojo.");
+
+            return;
+        }
+
+        if (this.mappers.isEmpty()) {
+            this.mappers.add(new Suffix("-transformed"));
+        }
+
+        final List<AuthorizationValue> authz = buildAuthorization();
+
+        try {
+            this.inputs.forEach(input -> transform(input, authz));
+        } catch (final RuntimeException e) {
+            final Throwable cause = e.getCause();
+
+            if (cause instanceof MojoExecutionException) {
+                throw (MojoExecutionException) cause;
+            }
+            if (cause instanceof MojoFailureException) {
+                throw (MojoFailureException) cause;
+            }
+
+            throw new MojoFailureException("Transformation failed", e);
+        }
+    }
+
+    @SneakyThrows
+    private void transform(String input, List<AuthorizationValue> authz) {
+        OpenAPI openAPI = OpenAPILoader.load(input, false, false, authz);
+
+        for (final Transformer t : this.pipeline) {
+            openAPI = t.transform(openAPI, this.options);
+        }
+
+        String destName = FilenameUtils.getName(input);
+
+        for (final FileMapper fm : this.mappers) {
+            destName = fm.getMappedFileName(destName);
+        }
+
+        destName = FilenameUtils.separatorsToSystem(destName);
+
+        File destFile = new File(destName);
+
+        if (!destFile.isAbsolute()) {
+            destFile = new File(this.output, destName);
+        }
+
+        destFile.getParentFile().mkdirs();
+
+        Files.write(destFile.toPath(),
+            SerializerUtils
+                .toYamlString(openAPI)
+                .getBytes(StandardCharsets.UTF_8),
+            StandardOpenOption.CREATE);
+    }
+
+    private List<AuthorizationValue> buildAuthorization() throws MojoExecutionException {
+        return ofNullable(readAuthorization())
+            .map(authz -> new AuthorizationValue("Authorization", "header", authz))
+            .map(authz -> {
+                this.options.put("authz", authz);
+
+                return authz;
+            })
+            .map(Arrays::asList)
+            .orElse(null);
+    }
+
+    private String readAuthorization() throws MojoExecutionException {
+        if (isEmpty(this.serverId)) {
+            return null;
+        }
+
+        final Server server = this.session.getSettings().getServer(this.serverId);
+
+        if (server == null) {
+            throw new MojoExecutionException(format("Cannot find serverId \"%s\" in Maven settings", this.serverId));
+        }
+
+        final SettingsDecryptionRequest request = new DefaultSettingsDecryptionRequest(server);
+        final SettingsDecryptionResult result = this.decrypter.decrypt(request);
+
+        // Un-encrypted passwords are passed through, so a problem indicates a real issue.
+        // If there are any ERROR or FATAL problems reported, then decryption failed.
+        for (final SettingsProblem problem : result.getProblems()) {
+            switch (problem.getSeverity()) {
+                case ERROR:
+                case FATAL:
+                    throw new MojoExecutionException(
+                        format("Unable to decrypt serverId \"%s\":%s ", this.serverId, problem));
+
+                default:
+                    getLog().warn(format("Decrypting \"%s\": %s", this.serverId, problem));
+            }
+        }
+
+        final Server resultServer = result.getServer();
+        final String username = resultServer.getUsername();
+        final String password = resultServer.getPassword();
+        final String auth = username + ":" + password;
+
+        return "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+    }
+}
+

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/transformers/TransformMojoTest.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/transformers/TransformMojoTest.java
@@ -1,0 +1,144 @@
+package com.backbase.oss.boat.transformers;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecryptionResult;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.sonatype.plexus.build.incremental.DefaultBuildContext;
+
+import static java.util.Collections.emptyList;
+import static org.apache.commons.io.FileUtils.deleteDirectory;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings
+@SuppressWarnings("java:S5979")
+class TransformMojoTest {
+    private final DefaultBuildContext buildContext = new DefaultBuildContext();
+
+    @Mock
+    private MavenSession session;
+    @Mock
+    private SettingsDecrypter decrypter;
+
+    @InjectMocks
+    private TransformMojo mojo;
+
+    @BeforeEach
+    void beforeEach() throws IOException {
+        this.buildContext.enableLogging(new ConsoleLogger(2, "BOAT"));
+
+        this.mojo.inputs.add("src/test/resources/oas-examples/petstore.yaml");
+        this.mojo.output = new File("target", "transform-mojo");
+
+        deleteDirectory(this.mojo.output);
+    }
+
+    @Test
+    void serverId() throws MojoExecutionException, MojoFailureException {
+        this.mojo.serverId = "server-id";
+
+        final Server server = mock(Server.class);
+        final Settings settings = mock(Settings.class);
+        final SettingsDecryptionResult result = mock(SettingsDecryptionResult.class);
+
+        when(this.session.getSettings()).thenReturn(settings);
+        when(settings.getServer(this.mojo.serverId)).thenReturn(server);
+        when(this.decrypter.decrypt(any())).thenReturn(result);
+        when(result.getProblems()).thenReturn(emptyList());
+        when(result.getServer()).thenReturn(server);
+        when(server.getUsername()).thenReturn("username");
+        when(server.getPassword()).thenReturn("password");
+
+
+        this.mojo.execute();
+
+        assertThat(this.mojo.options, hasKey("authz"));
+        assertThat(output("petstore-transformed").exists(), is(true));
+    }
+
+    @Test
+    void empty() throws MojoExecutionException, MojoFailureException {
+        this.mojo.execute();
+
+        assertThat(output("petstore-transformed").exists(), is(true));
+    }
+
+    @Test
+    void transform() throws MojoExecutionException, MojoFailureException {
+        final Transformer tran = mock(Transformer.class);
+
+        when(tran.transform(any(), any())).then(ivc -> ivc.getArgument(0));
+
+        this.mojo.pipeline.add(tran);
+        this.mojo.execute();
+
+        verify(tran, times(1)).transform(any(), any());
+        assertThat(output("petstore-transformed").exists(), is(true));
+    }
+
+    @Test
+    void mappers() throws MojoExecutionException, MojoFailureException {
+        this.mojo.mappers.add(new Merge("open--api"));
+        this.mojo.mappers.add(new Prefix("prefix-"));
+        this.mojo.mappers.add(new Suffix("-suffix"));
+        this.mojo.mappers.add(new Regex("--", "-"));
+        this.mojo.mappers.add(new Suffix(".yaml"));
+        this.mojo.execute();
+
+        assertThat(output("prefix-open-api-suffix").exists(), is(true));
+    }
+
+    @Test
+    void merge() throws MojoExecutionException, MojoFailureException {
+        this.mojo.mappers.add(new Merge("open--api.yaml"));
+        this.mojo.execute();
+
+        assertThat(output("open--api").exists(), is(true));
+    }
+
+    @Test
+    void suffix() throws MojoExecutionException, MojoFailureException {
+        this.mojo.mappers.add(new Suffix("-suffix"));
+        this.mojo.execute();
+
+        assertThat(output("petstore-suffix").exists(), is(true));
+    }
+
+    @Test
+    void prefix() throws MojoExecutionException, MojoFailureException {
+        this.mojo.mappers.add(new Prefix("prefix-"));
+        this.mojo.execute();
+
+        assertThat(output("prefix-petstore").exists(), is(true));
+    }
+
+    @Test
+    void regex() throws MojoExecutionException, MojoFailureException {
+        this.mojo.mappers.add(new Regex("(.+)tst(.+)", "$1te-st$2"));
+        this.mojo.execute();
+
+        assertThat(output("pete-store").exists(), is(true));
+    }
+
+    private File output(String name) {
+        return new File(this.mojo.output, name + ".yaml");
+    }
+}

--- a/boat-scaffold/src/main/templates/boat-spring/model.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/model.mustache
@@ -42,6 +42,8 @@ import javax.xml.bind.annotation.*;
 import org.springframework.hateoas.RepresentationModel;
 {{/hateoas}}
 {{/parent}}
+{{#vendorExtensions.x-extra-java-imports}}
+{{{vendorExtensions.x-extra-java-imports}}}{{/vendorExtensions.x-extra-java-imports}}
 
 {{#models}}
 {{#model}}

--- a/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
@@ -4,7 +4,9 @@
 @ApiModel(description = "{{{description}}}"){{/description}}
 {{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}{{>additionalModelTypeAnnotations}}
 {{#useLombokAnnotations}}
-@lombok.EqualsAndHashCode(onlyExplicitlyIncluded = true{{#parent}}, callSuper = true{{/parent}}){{/useLombokAnnotations}}
+@lombok.EqualsAndHashCode(onlyExplicitlyIncluded = true, doNotUseGetters = true{{#parent}}, callSuper = true{{/parent}})
+@lombok.ToString(onlyExplicitlyIncluded = true, doNotUseGetters = true{{#parent}}, callSuper = true{{/parent}})
+{{/useLombokAnnotations}}
 {{#vendorExtensions.x-extra-annotation}}
 {{{vendorExtensions.x-extra-annotation}}}{{/vendorExtensions.x-extra-annotation}}
 public {{#vendorExtensions.x-abstract}}abstract {{/vendorExtensions.x-abstract}}class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}{{#hateoas}}extends RepresentationModel<{{classname}}> {{/hateoas}}{{/parent}}{{#serializableModel}}implements Serializable{{/serializableModel}}
@@ -37,6 +39,7 @@ public {{#vendorExtensions.x-abstract}}abstract {{/vendorExtensions.x-abstract}}
     @lombok.Getter(onMethod_ = @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"))
     @lombok.Setter
     @lombok.EqualsAndHashCode.Include
+    @lombok.ToString.Include
     {{#vendorExtensions.x-extra-annotation}}
     {{#indent4}}{{{vendorExtensions.x-extra-annotation}}}{{/indent4}}{{/vendorExtensions.x-extra-annotation}}
     {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}
@@ -148,6 +151,9 @@ public {{#vendorExtensions.x-abstract}}abstract {{/vendorExtensions.x-abstract}}
 
     {{/vars}}
 
+    {{#vendorExtensions.x-extra-java-code}}
+    {{#indent4}}{{{vendorExtensions.x-extra-java-code}}}{{/indent4}}{{/vendorExtensions.x-extra-java-code}}
+
     {{^useLombokAnnotations}}
     @Override
     public boolean equals(java.lang.Object o) {
@@ -172,7 +178,6 @@ public {{#vendorExtensions.x-abstract}}abstract {{/vendorExtensions.x-abstract}}
             {{/hasVars}}super.hashCode(){{/parent}}
         );
     }
-    {{/useLombokAnnotations}}
 
     @Override
     public String toString() {
@@ -194,4 +199,5 @@ public {{#vendorExtensions.x-abstract}}abstract {{/vendorExtensions.x-abstract}}
         }
         return o.toString().replace("\n", "\n        ");
     }
+    {{/useLombokAnnotations}}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.backbase.oss</groupId>
@@ -58,10 +59,8 @@
         <sonar.coverage.jacoco.xmlReportPaths>${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
 
         <lombok.version>1.18.16</lombok.version>
-        <junit.version>4.13.1</junit.version>
-
         <jackson.version>2.11.3</jackson.version>
-        <guava-version>30.0-jre</guava-version>
+        <mockito.version>3.8.0</mockito.version>
 
         <slf4j.version>1.7.30</slf4j.version>
         <swagger-core.version>2.1.5</swagger-core.version>
@@ -71,7 +70,7 @@
     </properties>
 
     <modules>
-        <!-- Project holding all RAML and OpenAPI specs for testing. Also includes reusable test harnesses-->
+        <!-- Project holding all RAML and OpenAPI specs for testing. Also includes reusable test harnesses -->
         <module>boat-trail-resources</module>
         <module>boat-engine</module>
         <module>boat-scaffold</module>
@@ -302,11 +301,13 @@
                 <artifactId>jackson-databind-nullable</artifactId>
                 <version>0.2.1</version>
             </dependency>
+
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
-                <version>5.7.0</version>
-                <scope>test</scope>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.7.1</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -315,13 +316,19 @@
                 <version>2.2</version>
                 <scope>test</scope>
             </dependency>
+
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>3.3.3</version>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
-
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
1. New boat:transform goal to pipeline existing transformers in an execution; works with multiple inputs
2. Use vendor extensions to inject arbitrary Java code in models generated by Spring generator