### PR TITLE
boat-angular update ngVersion to use >= range in dependencies

### DIFF
--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -217,7 +217,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>4.9.1</version>
+            <version>4.10.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/boat-maven-plugin/src/it/example/boat-generate/angular/pom.xml
+++ b/boat-maven-plugin/src/it/example/boat-generate/angular/pom.xml
@@ -64,7 +64,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v12.19.0</nodeVersion>
+                            <nodeVersion>v14.18.2</nodeVersion>
                         </configuration>
                     </execution>
                     <execution>
@@ -93,4 +93,3 @@
 
 
 </project>
-

--- a/boat-maven-plugin/src/it/example/boat-generate/angular/pom.xml
+++ b/boat-maven-plugin/src/it/example/boat-generate/angular/pom.xml
@@ -64,7 +64,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v14.18.2</nodeVersion>
+                            <nodeVersion>v16.15.1</nodeVersion>
                         </configuration>
                     </execution>
                     <execution>

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/GeneratorTests.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/GeneratorTests.java
@@ -306,6 +306,7 @@ class GeneratorTests {
         mojo.additionalProperties.add("withMocks=true");
         mojo.additionalProperties.add("npmName=@petstore/http");
         mojo.additionalProperties.add("npmRepository=https://repo.example.com");
+        mojo.additionalProperties.add("tsVersion=4.6");
 
         assertDoesNotThrow(mojo::execute, "Angular client generation should not throw exceptions");
     }

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/GeneratorTests.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/GeneratorTests.java
@@ -306,7 +306,6 @@ class GeneratorTests {
         mojo.additionalProperties.add("withMocks=true");
         mojo.additionalProperties.add("npmName=@petstore/http");
         mojo.additionalProperties.add("npmRepository=https://repo.example.com");
-        mojo.additionalProperties.add("tsVersion=4.6");
 
         assertDoesNotThrow(mojo::execute, "Angular client generation should not throw exceptions");
     }

--- a/boat-quay/boat-quay-rules/pom.xml
+++ b/boat-quay/boat-quay-rules/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
-        <kotlin.version>1.4.10</kotlin.version>
+        <kotlin.version>1.7.0</kotlin.version>
         <kotlin.compiler.incremental>false</kotlin.compiler.incremental>
         <auto-service.version>1.0-rc7</auto-service.version>
         <dokka.version>1.4.10.2</dokka.version>

--- a/boat-scaffold/pom.xml
+++ b/boat-scaffold/pom.xml
@@ -39,6 +39,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.jknack</groupId>
+            <artifactId>handlebars</artifactId>
+            <version>4.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.jknack</groupId>
+            <artifactId>handlebars-jackson2</artifactId>
+            <version>4.3.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.backbase.oss</groupId>
             <artifactId>boat-engine</artifactId>
             <version>${project.version}</version>

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -228,7 +228,7 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
                 additionalProperties.put("tsVersion", "~4.1.0");
                 additionalProperties.put("ngPackagrVersion", "11.0.0");
             } else {
-                additionalProperties.put("tsVersion", ">=3.9.2 <4.0.0");
+                additionalProperties.put("tsVersion", ">=4.2 <4.7.0");
                 additionalProperties.put("ngPackagrVersion", "10.0.3");
             }
         }

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -225,10 +225,10 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
             additionalProperties.put("rxjsVersion", "6.6.0");
 
             if (angularVersion.atLeast("11.0.0")) {
-                additionalProperties.put("tsVersion", "~4.1.0");
+                additionalProperties.put("tsVersion", ">=4.2.0");
                 additionalProperties.put("ngPackagrVersion", "11.0.0");
             } else {
-                additionalProperties.put("tsVersion", ">=4.2 <4.7.0");
+                additionalProperties.put("tsVersion", ">=3.9.2");
                 additionalProperties.put("ngPackagrVersion", "10.0.3");
             }
         }

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/marina/BoatHandlebarsEngineAdapter.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/marina/BoatHandlebarsEngineAdapter.java
@@ -39,8 +39,7 @@ public class BoatHandlebarsEngineAdapter extends HandlebarsEngineAdapter {
                 .newBuilder(bundle)
                 .resolver(
                         MapValueResolver.INSTANCE,
-                        JavaBeanValueResolver.INSTANCE,
-                        FieldValueResolver.INSTANCE)
+                        JavaBeanValueResolver.INSTANCE)
                 .build();
 
         Handlebars handlebars = new Handlebars(loader);

