### PR TITLE
BoatAngularGenerator: add dependency versions for ang@13

### DIFF
--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -222,14 +222,19 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
             supportingFiles.add(new SupportingFile("ng-package.mustache", getIndexDirectory(), "ng-package.json"));
             supportingFiles.add(new SupportingFile("tsconfig.mustache", getIndexDirectory(), "tsconfig.json"));
             additionalProperties.put("zonejsVersion", "0.10.2");
-            additionalProperties.put("rxjsVersion", "6.6.0");
 
-            if (angularVersion.atLeast("11.0.0")) {
+            if (angularVersion.atLeast("13.0.0")) {
+                additionalProperties.put("tsVersion", ">=4.4.2");
+                additionalProperties.put("ngPackagrVersion", "13.3.1");
+                additionalProperties.put("rxjsVersion", "7.0.1");
+            } else if (angularVersion.atLeast("11.0.0")) {
                 additionalProperties.put("tsVersion", ">=4.2.0");
                 additionalProperties.put("ngPackagrVersion", "11.0.0");
+                additionalProperties.put("rxjsVersion", "6.6.0");
             } else {
                 additionalProperties.put("tsVersion", ">=3.9.2");
                 additionalProperties.put("ngPackagrVersion", "10.0.3");
+                additionalProperties.put("rxjsVersion", "6.6.0");
             }
         }
     }

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -221,20 +221,24 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
             supportingFiles.add(new SupportingFile("package.mustache", getIndexDirectory(), "package.json"));
             supportingFiles.add(new SupportingFile("ng-package.mustache", getIndexDirectory(), "ng-package.json"));
             supportingFiles.add(new SupportingFile("tsconfig.mustache", getIndexDirectory(), "tsconfig.json"));
-            additionalProperties.put("zonejsVersion", "0.10.2");
+            additionalProperties.put("zonejsVersion", "0.11.4");
+
+            final String tsVersion = "tsVersion";
+            final String ngPackagrVersion = "ngPackagrVersion";
+            final String rxjsVersion = "rxjsVersion";
 
             if (angularVersion.atLeast("13.0.0")) {
-                additionalProperties.put("tsVersion", ">=4.4.2");
-                additionalProperties.put("ngPackagrVersion", "13.0.1");
-                additionalProperties.put("rxjsVersion", "7.0.1");
+                additionalProperties.put(tsVersion, ">=4.4.2");
+                additionalProperties.put(ngPackagrVersion, "13.0.1");
+                additionalProperties.put(rxjsVersion, "7.5.0");
             } else if (angularVersion.atLeast("11.0.0")) {
-                additionalProperties.put("tsVersion", ">=4.2.0");
-                additionalProperties.put("ngPackagrVersion", "11.0.0");
-                additionalProperties.put("rxjsVersion", "6.6.0");
+                additionalProperties.put(tsVersion, ">=4.2.0");
+                additionalProperties.put(ngPackagrVersion, "11.0.0");
+                additionalProperties.put(rxjsVersion, "6.6.0");
             } else {
-                additionalProperties.put("tsVersion", ">=3.9.2");
-                additionalProperties.put("ngPackagrVersion", "10.0.3");
-                additionalProperties.put("rxjsVersion", "6.6.0");
+                additionalProperties.put(tsVersion, ">=3.9.2");
+                additionalProperties.put(ngPackagrVersion, "10.0.3");
+                additionalProperties.put(rxjsVersion, "6.6.0");
             }
         }
     }

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -229,7 +229,7 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
 
             if (angularVersion.atLeast("13.0.0")) {
                 additionalProperties.put(tsVersion, ">=4.4.2");
-                additionalProperties.put(ngPackagrVersion, "13.0.1");
+                additionalProperties.put(ngPackagrVersion, "13.3.1");
                 additionalProperties.put(rxjsVersion, "7.5.0");
             } else if (angularVersion.atLeast("11.0.0")) {
                 additionalProperties.put(tsVersion, ">=4.2.0");

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -225,7 +225,7 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
 
             if (angularVersion.atLeast("13.0.0")) {
                 additionalProperties.put("tsVersion", ">=4.4.2");
-                additionalProperties.put("ngPackagrVersion", "13.3.1");
+                additionalProperties.put("ngPackagrVersion", "13.0.1");
                 additionalProperties.put("rxjsVersion", "7.0.1");
             } else if (angularVersion.atLeast("11.0.0")) {
                 additionalProperties.put("tsVersion", ">=4.2.0");

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/angular/BoatAngularTemplatesTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/angular/BoatAngularTemplatesTests.java
@@ -1,20 +1,19 @@
 package com.backbase.oss.codegen.angular;
 
-import java.util.Optional;
+import java.util.*;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DynamicNode;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
+import org.assertj.core.api.Assert;
+import org.junit.jupiter.api.*;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.languages.AbstractTypeScriptClientCodegen;
-
+import org.openapitools.codegen.utils.SemVer;
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.ElementType;
@@ -24,9 +23,6 @@ import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
@@ -285,7 +281,7 @@ class BoatAngularTemplatesTests {
 
         Combination(int mask) {
             this.name = caseName(mask);
-            this.ngVersion = mask == 0 ? "10.0.0" : mask == 1 ? "11.0.0" : null;
+            this.ngVersion = mask == 0 ? "10.0.0" : mask == 1 ? "11.0.0" : mask == 2 ? "12.0.0" : mask == -1 ? "13.0.0" :  null;
             this.foundationVersion = mask == 0 ? "6.0.0" : mask == 1 ? "7.0.0" : null;
             this.buildDist = mask > 0 ? caseName(mask) : null;
             this.npmName = (mask & 1) != 0;


### PR DESCRIPTION
### Description

BoatAngularGenerator: add dependency versions to support `angular@13`. The compatible peer dependency versions were found in the following resources:

- **RxJS version**: https://gist.github.com/LayZeeDK/c822cc812f75bb07b7c55d07ba2719b3
- **TypeScript version**: https://github.com/angular/angular/releases?expanded=true&page=5&q=13#:~:text=TypeScript%20versions%20older%20than%204.4.2%20are%20no%20longer%20supported. 
- **NG-PACKAGR version**: https://github.com/ng-packagr/ng-packagr/blob/1a503338c623ad1dfefc379067b8637daa19f901/package.json#L3-L71


Fixes # nojira

#### Type of change

- [X] Versions (update of Angular dependency versions)

