### PR TITLE
Use ^ not >= in devDependencies of generated package.json files and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The project is very much Work In Progress and will be published on maven central
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.16.6
+* Boat Angular generator
+  * Use `^` instead of `>=` for `devDependencies` in the generated project, so project will be built using correct target version of ng-packagr & the Angular CLI
+  * Declare some extra `devDependencies` at explicit versions to fix `npm install` issues in the generated project when using `npm` v8
 ## 0.16.5
 * Boat Angular generator
   * Allow any format for spec versions.

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -260,27 +260,28 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
             final String tsVersion = "tsVersion";
             final String ngPackagrVersion = "ngPackagrVersion";
             final String rxjsVersion = "rxjsVersion";
+            final String zonejsVersion = "zonejsVersion";
 
             if (angularVersion.atLeast("13.0.0")) {
                 additionalProperties.put(tsVersion, "4.4.2");
                 additionalProperties.put(ngPackagrVersion, "13.3.1");
                 additionalProperties.put(rxjsVersion, "7.5.0");
-                additionalProperties.put("zonejsVersion", "0.11.4");
+                additionalProperties.put(zonejsVersion, "0.11.4");
             } else if (angularVersion.atLeast("12.0.0")) {
                 additionalProperties.put(tsVersion, "4.3.2");
                 additionalProperties.put(ngPackagrVersion, "12.0.0");
                 additionalProperties.put(rxjsVersion, "6.6.0");
-                additionalProperties.put("zonejsVersion", "0.11.4");
+                additionalProperties.put(zonejsVersion, "0.11.4");
             } else if (angularVersion.atLeast("11.0.0")) {
                 additionalProperties.put(tsVersion, "4.0.0");
                 additionalProperties.put(ngPackagrVersion, "11.0.0");
                 additionalProperties.put(rxjsVersion, "6.6.0");
-                additionalProperties.put("zonejsVersion", "0.10.3");
+                additionalProperties.put(zonejsVersion, "0.10.3");
             } else {
                 additionalProperties.put(tsVersion, "3.9.2");
                 additionalProperties.put(ngPackagrVersion, "10.0.3");
                 additionalProperties.put(rxjsVersion, "6.6.0");
-                additionalProperties.put("zonejsVersion", "0.10.3");
+                additionalProperties.put(zonejsVersion, "0.10.3");
             }
         }
     }

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -256,7 +256,6 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
             supportingFiles.add(new SupportingFile("package.mustache", getIndexDirectory(), "package.json"));
             supportingFiles.add(new SupportingFile("ng-package.mustache", getIndexDirectory(), "ng-package.json"));
             supportingFiles.add(new SupportingFile("tsconfig.mustache", getIndexDirectory(), "tsconfig.json"));
-            additionalProperties.put("zonejsVersion", "0.11.4");
 
             final String tsVersion = "tsVersion";
             final String ngPackagrVersion = "ngPackagrVersion";
@@ -266,18 +265,22 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
                 additionalProperties.put(tsVersion, "4.4.2");
                 additionalProperties.put(ngPackagrVersion, "13.3.1");
                 additionalProperties.put(rxjsVersion, "7.5.0");
+                additionalProperties.put("zonejsVersion", "0.11.4");
             } else if (angularVersion.atLeast("12.0.0")) {
                 additionalProperties.put(tsVersion, "4.3.2");
                 additionalProperties.put(ngPackagrVersion, "12.0.0");
                 additionalProperties.put(rxjsVersion, "6.6.0");
+                additionalProperties.put("zonejsVersion", "0.11.4");
             } else if (angularVersion.atLeast("11.0.0")) {
                 additionalProperties.put(tsVersion, "4.0.0");
                 additionalProperties.put(ngPackagrVersion, "11.0.0");
                 additionalProperties.put(rxjsVersion, "6.6.0");
+                additionalProperties.put("zonejsVersion", "0.10.3");
             } else {
                 additionalProperties.put(tsVersion, "3.9.2");
                 additionalProperties.put(ngPackagrVersion, "10.0.3");
                 additionalProperties.put(rxjsVersion, "6.6.0");
+                additionalProperties.put("zonejsVersion", "0.10.3");
             }
         }
     }

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -263,15 +263,19 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
             final String rxjsVersion = "rxjsVersion";
 
             if (angularVersion.atLeast("13.0.0")) {
-                additionalProperties.put(tsVersion, ">=4.4.2");
+                additionalProperties.put(tsVersion, "4.4.2");
                 additionalProperties.put(ngPackagrVersion, "13.3.1");
                 additionalProperties.put(rxjsVersion, "7.5.0");
+            } else if (angularVersion.atLeast("12.0.0")) {
+                additionalProperties.put(tsVersion, "4.3.2");
+                additionalProperties.put(ngPackagrVersion, "12.0.0");
+                additionalProperties.put(rxjsVersion, "6.6.0");
             } else if (angularVersion.atLeast("11.0.0")) {
-                additionalProperties.put(tsVersion, ">=4.2.0");
+                additionalProperties.put(tsVersion, "4.0.0");
                 additionalProperties.put(ngPackagrVersion, "11.0.0");
                 additionalProperties.put(rxjsVersion, "6.6.0");
             } else {
-                additionalProperties.put(tsVersion, ">=3.9.2");
+                additionalProperties.put(tsVersion, "3.9.2");
                 additionalProperties.put(ngPackagrVersion, "10.0.3");
                 additionalProperties.put(rxjsVersion, "6.6.0");
             }

