### PR TITLE
Fix/examples url encoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ The project is very much Work In Progress and will be published on maven central
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.14.10
+* *Boat Scaffold*
+  * Makes sure to URLDecode paths while dereferencing examples
+## 0.14.9
+* *Boat Scaffold*
+  * Resolve references to other path operations' examples
 
-## 0.14.8
+* ## 0.14.8
 * *Boat Marina*
   * Removes flatObjects as they are no longer needed
   * response.message was wrongfully escaped, escaping in the docs template instead

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ BOAT is still under development and subject to change.
 * *Boat Scaffold*
   * Resolve references to other path operations' examples
 
-* ## 0.14.8
+## 0.14.8
 * *Boat Marina*
   * Removes flatObjects as they are no longer needed
   * response.message was wrongfully escaped, escaping in the docs template instead

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -132,7 +133,7 @@ public class BoatExampleUtils {
         }
 
         String[] refParts = Arrays.stream(ref.replace(PATHS_REF_PREFIX, "").split("/"))
-                .map(s -> URLDecoder.decode(s.replace("~1", "/").replace("~0", "~"), java.nio.charset.Charset.forName(("UTF-8"))))
+                .map(s -> URLDecoder.decode(s.replace("~1", "/").replace("~0", "~"), StandardCharsets.UTF_8))
                 .toArray(String[]::new);
 
         String pathName = refParts[1];

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
@@ -14,6 +14,7 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -129,8 +130,9 @@ public class BoatExampleUtils {
             log.warn("Example ref: {}  refers to '/paths' but it is not there.", ref);
             return;
         }
+
         String[] refParts = Arrays.stream(ref.replace(PATHS_REF_PREFIX, "").split("/"))
-                .map(s -> s.replace("~1", "/"))
+                .map(s -> URLDecoder.decode(s.replace("~1", "/").replace("~0", "~"), java.nio.charset.Charset.forName(("UTF-8"))))
                 .toArray(String[]::new);
 
         String pathName = refParts[1];

--- a/boat-scaffold/src/test/resources/oas-examples/petstore-example-refs.yaml
+++ b/boat-scaffold/src/test/resources/oas-examples/petstore-example-refs.yaml
@@ -68,6 +68,14 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 $ref: "#/components/examples/InternalServerError"
+        '400':
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                $ref: "#/paths/~1pets~1%7BpetId%7D/get/responses/default/content/application~1json/example"
         default:
           description: unexpected error
           content:


### PR DESCRIPTION
Paths with strings like `/foo/{bar}` are URL encoded, `/` and `~` are escaped (see: https://swagger.io/docs/specification/using-ref/)

When dereferencing examples, we need to do the opposite on the `$ref` string otherwise it doesn't match the object key and hence the example is not found.