### PR TITLE
Add rule to enforce access-control specification for endpoints.

### DIFF
--- a/boat-maven-plugin/src/it/example/boat-generate/angular/pom.xml
+++ b/boat-maven-plugin/src/it/example/boat-generate/angular/pom.xml
@@ -46,6 +46,9 @@
                             <output>${project.basedir}/target/http-module</output>
                             <reservedWordsMappings>delete=delete,function=function,new=new</reservedWordsMappings>
                             <additionalProperties>npmName=${codegen.npmPackage.name},npmVersion=${codegen.npmPackage.version},withMocks=${codegen.generateMocks},buildDist=${codegen.buildDist},serviceSuffix=${codegen.serviceSuffix},apiModulePrefix=${codegen.apiModulePrefix}</additionalProperties>
+                            <configOptions>
+                                <ngVersion>11.0.0</ngVersion>
+                            </configOptions>
                         </configuration>
                     </execution>
                 </executions>

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/LintMojoTests.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/LintMojoTests.java
@@ -21,7 +21,7 @@ class LintMojoTests {
     @Test
     void testFailOnWarningNoWarnings() throws MojoFailureException, MojoExecutionException {
         LintMojo lintMojo = new LintMojo();
-        lintMojo.setIgnoreRules(Arrays.array("219", "105", "104", "151", "134", "115","M0012", "224"));
+        lintMojo.setIgnoreRules(Arrays.array("219", "105", "104", "151", "134", "115","M0012", "224", "B013"));
         lintMojo.setInput(getFile("/oas-examples/no-lint-warnings.yaml"));
         lintMojo.setFailOnWarning(true);
         lintMojo.execute();

--- a/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRule.kt
+++ b/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRule.kt
@@ -1,0 +1,48 @@
+package com.backbase.oss.boat.quay.ruleset
+
+import com.fasterxml.jackson.core.JsonPointer
+import com.typesafe.config.Config
+import org.zalando.zally.rule.api.*
+import java.nio.file.FileVisitOption
+import java.util.Optional
+
+@Rule(
+        ruleSet = BoatRuleSet::class,
+        id = "B013",
+        severity = Severity.MUST,
+        title = "Check access control is properly defined."
+)
+class EndpointAccessControlDefinedRule(config: Config) {
+
+    @Check(Severity.MUST)
+    fun validate(context: Context): List<Violation>  {
+
+        fun notEmpty(s: Any?) : Boolean {
+            return s != null && !s.toString().equals("")
+        }
+
+        val violations = mutableListOf<Violation>()
+        context.api.paths.orEmpty().values
+                .flatMap { it?.readOperations().orEmpty() }
+                .forEach {
+                    val acEnabledSet : Boolean = notEmpty(it.extensions["x-BBAccessControl"])
+                    val acResourceSet : Boolean = notEmpty(it.extensions["x-BBAccessControl-resource"])
+                    val acFunctionSet : Boolean = notEmpty(it.extensions["x-BBAccessControl-function"])
+                    val acPrivilegeSet : Boolean = notEmpty(it.extensions["x-BBAccessControl-privilege"])
+                    val acExplicitlyDisabled : Boolean = "false" == it.extensions["x-BBAccessControl"].toString()
+                    if (acExplicitlyDisabled) {
+                        if (acResourceSet || acFunctionSet || acPrivilegeSet) {
+                            violations.add(
+                                    context.violation("AC both disabled and defined: ${it.operationId}", it))
+                        }
+                    } else if (!acEnabledSet) {
+                        if (!acResourceSet || !acFunctionSet || !acPrivilegeSet) {
+                            violations.add(
+                                    context.violation("AC info not complete: ${it.extensions}", it))
+                        }
+                    }
+                }
+        return violations
+    }
+
+}

--- a/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRule.kt
+++ b/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRule.kt
@@ -25,20 +25,25 @@ class EndpointAccessControlDefinedRule(config: Config) {
         context.api.paths.orEmpty().values
                 .flatMap { it?.readOperations().orEmpty() }
                 .forEach {
-                    val acEnabledSet : Boolean = notEmpty(it.extensions["x-BBAccessControl"])
-                    val acResourceSet : Boolean = notEmpty(it.extensions["x-BBAccessControl-resource"])
-                    val acFunctionSet : Boolean = notEmpty(it.extensions["x-BBAccessControl-function"])
-                    val acPrivilegeSet : Boolean = notEmpty(it.extensions["x-BBAccessControl-privilege"])
-                    val acExplicitlyDisabled : Boolean = "false" == it.extensions["x-BBAccessControl"].toString()
-                    if (acExplicitlyDisabled) {
-                        if (acResourceSet || acFunctionSet || acPrivilegeSet) {
-                            violations.add(
-                                    context.violation("AC both disabled and defined: ${it.operationId}", it))
-                        }
-                    } else if (!acEnabledSet) {
-                        if (!acResourceSet || !acFunctionSet || !acPrivilegeSet) {
-                            violations.add(
-                                    context.violation("AC info not complete: ${it.extensions}", it))
+                    if (it.extensions == null) {
+                        violations.add(
+                                context.violation("Access Control not defined: ${it.operationId}", it))
+                    } else {
+                        val acEnabledSet: Boolean = notEmpty(it.extensions["x-BBAccessControl"])
+                        val acResourceSet: Boolean = notEmpty(it.extensions["x-BBAccessControl-resource"])
+                        val acFunctionSet: Boolean = notEmpty(it.extensions["x-BBAccessControl-function"])
+                        val acPrivilegeSet: Boolean = notEmpty(it.extensions["x-BBAccessControl-privilege"])
+                        val acExplicitlyDisabled: Boolean = "false" == it.extensions["x-BBAccessControl"].toString()
+                        if (acExplicitlyDisabled) {
+                            if (acResourceSet || acFunctionSet || acPrivilegeSet) {
+                                violations.add(
+                                        context.violation("AC both disabled and defined: ${it.operationId}", it))
+                            }
+                        } else if (!acEnabledSet) {
+                            if (!acResourceSet || !acFunctionSet || !acPrivilegeSet) {
+                                violations.add(
+                                        context.violation("AC info not complete: ${it.extensions}", it))
+                            }
                         }
                     }
                 }

--- a/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRule.kt
+++ b/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRule.kt
@@ -29,11 +29,11 @@ class EndpointAccessControlDefinedRule(config: Config) {
                         violations.add(
                                 context.violation("Access Control not defined: ${it.operationId}", it))
                     } else {
-                        val acEnabledSet: Boolean = notEmpty(it.extensions["x-BBAccessControl"])
-                        val acResourceSet: Boolean = notEmpty(it.extensions["x-BBAccessControl-resource"])
-                        val acFunctionSet: Boolean = notEmpty(it.extensions["x-BBAccessControl-function"])
-                        val acPrivilegeSet: Boolean = notEmpty(it.extensions["x-BBAccessControl-privilege"])
-                        val acExplicitlyDisabled: Boolean = "false" == it.extensions["x-BBAccessControl"].toString()
+                        val acEnabledSet: Boolean = notEmpty(it.extensions["x-BbAccessControl"])
+                        val acResourceSet: Boolean = notEmpty(it.extensions["x-BbAccessControl-resource"])
+                        val acFunctionSet: Boolean = notEmpty(it.extensions["x-BbAccessControl-function"])
+                        val acPrivilegeSet: Boolean = notEmpty(it.extensions["x-BbAccessControl-privilege"])
+                        val acExplicitlyDisabled: Boolean = "false" == it.extensions["x-BbAccessControl"].toString()
                         if (acExplicitlyDisabled) {
                             if (acResourceSet || acFunctionSet || acPrivilegeSet) {
                                 violations.add(

--- a/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRuleTest.kt
+++ b/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRuleTest.kt
@@ -19,7 +19,7 @@ class EndpointAccessControlDefinedRuleTest {
             paths: 
               /client-api/foo:
                 get:
-                  x-BBAccessControl: false
+                  x-BbAccessControl: false
             """.trimIndent()
         )
 
@@ -39,9 +39,9 @@ class EndpointAccessControlDefinedRuleTest {
             paths: 
               /client-api/foo:
                 get:
-                  x-BBAccessControl-resource: Users
-                  x-BBAccessControl-function: Manage Users
-                  x-BBAccessControl-privilege: view
+                  x-BbAccessControl-resource: Users
+                  x-BbAccessControl-function: Manage Users
+                  x-BbAccessControl-privilege: view
             """.trimIndent()
         )
 
@@ -61,10 +61,10 @@ class EndpointAccessControlDefinedRuleTest {
             paths: 
               /client-api/foo:
                 get:
-                  x-BBAccessControl: true
-                  x-BBAccessControl-resource: Users
-                  x-BBAccessControl-function: Manage Users
-                  x-BBAccessControl-privilege: view
+                  x-BbAccessControl: true
+                  x-BbAccessControl-resource: Users
+                  x-BbAccessControl-function: Manage Users
+                  x-BbAccessControl-privilege: view
             """.trimIndent()
         )
 
@@ -104,9 +104,9 @@ class EndpointAccessControlDefinedRuleTest {
             paths: 
               /client-api/foo:
                 get:
-                  x-BBAccessControl-resource: Users
-                  x-BBAccessControl-function: ""
-                  x-BBAccessControl-privilege: view
+                  x-BbAccessControl-resource: Users
+                  x-BbAccessControl-function: ""
+                  x-BbAccessControl-privilege: view
             """.trimIndent()
         )
 
@@ -126,8 +126,8 @@ class EndpointAccessControlDefinedRuleTest {
             paths: 
               /client-api/foo:
                 get:
-                  x-BBAccessControl-function: Manage Users
-                  x-BBAccessControl-privilege: view
+                  x-BbAccessControl-function: Manage Users
+                  x-BbAccessControl-privilege: view
             """.trimIndent()
         )
 
@@ -147,8 +147,8 @@ class EndpointAccessControlDefinedRuleTest {
             paths: 
               /client-api/foo:
                 get:
-                  x-BBAccessControl-resource: Users
-                  x-BBAccessControl-privilege: view
+                  x-BbAccessControl-resource: Users
+                  x-BbAccessControl-privilege: view
             """.trimIndent()
         )
 
@@ -168,8 +168,8 @@ class EndpointAccessControlDefinedRuleTest {
             paths: 
               /client-api/foo:
                 get:
-                  x-BBAccessControl-resource: Users
-                  x-BBAccessControl-function: Manage Users
+                  x-BbAccessControl-resource: Users
+                  x-BbAccessControl-function: Manage Users
             """.trimIndent()
         )
 
@@ -189,10 +189,10 @@ class EndpointAccessControlDefinedRuleTest {
             paths: 
               /client-api/foo:
                 get:
-                  x-BBAccessControl: false
-                  x-BBAccessControl-resource: Users
-                  x-BBAccessControl-function: Manage Users
-                  x-BBAccessControl-privilege: view
+                  x-BbAccessControl: false
+                  x-BbAccessControl-resource: Users
+                  x-BbAccessControl-function: Manage Users
+                  x-BbAccessControl-privilege: view
             """.trimIndent()
         )
 

--- a/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRuleTest.kt
+++ b/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRuleTest.kt
@@ -1,0 +1,206 @@
+package com.backbase.oss.boat.quay.ruleset
+
+import com.backbase.oss.boat.quay.ruleset.test.ZallyAssertions
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+import org.zalando.zally.core.DefaultContextFactory
+import org.zalando.zally.core.rulesConfig
+
+class EndpointAccessControlDefinedRuleTest {
+
+    private val rule = EndpointAccessControlDefinedRule(rulesConfig)
+
+    @Test
+    fun `Endpoint has ac defined as false`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BBAccessControl: false
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isEmpty()
+    }
+
+    @Test
+    fun `Endpoint has ac defined correctly`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BBAccessControl-resource: Users
+                  x-BBAccessControl-function: Manage Users
+                  x-BBAccessControl-privilege: view
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isEmpty()
+    }
+
+    @Test
+    fun `Endpoint has ac enabled AND defined correctly (a bit too much but still ok)`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BBAccessControl: true
+                  x-BBAccessControl-resource: Users
+                  x-BBAccessControl-function: Manage Users
+                  x-BBAccessControl-privilege: view
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isEmpty()
+    }
+
+    @Test
+    fun `Endpoint has no ac defined at all`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-SomethingElse: yes
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
+    }
+
+    @Test
+    fun `Endpoint has ac defined but with empty value`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BBAccessControl-resource: Users
+                  x-BBAccessControl-function: ""
+                  x-BBAccessControl-privilege: view
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
+    }
+
+    @Test
+    fun `Endpoint has ac defined but resource missing`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BBAccessControl-function: Manage Users
+                  x-BBAccessControl-privilege: view
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
+    }
+
+    @Test
+    fun `Endpoint has ac defined but function missing`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BBAccessControl-resource: Users
+                  x-BBAccessControl-privilege: view
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
+    }
+
+    @Test
+    fun `Endpoint has ac defined but privilege missing`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BBAccessControl-resource: Users
+                  x-BBAccessControl-function: Manage Users
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
+    }
+
+    @Test
+    fun `Endpoint has ac both defined and explicitly set false `() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BBAccessControl: false
+                  x-BBAccessControl-resource: Users
+                  x-BBAccessControl-function: Manage Users
+                  x-BBAccessControl-privilege: view
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
+    }
+
+}


### PR DESCRIPTION
For each endpoint, what permissions are required should be defined, or it should explicitly state that access control is not enforced.