--- a/boat-scaffold/src/main/templates/boat-angular/package.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/package.mustache
@@ -31,7 +31,10 @@
     "@angular/compiler": "^{{ngVersion}}",
     "@angular/compiler-cli": "^{{ngVersion}}",
     "@angular/core": "^{{ngVersion}}",
+    "@angular/router": "^{{ngVersion}}",
     "@angular/platform-browser": "^{{ngVersion}}",
+    "@ngrx/effects": "^{{ngVersion}}",
+    "@ngrx/store": "^{{ngVersion}}",
     "ng-packagr": "^{{ngPackagrVersion}}",
     "reflect-metadata": "^0.1.3",
     {{#withMocks}}

--- a/boat-scaffold/src/main/templates/boat-angular/package.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/package.mustache
@@ -27,19 +27,19 @@
     "rxjs": ">={{rxjsVersion}}"
   },
   "devDependencies": {
-    "@angular/common": ">={{ngVersion}}",
-    "@angular/compiler": ">={{ngVersion}}",
-    "@angular/compiler-cli": ">={{ngVersion}}",
-    "@angular/core": ">={{ngVersion}}",
-    "@angular/platform-browser": ">={{ngVersion}}",
-    "ng-packagr": ">={{ngPackagrVersion}}",
+    "@angular/common": "^{{ngVersion}}",
+    "@angular/compiler": "^{{ngVersion}}",
+    "@angular/compiler-cli": "^{{ngVersion}}",
+    "@angular/core": "^{{ngVersion}}",
+    "@angular/platform-browser": "^{{ngVersion}}",
+    "ng-packagr": "^{{ngPackagrVersion}}",
     "reflect-metadata": "^0.1.3",
     {{#withMocks}}
-    "@backbase/foundation-ang": ">={{foundationVersion}}",
+    "@backbase/foundation-ang": "^{{foundationVersion}}",
     {{/withMocks}}
-    "rxjs": ">={{rxjsVersion}}",
-    "typescript": "{{{tsVersion}}}",
-    "zone.js": ">={{zonejsVersion}}"
+    "rxjs": "^{{rxjsVersion}}",
+    "typescript": "~{{{tsVersion}}}",
+    "zone.js": "^{{zonejsVersion}}"
   }{{#npmRepository}},
   "publishConfig": {
     "registry": "{{{npmRepository}}}"

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/angular/BoatAngularTemplatesTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/angular/BoatAngularTemplatesTests.java
@@ -284,9 +284,9 @@ class BoatAngularTemplatesTests {
         final boolean apiModulePrefix;
         final boolean serviceSuffix;
 
-        Combination(int mask) {
-            this.name = caseName(mask);
-            this.ngVersion = mask == 0 ? "10.0.0" : mask == 1 ? "11.0.0" : mask == 2 ? "12.0.0" : mask == -1 ? "13.0.0" :  null;
+        Combination(int mask, String ngVersion) {
+            this.name = caseName(mask) + "-ng-" + ngVersion;
+            this.ngVersion = ngVersion;
             this.foundationVersion = mask == 0 ? "6.0.0" : mask == 1 ? "7.0.0" : null;
             this.specVersion = mask == 0 ? "1.0.0" : mask == 1 ? "2.0.0" : null;
             this.buildDist = mask > 0 ? caseName(mask) : null;
@@ -326,8 +326,15 @@ class BoatAngularTemplatesTests {
             if (minimal) {
                 cases.add(-1);
             }
+            final String[] ngVersions = {
+                "13.0.0",
+                "12.0.0",
+                "11.0.0",
+                "10.0.0",
+                null,
+            };
 
-            return cases.stream().map(Combination::new);
+            return cases.stream().flatMap((mask) -> stream(ngVersions).map(ngVersion -> new Combination(mask, ngVersion)));
         }
     }
 }


### PR DESCRIPTION
…fix version of typescript used for Angular 11.

Also fix issues running `npm install` in the generated project when using npm v8.