### PR TITLE
Set removeComments=false in generated tsconfig.json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The project is very much Work In Progress and will be published on maven central
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.16.11
+* Boat Angular generator
+  * Set `removeComments: false` in generated tsconfig.json files to retain `/*#__PURE__*/` annotation in compiled JS.
 ## 0.16.10
 * Boat Angular generator
   * Remove types from generated mock providers due to a TypeScript which prevents `/*#__PURE__*/` annotation from working

--- a/boat-scaffold/src/main/templates/boat-angular-mock/tsconfig.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular-mock/tsconfig.mustache
@@ -7,7 +7,7 @@
         "target": "{{#supportsES6}}es6{{/supportsES6}}{{^supportsES6}}es5{{/supportsES6}}",
         "module": "{{#supportsES6}}es6{{/supportsES6}}{{^supportsES6}}commonjs{{/supportsES6}}",
         "moduleResolution": "node",
-        "removeComments": true,
+        "removeComments": false,
         "sourceMap": true,
         "outDir": "./dist",
         "noLib": false,

--- a/boat-scaffold/src/main/templates/boat-angular/tsconfig.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/tsconfig.mustache
@@ -12,7 +12,7 @@
         "target": "{{#supportsES6}}es6{{/supportsES6}}{{^supportsES6}}es5{{/supportsES6}}",
         "module": "{{#supportsES6}}es6{{/supportsES6}}{{^supportsES6}}commonjs{{/supportsES6}}",
         "moduleResolution": "node",
-        "removeComments": true,
+        "removeComments": false,
         "sourceMap": true,
         "outDir": "./dist",
         "noLib": false,


### PR DESCRIPTION
Prevents the removal of the `/*#__PURE__*/` comments in the compiled output.