### PR TITLE
Improve the error message.

### DIFF
--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
@@ -144,8 +144,13 @@ public class BundleMojo extends AbstractMojo {
         if (openApiVersion == null) {
             throw new MojoExecutionException("Configured to use version in filename, but no version set.");
         }
-        String majorFromFileName = originalFileName.replaceAll("^(.*api-v)([0-9]+)(\\.yaml$)", "$2");
+        if (!openApiVersion.matches("^\\d\\..*")) {
+            throw new MojoExecutionException(
+                "Version should be semver (or at least have a recognisable major version), but found '" + openApiVersion
+                    + "' (string starts with number and dot: 2.0.0, 2.blabla, 2.3.4.5.6.234234)");
+        }
         String majorFromVersion = openApiVersion.substring(0, openApiVersion.indexOf("."));
+        String majorFromFileName = originalFileName.replaceAll("^(.*api-v)([0-9]+)(\\.yaml$)", "$2");
         if (!majorFromFileName.equals(majorFromVersion)) {
             throw new MojoExecutionException("Invalid version " + openApiVersion + " in file " + originalFileName);
         }

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/BundleMojoTest.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/BundleMojoTest.java
@@ -12,6 +12,7 @@ import lombok.SneakyThrows;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -110,10 +111,23 @@ class BundleMojoTest {
 
         OpenAPI openAPI = new OpenAPI();
         openAPI.setInfo(new Info());
-        assertThrows(MojoExecutionException.class, () ->
-            mojo.versionFileName("payment-order-client-api-v2.yaml", createOpenApiWithVersion("3.0.0")));
+        assertThrowsMojoExecutionExceptionWithMessage(
+            () -> mojo.versionFileName("payment-order-client-api-v2.yaml", createOpenApiWithVersion("3.0.0")),
+            "Invalid version 3.0.0 in file payment-order-client-api-v2.yaml");
+        assertThrowsMojoExecutionExceptionWithMessage(
+            () -> mojo.versionFileName("payment-order-client-api-v2.yaml", createOpenApiWithVersion("v2.0")),
+            "Version should be semver (or at least have a recognisable major version), but found 'v2.0'");
+        assertThrowsMojoExecutionExceptionWithMessage(
+            ()  -> mojo.versionFileName("payment-order-client-api-v2.yaml", createOpenApiWithVersion("2dada")),
+            "Version should be semver (or at least have a recognisable major version), but found '2dada'");
+
     }
 
+    private void assertThrowsMojoExecutionExceptionWithMessage(Executable executable, String message) {
+        MojoExecutionException thrown = assertThrows(MojoExecutionException.class, executable);
+        assertTrue(thrown.getMessage().startsWith(message), "Expected message '" + message + "' but got '"
+            + thrown.getMessage() + "'");
+    }
 
     private OpenAPI createOpenApiWithVersion(String version) {
         OpenAPI openAPI = new OpenAPI();


### PR DESCRIPTION
Fix for https://github.com/Backbase/backbase-openapi-tools/issues/242

Improve the error message when the api version in the file cannot be parsed.