### PR TITLE
Fixed query param mapping for Maps.

### DIFF
--- a/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/ApiClient.mustache
+++ b/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/ApiClient.mustache
@@ -492,6 +492,15 @@ public class ApiClient {
             collectionFormat = CollectionFormat.CSV;
         }
 
+        if (value instanceof Map) {
+            Map map = (Map) value;
+
+            for (Object key : map.keySet()) {
+                params.add(parameterToString(key), parameterToString(map.get(key)));
+            }
+            return params;
+        }
+
         Collection<?> valueCollection = null;
         if (value instanceof Collection) {
             valueCollection = (Collection<?>) value;

--- a/boat-scaffold/src/main/templates/boat-java/libraries/webclient/ApiClient.mustache
+++ b/boat-scaffold/src/main/templates/boat-java/libraries/webclient/ApiClient.mustache
@@ -382,6 +382,15 @@ public class ApiClient {
             collectionFormat = CollectionFormat.CSV;
         }
 
+        if (value instanceof Map) {
+            Map map = (Map) value;
+
+            for (Object key : map.keySet()) {
+                params.add(parameterToString(key), parameterToString(map.get(key)));
+            }
+            return params;
+        }
+
         Collection<?> valueCollection = null;
         if (value instanceof Collection) {
             valueCollection = (Collection<?>) value;


### PR DESCRIPTION
A fix for mapping of Map for query params (in client code). You can have Map in query params when using additionalProperties. In current version generated client code throws an exception. This is a fix for it.