### PR TITLE
date fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The project is very much Work In Progress and will be published on maven central
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.15.2
+* *Maven Plugin*
+  * Changed boat-bay dateLibrary for upload spec .
 ## 0.15.1
 * *Maven Plugin*
   * Made `boat:radio` goal properties w.r.t boat-bay server unique.

--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -357,7 +357,7 @@
                                 <modelPackage>com.backbase.oss.boat.bay.client.model</modelPackage>
                                 <apiPackage>com.backbase.oss.boat.bay.client.api</apiPackage>
                                 <library>feign</library>
-                                <dateLibrary>java8-localdatetime</dateLibrary>
+                                <dateLibrary>java8</dateLibrary>
                                 <additionalModelTypeAnnotations>@lombok.AllArgsConstructor @lombok.Builder @lombok.NoArgsConstructor</additionalModelTypeAnnotations>
                             </configOptions>
                         </configuration>


### PR DESCRIPTION
The specs says [date-time](https://github.com/Backbase/backbase-openapi-tools/blob/main/boat-maven-plugin/src/main/resources/schemas/definitions.yaml#L21). The actual output is [ZoneDateTime](https://github.com/Backbase/boat-bay/blob/main/boat-bay-server/src/main/java/com/backbase/oss/boat/bay/domain/Spec.java#L56).

The upload is successful tough, but in some cases it might throw an error:
```
Cannot deserialize value of type `java.time.LocalDateTime` from String "2021-11-28T21:03:09.757471+01:00": Failed to deserialize java.time.LocalDateTime
```