### PR TITLE
java17 uplift and fixes

### DIFF
--- a/boat-maven-plugin/src/it/example/pom.xml
+++ b/boat-maven-plugin/src/it/example/pom.xml
@@ -12,9 +12,9 @@
 
         <boat-maven-plugin.version>@pom.version@</boat-maven-plugin.version>
 <!--        <boat-maven-plugin.version>0.12.0-SNAPSHOT</boat-maven-plugin.version>-->
-        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.3</jackson-databind-nullable-version>
 
-        <jackson.version>2.11.3</jackson.version>
+        <jackson.version>2.13.3</jackson.version>
         <jackson.version.annotations>${jackson.version}</jackson.version.annotations>
         <jackson.version.core>${jackson.version}</jackson.version.core>
         <jackson.version.databind>${jackson.version}</jackson.version.databind>
@@ -29,7 +29,7 @@
         <!-- JPMS Library Updates-->
         <javax.activation.version>1.2.0</javax.activation.version>
 
-        <swagger-annotations-version>1.5.22</swagger-annotations-version>
+        <swagger-annotations-version>1.6.6</swagger-annotations-version>
 
     </properties>
 
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.16</version>
+                <version>1.18.24</version>
             </dependency>
 
             <dependency>
@@ -105,13 +105,13 @@
             <dependency>
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
-                <version>1.1.0.Final</version>
+                <version>2.0.1.Final</version>
             </dependency>
 
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>6.1.7.Final</version>
+                <version>6.2.3.Final</version>
             </dependency>
 
             <dependency>
@@ -123,7 +123,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-webflux</artifactId>
-                <version>2.5.12</version>
+                <version>2.7.2</version>
             </dependency>
 
             <dependency>
@@ -135,13 +135,13 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-web</artifactId>
-                <version>2.5.12</version>
+                <version>2.7.2</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
-                <version>5.2.22.RELEASE</version>
+                <version>5.3.22</version>
                 <scope>compile</scope>
             </dependency>
 

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/radio/RadioMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/radio/RadioMojo.java
@@ -7,6 +7,7 @@ import com.backbase.oss.boat.bay.client.model.*;
 import com.backbase.oss.boat.loader.OpenAPILoader;
 import com.backbase.oss.boat.loader.OpenAPILoaderException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import feign.auth.BasicAuthRequestInterceptor;
 import java.io.File;
 import java.io.IOException;
@@ -141,7 +142,9 @@ public class RadioMojo extends AbstractMojo {
 
         BasicAuthRequestInterceptor basicAuthRequestInterceptor = null;
 
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .build();
 
         if (StringUtils.isNotEmpty(boatBayUsername) && StringUtils.isNotEmpty(boatBayPassword)) {
             getLog().info("Basic Authentication set for username " + boatBayUsername);

--- a/boat-scaffold/src/main/templates/boat-spring/libraries/spring-boot/pom.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/libraries/spring-boot/pom.mustache
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>{{#java8}}2.3.3.RELEASE{{/java8}}{{^java8}}1.5.12.RELEASE{{/java8}}</version>
+        <version>{{#java8}}2.7.2{{/java8}}{{^java8}}1.5.12.RELEASE{{/java8}}</version>
     </parent>
 {{/parentOverridden}}
     <build>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.2.11</version>
+            <version>2.3.1</version>
         </dependency>
         {{/useSpringfox}}
         {{^useSpringfox}}
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>1.5.14</version>
+            <version>1.6.6</version>
         </dependency>
         <!-- @Nullable annotation -->
         <dependency>
@@ -156,14 +156,14 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.2.1</version>
+            <version>0.2.3</version>
         </dependency>
 {{/openApiNullable}}
 {{#useLombokAnnotations}}
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
 {{/useLombokAnnotations}}
@@ -186,12 +186,12 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.3.2</version>
+            <version>2.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>{{#java8}}2.3.3.RELEASE{{/java8}}{{^java8}}1.5.12.RELEASE{{/java8}}</version>
+            <version>{{#java8}}2.7.2{{/java8}}{{^java8}}1.5.12.RELEASE{{/java8}}</version>
         </dependency>
     <!-- END Virtual Service API support -->
 {{/virtualService}}


### PR DESCRIPTION
- fixed ObjectMapper in `radio` goal
- latest dependencies

Full error from Jenkins:
```
[INFO] [jenkins-event-spy] Generated /opt/fsroot/workspace/Cardiff/BBT/building-blocks-test-wallet/boat-plugin-version@tmp/withMaven5e09333c/maven-spy-20220801-134826-5065350269485296098564.log
[ERROR] Failed to execute goal com.backbase.oss:boat-maven-plugin:0.16.0:radio (upload-to-boat-bay) on project building-blocks-test-wallet-presentation-service: Failed to write output: Java 8 date/time type `java.time.OffsetDateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: java.util.ArrayList[0]->com.backbase.oss.boat.bay.client.model.BoatLintReport["spec"]->com.backbase.oss.boat.bay.client.model.BoatSpec["createdOn"]) -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.backbase.oss:boat-maven-plugin:0.16.0:radio (upload-to-boat-bay) on project building-blocks-test-wallet-presentation-service: Failed to write output
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.MojoFailureException: Failed to write output
    at com.backbase.oss.boat.radio.RadioMojo.execute (RadioMojo.java:207)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.OffsetDateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: java.util.ArrayList[0]->com.backbase.oss.boat.bay.client.model.BoatLintReport["spec"]->com.backbase.oss.boat.bay.client.model.BoatSpec["createdOn"])
    at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from (InvalidDefinitionException.java:77)
    at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition (SerializerProvider.java:1300)
    at com.fasterxml.jackson.databind.ser.impl.UnsupportedTypeSerializer.serialize (UnsupportedTypeSerializer.java:35)
    at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField (BeanPropertyWriter.java:728)
    at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields (BeanSerializerBase.java:774)
    at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize (BeanSerializer.java:178)
    at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField (BeanPropertyWriter.java:728)
    at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields (BeanSerializerBase.java:774)
    at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize (BeanSerializer.java:178)
    at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serializeContents (IndexedListSerializer.java:119)
    at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize (IndexedListSerializer.java:79)
    at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize (IndexedListSerializer.java:18)
    at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize (DefaultSerializerProvider.java:480)
    at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue (DefaultSerializerProvider.java:319)
    at com.fasterxml.jackson.databind.ObjectWriter$Prefetch.serialize (ObjectWriter.java:1518)
    at com.fasterxml.jackson.databind.ObjectWriter._writeValueAndClose (ObjectWriter.java:1219)
    at com.fasterxml.jackson.databind.ObjectWriter.writeValue (ObjectWriter.java:1027)
    at com.backbase.oss.boat.radio.RadioMojo.execute (RadioMojo.java:182)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)

```