--- a/boat-scaffold/src/main/templates/boat-angular/package.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/package.mustache
@@ -15,18 +15,18 @@
     "build": "ng-packagr -p ng-package.json"
   },
   "peerDependencies": {
-    "@angular/core": "^{{ngVersion}}",
+    "@angular/core": ">={{ngVersion}}",
     {{#withMocks}}
     "@backbase/foundation-ang": "^{{foundationVersion}}",
     {{/withMocks}}
     "rxjs": "^{{rxjsVersion}}"
   },
   "devDependencies": {
-    "@angular/common": "~{{ngVersion}}",
-    "@angular/compiler": "~{{ngVersion}}",
-    "@angular/compiler-cli": "~{{ngVersion}}",
-    "@angular/core": "~{{ngVersion}}",
-    "@angular/platform-browser": "~{{ngVersion}}",
+    "@angular/common": ">={{ngVersion}}",
+    "@angular/compiler": ">={{ngVersion}}",
+    "@angular/compiler-cli": ">={{ngVersion}}",
+    "@angular/core": ">={{ngVersion}}",
+    "@angular/platform-browser": ">={{ngVersion}}",
     "ng-packagr": "^{{ngPackagrVersion}}",
     "reflect-metadata": "^0.1.3",
     {{#withMocks}}

--- a/boat-scaffold/src/main/templates/boat-angular/package.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/package.mustache
@@ -34,7 +34,7 @@
     {{/withMocks}}
     "rxjs": ">={{rxjsVersion}}",
     "typescript": "{{{tsVersion}}}",
-    "zone.js": "^{{zonejsVersion}}"
+    "zone.js": ">={{zonejsVersion}}"
   }{{#npmRepository}},
   "publishConfig": {
     "registry": "{{{npmRepository}}}"

--- a/boat-scaffold/src/main/templates/boat-angular/package.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/package.mustache
@@ -17,9 +17,9 @@
   "peerDependencies": {
     "@angular/core": ">={{ngVersion}}",
     {{#withMocks}}
-    "@backbase/foundation-ang": "^{{foundationVersion}}",
+    "@backbase/foundation-ang": ">={{foundationVersion}}",
     {{/withMocks}}
-    "rxjs": "^{{rxjsVersion}}"
+    "rxjs": ">={{rxjsVersion}}"
   },
   "devDependencies": {
     "@angular/common": ">={{ngVersion}}",
@@ -30,9 +30,9 @@
     "ng-packagr": "^{{ngPackagrVersion}}",
     "reflect-metadata": "^0.1.3",
     {{#withMocks}}
-    "@backbase/foundation-ang": "~{{foundationVersion}}",
+    "@backbase/foundation-ang": ">={{foundationVersion}}",
     {{/withMocks}}
-    "rxjs": "~{{rxjsVersion}}",
+    "rxjs": ">={{rxjsVersion}}",
     "typescript": "{{{tsVersion}}}",
     "zone.js": "^{{zonejsVersion}}"
   }{{#npmRepository}},

--- a/boat-scaffold/src/main/templates/boat-angular/package.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/package.mustache
@@ -27,7 +27,7 @@
     "@angular/compiler-cli": ">={{ngVersion}}",
     "@angular/core": ">={{ngVersion}}",
     "@angular/platform-browser": ">={{ngVersion}}",
-    "ng-packagr": "^{{ngPackagrVersion}}",
+    "ng-packagr": ">={{ngPackagrVersion}}",
     "reflect-metadata": "^0.1.3",
     {{#withMocks}}
     "@backbase/foundation-ang": ">={{foundationVersion}}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,15 +56,15 @@
         <aggregate.report.dir>tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
         <sonar.coverage.jacoco.xmlReportPaths>${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
 
-        <lombok.version>1.18.16</lombok.version>
-        <jackson.version>2.11.3</jackson.version>
-        <mockito.version>3.8.0</mockito.version>
+        <lombok.version>1.18.24</lombok.version>
+        <jackson.version>2.13.3</jackson.version>
+        <mockito.version>4.6.1</mockito.version>
 
         <slf4j.version>1.7.30</slf4j.version>
         <swagger-core.version>2.1.5</swagger-core.version>
         <swagger-parser.version>2.0.23</swagger-parser.version>
         <snakeyaml.version>1.26</snakeyaml.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     </properties>
 
     <modules>
@@ -98,7 +98,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.2.3</version>
+                <version>1.2.9</version>
             </dependency>
 
 


### PR DESCRIPTION
Change:

Specify boat-angular ngVersion via range `>={{ngVersion}}` to support Angular version greater than range.