### PR TITLE
Version update

### DIFF
--- a/boat-maven-plugin/README.md
+++ b/boat-maven-plugin/README.md
@@ -278,6 +278,9 @@ Available parameters:
       User property: failOnLintViolation
       Fail the build if the spec has lint violation (Violation with Severity.MUST)
 
+    failOnBoatBayErrorResponse (Default: true)
+      User property: failOnBoatBayErrorResponse
+      Fail the build if boatbay server returns an error
 
     groupId (Default: ${project.groupId})
       User property: groupId

--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -339,7 +339,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>5.0.0</version>
+                <version>5.2.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -339,7 +339,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>5.2.1</version>
+                <version>${openapi-generator.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This will negate the https://github.com/Backbase/backbase-openapi-tools/pull/236/files from dependency bot. for some reason the generated sources has errors in 5.1.0.

Updated to use the parent version. 