### PR TITLE
Do not split on spaces for properties which take a comma-separated list of values

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The project is very much Work In Progress and will be published on maven central
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.16.3
+* *Maven Plugin*
+  * Do not treat spaces as delimiters in configuration properties which take a comma-separated list of values.
+    Fixes an issue that prevented the use of tag names containing spaces in the `apisToGenerate` property.
 ## 0.16.2
 * Boat Angular generator
   * Specify minimum Angular-related package versions when Angular v13 is used

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
@@ -81,7 +81,7 @@ public class GenerateMojo extends InputMavenArtifactMojo {
 
     private static String trimCSV(String text) {
         if (isNotEmpty(text)) {
-            return stream(text.split("[,;\\s]+"))
+            return stream(text.split("[,;]+"))
                 .map(StringUtils::trimToNull)
                 .filter(Objects::nonNull)
                 .collect(joining(","));


### PR DESCRIPTION
Splitting on spaces causes issues where a value contains a legitimate space.

For example, an operation could have a tag with a space in it.  Passing that tag to the `apisToGenerate` config property causes it to be interpreted as two separate tags and therefore it is omitted from the generated APIs.