### PR TITLE
Angular b/w compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The project is very much Work In Progress and will be published on maven central
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.17.3
+* Boat Angular generator
+  * Map the `Set` type to `Array` by default to avoid breaking changes vs clients generated with 0.16.x. 
 ## 0.17.2
 * Boat Angular generator
   * Remove leading comment from typescript files so that there are fewer differences between files when regenerating with a new spec version (info moved to README)

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -84,6 +84,8 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
     public BoatAngularGenerator() {
         super();
 
+        this.openapiNormalizer.put("REFACTOR_ALLOF_WITH_PROPERTIES_ONLY", "true");
+
         typeMapping.put("Set", "Array");
         typeMapping.put("set", "Array");
 

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/angular/BoatAngularGenerator.java
@@ -84,6 +84,9 @@ public class BoatAngularGenerator extends AbstractTypeScriptClientCodegen {
     public BoatAngularGenerator() {
         super();
 
+        typeMapping.put("Set", "Array");
+        typeMapping.put("set", "Array");
+
         modifyFeatureSet(features -> features.includeDocumentationFeatures(DocumentationFeature.Readme));
 
         this.outputFolder = "generated-code/boat-angular";

--- a/boat-scaffold/src/main/templates/boat-angular/licenseInfo.mustache
+++ b/boat-scaffold/src/main/templates/boat-angular/licenseInfo.mustache
@@ -1,0 +1,3 @@
+/**
+ * Generated code
+ */


### PR DESCRIPTION
* Use Array instead of Set by default for backwards compatibility with 0.16.x
* Add a fixed "generated code" comment at the start of every file so that API report diffs do not show "(undocumented}" everywhere (otherwise the PR updating data-ang to this version of BOAT will be polluted with thousands of irrelevant changes in the API reports)