### PR TITLE
Fix reference to /examples/foo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The project is very much Work In Progress and will be published on maven central
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.14.11
+* *Boat Scaffold*
+  * References to /examples/foo now are also dereferenced
 ## 0.14.10
 * *Boat Scaffold*
   * Makes sure to URLDecode paths while dereferencing examples

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
@@ -42,7 +42,7 @@ public class BoatExampleUtils {
 
         if (mediaType.getExamples() != null) {
             mediaType.getExamples().forEach((key, example) -> {
-                log.debug("Adding example: {} to examples with content type: {} and responseCode: {} ", key, contentType, responseCode);
+                log.info("Adding example: {} to examples with content type: {} and responseCode: {} ", key, contentType, responseCode);
                 BoatExample boatExample = new BoatExample(key, contentType, example, isJson(contentType));
                 examples.add(boatExample);
             });
@@ -172,6 +172,28 @@ public class BoatExampleUtils {
         MediaType mediaType = content.get(mediaTypeName);
         if (mediaType == null) {
             log.warn("Example ref: {} refers to mediaType {} that is not defined.", ref, mediaTypeName);
+            return;
+        }
+
+        /* This could be a ref to /example or to /examples/foo in the case of responses.
+        *  responses:
+        200:
+          description: OK
+          examples:
+            application/json: { "id": 38, "title": "T-shirt" }
+            text/csv: >
+              id,title
+              38,T-shirt
+        *
+        *
+        * */
+        if (refParts[7].equals("examples")) {
+            Example example = mediaType.getExamples().get(refParts[8]);
+            if(example == null) {
+                log.error("Incorrect example reference found! ref: {} , {} does not exist", ref, refParts[8]);
+                return;
+            }
+            boatExample.setExample(example);
             return;
         }
 

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 @Slf4j
 @UtilityClass
-@SuppressWarnings("java:S3740")
+@SuppressWarnings({"java:S3740", "java:S125"})
 public class BoatExampleUtils {
 
     private static final String PATHS_REF_PREFIX = "#/paths";

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatExampleUtils.java
@@ -189,10 +189,6 @@ public class BoatExampleUtils {
         * */
         if (refParts[7].equals("examples")) {
             Example example = mediaType.getExamples().get(refParts[8]);
-            if(example == null) {
-                log.error("Incorrect example reference found! ref: {} , {} does not exist", ref, refParts[8]);
-                return;
-            }
             boatExample.setExample(example);
             return;
         }

--- a/boat-scaffold/src/test/resources/oas-examples/petstore-example-refs.yaml
+++ b/boat-scaffold/src/test/resources/oas-examples/petstore-example-refs.yaml
@@ -123,7 +123,7 @@ paths:
             application/xml:
               examples:
                 Inexistent:
-                  $ref: "#/paths/~1pets/post/responses/202/content/application~1json/examples/foo"
+                  $ref: "#/paths/~1pets/post/responses/202/content/application~1json/examples/theinexistentexample"
                 AnotheOne:
                   $ref: "#/paths/~1pets/post/responses/202/content/application~1json/examples/example"
         '500':

--- a/boat-scaffold/src/test/resources/oas-examples/petstore-example-refs.yaml
+++ b/boat-scaffold/src/test/resources/oas-examples/petstore-example-refs.yaml
@@ -120,6 +120,12 @@ paths:
             application/json:
               example:
                 $ref: "#/paths/~1pets/post/responses/202/content/application~1json/examples/example"
+            application/xml:
+              examples:
+                Inexistent:
+                  $ref: "#/paths/~1pets/post/responses/202/content/application~1json/examples/foo"
+                AnotheOne:
+                  $ref: "#/paths/~1pets/post/responses/202/content/application~1json/examples/example"
         '500':
           description: InternalServerError
           content:

--- a/boat-scaffold/src/test/resources/oas-examples/petstore-example-refs.yaml
+++ b/boat-scaffold/src/test/resources/oas-examples/petstore-example-refs.yaml
@@ -76,6 +76,14 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 $ref: "#/paths/~1pets~1%7BpetId%7D/get/responses/default/content/application~1json/example"
+        '202':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              examples:
+                example:
+                  summary: This is an example referenced in a horrible path
+                  value: foo
         default:
           description: unexpected error
           content:
@@ -106,6 +114,12 @@ paths:
                 $ref: "#/components/schemas/Pet"
               example:
                 $ref: "#/paths/~1pets/get/responses/default/content/application~1json/example"
+        '400':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              example:
+                $ref: "#/paths/~1pets/post/responses/202/content/application~1json/examples/example"
         '500':
           description: InternalServerError
           content:


### PR DESCRIPTION
Responses can have multiple examples, the previous fix assumed it only had one.