### PR TITLE
Treat specVersion as an opaque string, not a semver version

### DIFF
--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -189,7 +189,7 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
         processOpt(SPEC_VERSION,
             value -> {
                 if(StringUtils.isNotEmpty(value)) {
-                    additionalProperties.put(SPEC_VERSION, new SemVer(value));
+                    additionalProperties.put(SPEC_VERSION, value);
                 }
             },
             () -> {


### PR DESCRIPTION
Unlike npm, there is no requirement for maven artifacts to follow any particular versioning strategy, so therefore no guarantee a spec artifact version is a valid semver version.