### PR TITLE
Adds missing export

### DIFF
--- a/boat-scaffold/src/main/templates/boat-marina/api.js.handlebars
+++ b/boat-scaffold/src/main/templates/boat-marina/api.js.handlebars
@@ -48,3 +48,4 @@ const data = {
 
 
 
+module.exports = { data };


### PR DESCRIPTION
Since the output is a JS module, we need to export the data to be able to use it.