### PR TITLE
Remove types from generated mock providers due to a TypeScript which …

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The project is very much Work In Progress and will be published on maven central
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.16.10
+* Boat Angular generator
+  * Remove types from generated mock providers due to a TypeScript which prevents `/*#__PURE__*/` annotation from working
 ## 0.16.9
 * Boat Angular generator
   * Use of `/*#__PURE__*/` for `createMocks` function call in templates to enable tree-shaking

--- a/boat-scaffold/src/main/templates/boat-angular-mock/apiMocks.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular-mock/apiMocks.mustache
@@ -34,10 +34,10 @@ const {{nickname}}Examples = [
 /**
 * Mocks provider for {{{basePathWithoutHost}}}{{pattern}} URL pattern
 */
-export const {{classname}}{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}MocksProvider: Provider = /*#__PURE__*/ createMocks({{nickname}}Examples);
+export const {{classname}}{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}MocksProvider = /*#__PURE__*/ createMocks({{nickname}}Examples);
 
     {{/operation}}
 {{/operations}}
-export const {{classname}}MocksProvider: Provider = /*#__PURE__*/ createMocks({{baseName}}Examples);
+export const {{classname}}MocksProvider = /*#__PURE__*/ createMocks({{baseName}}Examples);
 
 

--- a/boat-scaffold/src/main/templates/boat-angular/apiMocks.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/apiMocks.mustache
@@ -6,7 +6,7 @@ import { Provider } from '@angular/core';
 /**
 * Mocks provider for {{{basePathWithoutHost}}}{{pattern}} URL pattern
 */
-export const {{classname}}{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}MocksProvider: Provider = /*#__PURE__*/ createMocks([{
+export const {{classname}}{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}MocksProvider = /*#__PURE__*/ createMocks([{
         urlPattern: "{{{basePathWithoutHost}}}{{pattern}}",
         method: "{{#lambda.uppercase}}{{httpMethod}}{{/lambda.uppercase}}",
         responses: [
@@ -37,7 +37,7 @@ export const {{classname}}{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}
     {{/operation}}
 {{/operations}}
 
-export const {{classname}}MocksProvider: Provider = /*#__PURE__*/ createMocks(
+export const {{classname}}MocksProvider = /*#__PURE__*/ createMocks(
     [{{#operations}}
     {{#operation}}
     {

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/angular/BoatAngularTemplatesTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/angular/BoatAngularTemplatesTests.java
@@ -121,7 +121,7 @@ class BoatAngularTemplatesTests {
     @Check
     public void withMocks() {
         assertThat(
-                findPattern(selectFiles("/api/.+\\.service\\.mocks\\.ts$"), "MocksProvider: Provider = /\\*#__PURE__\\*/ createMocks"),
+                findPattern(selectFiles("/api/.+\\.service\\.mocks\\.ts$"), "MocksProvider = /\\*#__PURE__\\*/ createMocks"),
                 equalTo(this.param.withMocks));
     }
 


### PR DESCRIPTION
Remove types from generated mock providers due to a TypeScript which prevents `/*#__PURE__*/` annotation from working