### PR TITLE
align pojo mustache templates with openapi 6.6.0

### DIFF
--- a/boat-scaffold/src/main/templates/boat-java/pojo.mustache
+++ b/boat-scaffold/src/main/templates/boat-java/pojo.mustache
@@ -1,343 +1,356 @@
 /**
- * {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
- * @deprecated{{/isDeprecated}}
- */{{#isDeprecated}}
-@Deprecated{{/isDeprecated}}{{#description}}
+* {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
+  * @deprecated{{/isDeprecated}}
+*/{{#isDeprecated}}
+  @Deprecated{{/isDeprecated}}
 {{#swagger1AnnotationLibrary}}
-@ApiModel(description = "{{{.}}}")
+  {{#description}}
+    @ApiModel(description = "{{{.}}}")
+  {{/description}}
 {{/swagger1AnnotationLibrary}}
-{{#swagger2AnnotationLibrary}}
-@Schema(description = "{{{.}}}")
-{{/swagger2AnnotationLibrary}}
-{{/description}}
 {{#jackson}}
-@JsonPropertyOrder({
-{{#vars}}
-  {{classname}}.JSON_PROPERTY_{{nameInSnakeCase}}{{^-last}},{{/-last}}
-{{/vars}}
-})
-{{#isClassnameSanitized}}
-@JsonTypeName("{{name}}")
-{{/isClassnameSanitized}}
+  @JsonPropertyOrder({
+  {{#vars}}
+    {{classname}}.JSON_PROPERTY_{{nameInSnakeCase}}{{^-last}},{{/-last}}
+  {{/vars}}
+  })
+  {{#isClassnameSanitized}}
+    {{^hasDiscriminatorWithNonEmptyMapping}}
+      @JsonTypeName("{{name}}")
+    {{/hasDiscriminatorWithNonEmptyMapping}}
+  {{/isClassnameSanitized}}
 {{/jackson}}
 {{>additionalModelTypeAnnotations}}{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+  {{{vendorExtensions.x-class-extra-annotation}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{#-last}} {{/-last}}{{/vendorExtensions.x-implements}}{
 {{#serializableModel}}
   private static final long serialVersionUID = 1L;
 
 {{/serializableModel}}
-  {{#vars}}
-    {{#isEnum}}
+{{#vars}}
+  {{#isEnum}}
     {{^isContainer}}
-{{>modelInnerEnum}}
+      {{>modelInnerEnum}}
     {{/isContainer}}
     {{#isContainer}}
-    {{#mostInnerItems}}
-{{>modelInnerEnum}}
-    {{/mostInnerItems}}
+      {{#mostInnerItems}}
+        {{>modelInnerEnum}}
+      {{/mostInnerItems}}
     {{/isContainer}}
-    {{/isEnum}}
+  {{/isEnum}}
   {{#gson}}
-  public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
+    public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
   {{/gson}}
   {{#jackson}}
-  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
+    public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
   {{/jackson}}
   {{#withXml}}
-  {{#isXmlAttribute}}
-  @XmlAttribute(name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
-  {{/isXmlAttribute}}
-  {{^isXmlAttribute}}
-    {{^isContainer}}
-  @XmlElement({{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
-    {{/isContainer}}
-    {{#isContainer}}
-  // Is a container wrapped={{isXmlWrapped}}
-      {{#items}}
-  // items.name={{name}} items.baseName={{baseName}} items.xmlName={{xmlName}} items.xmlNamespace={{xmlNamespace}}
-  // items.example={{example}} items.type={{dataType}}
-  @XmlElement({{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
-      {{/items}}
-      {{#isXmlWrapped}}
-  @XmlElementWrapper({{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
-      {{/isXmlWrapped}}
-    {{/isContainer}}
-  {{#isDateTime}}
-  @XmlJavaTypeAdapter(OffsetDateTimeXmlAdapter.class)
-  {{/isDateTime}}
-  {{/isXmlAttribute}}
+    {{#isXmlAttribute}}
+      @XmlAttribute(name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    {{/isXmlAttribute}}
+    {{^isXmlAttribute}}
+      {{^isContainer}}
+        @XmlElement({{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+      {{/isContainer}}
+      {{#isContainer}}
+        // Is a container wrapped={{isXmlWrapped}}
+        {{#items}}
+          // items.name={{name}} items.baseName={{baseName}} items.xmlName={{xmlName}} items.xmlNamespace={{xmlNamespace}}
+          // items.example={{example}} items.type={{dataType}}
+          @XmlElement({{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+        {{/items}}
+        {{#isXmlWrapped}}
+          @XmlElementWrapper({{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+        {{/isXmlWrapped}}
+      {{/isContainer}}
+      {{#isDateTime}}
+        @XmlJavaTypeAdapter(OffsetDateTimeXmlAdapter.class)
+      {{/isDateTime}}
+    {{/isXmlAttribute}}
   {{/withXml}}
   {{#gson}}
-  @SerializedName(SERIALIZED_NAME_{{nameInSnakeCase}})
+    @SerializedName(SERIALIZED_NAME_{{nameInSnakeCase}})
   {{/gson}}
   {{#vendorExtensions.x-field-extra-annotation}}
-  {{{vendorExtensions.x-field-extra-annotation}}}
+    {{{vendorExtensions.x-field-extra-annotation}}}
   {{/vendorExtensions.x-field-extra-annotation}}
   {{#vendorExtensions.x-is-jackson-optional-nullable}}
-  {{#isContainer}}
-  private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>undefined();
-  {{/isContainer}}
-  {{^isContainer}}
-  private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
-  {{/isContainer}}
+    {{#isContainer}}
+      private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>undefined();
+    {{/isContainer}}
+    {{^isContainer}}
+      private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
+    {{/isContainer}}
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
   {{^vendorExtensions.x-is-jackson-optional-nullable}}
-  {{#isContainer}}
-  private {{{datatypeWithEnum}}} {{name}}{{#required}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/required}}{{^required}} = null{{/required}};
-  {{/isContainer}}
-  {{^isContainer}}
-  {{#isDiscriminator}}protected{{/isDiscriminator}}{{^isDiscriminator}}private{{/isDiscriminator}} {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
-  {{/isContainer}}
+    {{#isContainer}}
+      private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+    {{/isContainer}}
+    {{^isContainer}}
+      {{#isDiscriminator}}protected{{/isDiscriminator}}{{^isDiscriminator}}private{{/isDiscriminator}} {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+    {{/isContainer}}
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
-  {{/vars}}
-  public {{classname}}() {
-    {{#parent}}
-    {{#parcelableModel}}
+{{/vars}}
+public {{classname}}() {
+{{#parent}}
+  {{#parcelableModel}}
     super();{{/parcelableModel}}
-    {{/parent}}
-    {{#gson}}
-    {{#discriminator}}
+{{/parent}}
+{{#gson}}
+  {{#discriminator}}
     {{#discriminator.isEnum}}
-    this.{{{discriminatorName}}} = this.getClass().getSimpleName();
+      this.{{{discriminatorName}}} = this.getClass().getSimpleName();
     {{/discriminator.isEnum}}
-    {{/discriminator}}
-    {{/gson}}
-  }
-  {{#vendorExtensions.x-has-readonly-properties}}
+  {{/discriminator}}
+{{/gson}}
+}
+{{#vendorExtensions.x-has-readonly-properties}}
   {{^withXml}}
 
-  {{#jsonb}}@JsonbCreator{{/jsonb}}{{#jackson}}@JsonCreator{{/jackson}}
-  public {{classname}}(
-  {{#readOnlyVars}}
-    {{#jsonb}}@JsonbProperty(value = "{{baseName}}"{{^required}}, nullable = true{{/required}}){{/jsonb}}{{#jackson}}@JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}}){{/jackson}} {{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}
-  {{/readOnlyVars}}
-  ) {
+    {{#jsonb}}@JsonbCreator{{/jsonb}}{{#jackson}}@JsonCreator{{/jackson}}
+    public {{classname}}(
+    {{#readOnlyVars}}
+      {{#jsonb}}@JsonbProperty(value = "{{baseName}}"{{^required}}, nullable = true{{/required}}){{/jsonb}}{{#jackson}}@JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}}){{/jackson}} {{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}
+    {{/readOnlyVars}}
+    ) {
     this();
-  {{#readOnlyVars}}
-    this.{{name}} = {{#vendorExtensions.x-is-jackson-optional-nullable}}{{name}} == null ? JsonNullable.<{{{datatypeWithEnum}}}>undefined() : JsonNullable.of({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{name}}{{/vendorExtensions.x-is-jackson-optional-nullable}};
-  {{/readOnlyVars}}
-  }
+    {{#readOnlyVars}}
+      this.{{name}} = {{#vendorExtensions.x-is-jackson-optional-nullable}}{{name}} == null ? JsonNullable.<{{{datatypeWithEnum}}}>undefined() : JsonNullable.of({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{name}}{{/vendorExtensions.x-is-jackson-optional-nullable}};
+    {{/readOnlyVars}}
+    }
   {{/withXml}}
-  {{/vendorExtensions.x-has-readonly-properties}}
-  {{#vars}}
+{{/vendorExtensions.x-has-readonly-properties}}
+{{#vars}}
 
   {{^isReadOnly}}
-  public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
+    public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-is-jackson-optional-nullable}}this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});{{/vendorExtensions.x-is-jackson-optional-nullable}}
     {{^vendorExtensions.x-is-jackson-optional-nullable}}this.{{name}} = {{name}};{{/vendorExtensions.x-is-jackson-optional-nullable}}
     return this;
-  }
-  {{#isArray}}
+    }
+    {{#isArray}}
 
-  public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
-    {{#vendorExtensions.x-is-jackson-optional-nullable}}
-    if (this.{{name}} == null || !this.{{name}}.isPresent()) {
-      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}});
-    }
-    try {
-      this.{{name}}.get().add({{name}}Item);
-    } catch (java.util.NoSuchElementException e) {
-      // this can never happen, as we make sure above that the value is present
-    }
-    return this;
-    {{/vendorExtensions.x-is-jackson-optional-nullable}}
-    {{^vendorExtensions.x-is-jackson-optional-nullable}}
-    {{^required}}
-    if (this.{{name}} == null) {
-      this.{{name}} = {{{defaultValue}}};
-    }
-    {{/required}}
-    this.{{name}}.add({{name}}Item);
-    return this;
-    {{/vendorExtensions.x-is-jackson-optional-nullable}}
-  }
-  {{/isArray}}
-  {{#isMap}}
+      public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+      {{#vendorExtensions.x-is-jackson-optional-nullable}}
+        if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+        this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}});
+        }
+        try {
+        this.{{name}}.get().add({{name}}Item);
+        } catch (java.util.NoSuchElementException e) {
+        // this can never happen, as we make sure above that the value is present
+        }
+        return this;
+      {{/vendorExtensions.x-is-jackson-optional-nullable}}
+      {{^vendorExtensions.x-is-jackson-optional-nullable}}
+        if (this.{{name}} == null) {
+        this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
+        }
+        this.{{name}}.add({{name}}Item);
+        return this;
+      {{/vendorExtensions.x-is-jackson-optional-nullable}}
+      }
+    {{/isArray}}
+    {{#isMap}}
 
-  public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
-    {{#vendorExtensions.x-is-jackson-optional-nullable}}
-    if (this.{{name}} == null || !this.{{name}}.isPresent()) {
-      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}});
-    }
-    try {
-      this.{{name}}.get().put(key, {{name}}Item);
-    } catch (java.util.NoSuchElementException e) {
-      // this can never happen, as we make sure above that the value is present
-    }
-    return this;
-    {{/vendorExtensions.x-is-jackson-optional-nullable}}
-    {{^vendorExtensions.x-is-jackson-optional-nullable}}
-    {{^required}}
-    if (this.{{name}} == null) {
-      this.{{name}} = {{{defaultValue}}};
-    }
-    {{/required}}
-    this.{{name}}.put(key, {{name}}Item);
-    return this;
-    {{/vendorExtensions.x-is-jackson-optional-nullable}}
-  }
-  {{/isMap}}
+      public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+      {{#vendorExtensions.x-is-jackson-optional-nullable}}
+        if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+        this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}});
+        }
+        try {
+        this.{{name}}.get().put(key, {{name}}Item);
+        } catch (java.util.NoSuchElementException e) {
+        // this can never happen, as we make sure above that the value is present
+        }
+        return this;
+      {{/vendorExtensions.x-is-jackson-optional-nullable}}
+      {{^vendorExtensions.x-is-jackson-optional-nullable}}
+        {{^required}}
+          if (this.{{name}} == null) {
+          this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}};
+          }
+        {{/required}}
+        this.{{name}}.put(key, {{name}}Item);
+        return this;
+      {{/vendorExtensions.x-is-jackson-optional-nullable}}
+      }
+    {{/isMap}}
 
   {{/isReadOnly}}
-   /**
+  /**
   {{#description}}
-   * {{.}}
+    * {{.}}
   {{/description}}
   {{^description}}
-   * Get {{name}}
+    * Get {{name}}
   {{/description}}
   {{#minimum}}
-   * minimum: {{.}}
+    * minimum: {{.}}
   {{/minimum}}
   {{#maximum}}
-   * maximum: {{.}}
+    * maximum: {{.}}
   {{/maximum}}
-   * @return {{name}}
-   {{#deprecated}}
-   * @deprecated
-   {{/deprecated}}
+  * @return {{name}}
+  {{#deprecated}}
+    * @deprecated
+  {{/deprecated}}
   **/
-{{#deprecated}}
-  @Deprecated
-{{/deprecated}}
-{{#required}}
-{{#isNullable}}
-{{#useJakartaEe}}  @jakarta.annotation.Nullable{{/useJakartaEe}}
-{{^useJakartaEe}}  @javax.annotation.Nullable{{/useJakartaEe}}
-{{/isNullable}}
-{{^isNullable}}
-  {{#useJakartaEe}}  @jakarta.annotation.Nonnull{{/useJakartaEe}}
-  {{^useJakartaEe}}  @javax.annotation.Nonnull{{/useJakartaEe}}
-{{/isNullable}}
-{{/required}}
-{{^required}}
-  {{#useJakartaEe}}  @jakarta.annotation.Nullable{{/useJakartaEe}}
-  {{^useJakartaEe}}  @javax.annotation.Nullable{{/useJakartaEe}}
-{{/required}}
-{{#jsonb}}
-  @JsonbProperty("{{baseName}}")
-{{/jsonb}}
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}   {{#swagger1AnnotationLibrary}} @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")  {{/swagger1AnnotationLibrary}}
-  {{#swagger2AnnotationLibrary}}
-    @Schema(name = "{{{baseName}}}",{{#example}}example = "{{{.}}}", {{/example}}{{#description}}description = "{{{.}}}", {{/description}}required = {{{required}}})
-  {{/swagger2AnnotationLibrary}}
-{{#vendorExtensions.x-extra-annotation}}
-  {{{vendorExtensions.x-extra-annotation}}}
-{{/vendorExtensions.x-extra-annotation}}
-{{#vendorExtensions.x-is-jackson-optional-nullable}}
+  {{#deprecated}}
+    @Deprecated
+  {{/deprecated}}
+  {{#required}}
+    {{#isNullable}}
+      @{{javaxPackage}}.annotation.Nullable
+    {{/isNullable}}
+    {{^isNullable}}
+      @{{javaxPackage}}.annotation.Nonnull
+    {{/isNullable}}
+  {{/required}}
+  {{^required}}
+    @{{javaxPackage}}.annotation.Nullable
+  {{/required}}
+  {{#jsonb}}
+    @JsonbProperty("{{baseName}}")
+  {{/jsonb}}
+  {{#useBeanValidation}}
+    {{>beanValidation}}
+  {{/useBeanValidation}}
+  {{#swagger1AnnotationLibrary}}
+    @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+  {{/swagger1AnnotationLibrary}}
+  {{#vendorExtensions.x-extra-annotation}}
+    {{{vendorExtensions.x-extra-annotation}}}
+  {{/vendorExtensions.x-extra-annotation}}
+  {{#vendorExtensions.x-is-jackson-optional-nullable}}
   {{!unannotated, Jackson would pick this up automatically and add it *in addition* to the _JsonNullable getter field}}
-  @JsonIgnore
-{{/vendorExtensions.x-is-jackson-optional-nullable}}
-{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#jackson}}{{> jackson_annotations}}{{/jackson}}{{/vendorExtensions.x-is-jackson-optional-nullable}}
+    @JsonIgnore
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  {{^vendorExtensions.x-is-jackson-optional-nullable}}{{#jackson}}{{> jackson_annotations}}{{/jackson}}{{/vendorExtensions.x-is-jackson-optional-nullable}}
   public {{{datatypeWithEnum}}} {{getter}}() {
-    {{#vendorExtensions.x-is-jackson-optional-nullable}}
+  {{#vendorExtensions.x-is-jackson-optional-nullable}}
     {{#isReadOnly}}{{! A readonly attribute doesn't have setter => jackson will set null directly if explicitly returned by API, so make sure we have an empty JsonNullable}}
-    if ({{name}} == null) {
+      if ({{name}} == null) {
       {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
-    }
+      }
     {{/isReadOnly}}
     return {{name}}.orElse(null);
-    {{/vendorExtensions.x-is-jackson-optional-nullable}}
-    {{^vendorExtensions.x-is-jackson-optional-nullable}}
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  {{^vendorExtensions.x-is-jackson-optional-nullable}}
     return {{name}};
-    {{/vendorExtensions.x-is-jackson-optional-nullable}}
+  {{/vendorExtensions.x-is-jackson-optional-nullable}}
   }
 
   {{#vendorExtensions.x-is-jackson-optional-nullable}}
-{{> jackson_annotations}}
-  public JsonNullable<{{{datatypeWithEnum}}}> {{getter}}_JsonNullable() {
+    {{> jackson_annotations}}
+    public JsonNullable<{{{datatypeWithEnum}}}> {{getter}}_JsonNullable() {
     return {{name}};
-  }
+    }
   {{/vendorExtensions.x-is-jackson-optional-nullable}}{{#vendorExtensions.x-is-jackson-optional-nullable}}
-  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
-  {{#isReadOnly}}private{{/isReadOnly}}{{^isReadOnly}}public{{/isReadOnly}} void {{setter}}_JsonNullable(JsonNullable<{{{datatypeWithEnum}}}> {{name}}) {
+    @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
+    {{#isReadOnly}}private{{/isReadOnly}}{{^isReadOnly}}public{{/isReadOnly}} void {{setter}}_JsonNullable(JsonNullable<{{{datatypeWithEnum}}}> {{name}}) {
     {{! For getters/setters that have name differing from attribute name, we must include setter (albeit private) for jackson to be able to set the attribute}}
     this.{{name}} = {{name}};
-  }
+    }
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{^isReadOnly}}
-{{#vendorExtensions.x-setter-extra-annotation}}  {{{vendorExtensions.x-setter-extra-annotation}}}
-{{/vendorExtensions.x-setter-extra-annotation}}{{#jackson}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{> jackson_annotations}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+    {{#vendorExtensions.x-setter-extra-annotation}}  {{{vendorExtensions.x-setter-extra-annotation}}}
+    {{/vendorExtensions.x-setter-extra-annotation}}{{#jackson}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{> jackson_annotations}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-is-jackson-optional-nullable}}
-    this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});
+      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});
     {{/vendorExtensions.x-is-jackson-optional-nullable}}
     {{^vendorExtensions.x-is-jackson-optional-nullable}}
-    this.{{name}} = {{name}};
+      this.{{name}} = {{name}};
     {{/vendorExtensions.x-is-jackson-optional-nullable}}
-  }
+    }
   {{/isReadOnly}}
 
-  {{/vars}}
+{{/vars}}
+{{#parent}}
+  {{#allVars}}
+    {{#isOverridden}}
+      @Override
+      public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
+      {{#vendorExtensions.x-is-jackson-optional-nullable}}
+        this.{{setter}}(JsonNullable.<{{{datatypeWithEnum}}}>of({{name}}));
+      {{/vendorExtensions.x-is-jackson-optional-nullable}}
+      {{^vendorExtensions.x-is-jackson-optional-nullable}}
+        this.{{setter}}({{name}});
+      {{/vendorExtensions.x-is-jackson-optional-nullable}}
+      return this;
+      }
 
-  @Override
-  public boolean equals(Object o) {
-  {{#useReflectionEqualsHashCode}}
-    return EqualsBuilder.reflectionEquals(this, o, false, null, true);
-  {{/useReflectionEqualsHashCode}}
-  {{^useReflectionEqualsHashCode}}
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }{{#hasVars}}
+    {{/isOverridden}}
+  {{/allVars}}
+{{/parent}}
+@Override
+public boolean equals(Object o) {
+{{#useReflectionEqualsHashCode}}
+  return EqualsBuilder.reflectionEquals(this, o, false, null, true);
+{{/useReflectionEqualsHashCode}}
+{{^useReflectionEqualsHashCode}}
+  if (this == o) {
+  return true;
+  }
+  if (o == null || getClass() != o.getClass()) {
+  return false;
+  }{{#hasVars}}
     {{classname}} {{classVarName}} = ({{classname}}) o;
     return {{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}equalsNullable(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}} &&
-        {{/-last}}{{/vars}}{{#parent}} &&
-        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    {{/-last}}{{/vars}}{{#parent}} &&
+    super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
     return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
-  {{/useReflectionEqualsHashCode}}
-  }{{#vendorExtensions.x-jackson-optional-nullable-helpers}}
+{{/useReflectionEqualsHashCode}}
+}{{#vendorExtensions.x-jackson-optional-nullable-helpers}}
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
     return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
-  }{{/vendorExtensions.x-jackson-optional-nullable-helpers}}
+    }{{/vendorExtensions.x-jackson-optional-nullable-helpers}}
 
   @Override
   public int hashCode() {
-  {{#useReflectionEqualsHashCode}}
+{{#useReflectionEqualsHashCode}}
     return HashCodeBuilder.reflectionHashCode(this);
-  {{/useReflectionEqualsHashCode}}
-  {{^useReflectionEqualsHashCode}}
+{{/useReflectionEqualsHashCode}}
+{{^useReflectionEqualsHashCode}}
     return Objects.hash({{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}hashCodeNullable({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
-  {{/useReflectionEqualsHashCode}}
+{{/useReflectionEqualsHashCode}}
   }{{#vendorExtensions.x-jackson-optional-nullable-helpers}}
 
-  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    private static <T> int hashCodeNullable(JsonNullable<T> a) {
     if (a == null) {
-      return 1;
+    return 1;
     }
     return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
-  }{{/vendorExtensions.x-jackson-optional-nullable-helpers}}
+    }{{/vendorExtensions.x-jackson-optional-nullable-helpers}}
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class {{classname}} {\n");
-    {{#parent}}
+  StringBuilder sb = new StringBuilder();
+  sb.append("class {{classname}} {\n");
+{{#parent}}
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-    {{/parent}}
-    {{#vars}}
+{{/parent}}
+{{#vars}}
     sb.append("    {{name}}: ").append(toIndentedString({{name}})).append("\n");
-    {{/vars}}
-    sb.append("}");
-    return sb.toString();
+{{/vars}}
+  sb.append("}");
+  return sb.toString();
   }
 
   /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
+  * Convert the given object to string with each line indented by 4 spaces
+  * (except the first line).
+  */
   private{{#jsonb}} static{{/jsonb}} String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
+  if (o == null) {
+  return "null";
+  }
+  return o.toString().replace("\n", "\n    ");
   }
 {{#supportUrlQuery}}
 
@@ -380,7 +393,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
         {{#uniqueItems}}
             if ({{getter}}() != null) {
             int i = 0;
-            for ({{items.dataType}} _item : {{getter}}()) {
+            for ({{{items.dataType}}} _item : {{getter}}()) {
             try {
             joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
             "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
@@ -413,8 +426,8 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
           {{#uniqueItems}}
               if ({{getter}}() != null) {
               int i = 0;
-              for ({{items.dataType}} _item : {{getter}}()) {
-              if ({{getter}}().get(i) != null) {
+              for ({{{items.dataType}}} _item : {{getter}}()) {
+              if (_item != null) {
               joiner.add(_item.toUrlQueryString(String.format("%s{{baseName}}%s%s", prefix, suffix,
               "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix))));
               }
@@ -437,12 +450,12 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
           {{#uniqueItems}}
               if ({{getter}}() != null) {
               int i = 0;
-              for ({{items.dataType}} _item : {{getter}}()) {
+              for ({{{items.dataType}}} _item : {{getter}}()) {
               if (_item != null) {
               try {
               joiner.add(String.format("%s{{baseName}}%s%s=%s", prefix, suffix,
-              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix)),
-              URLEncoder.encode(String.valueOf(_item), "UTF-8").replaceAll("\\+", "%20"));
+              "".equals(suffix) ? "" : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+              URLEncoder.encode(String.valueOf(_item), "UTF-8").replaceAll("\\+", "%20")));
               } catch (UnsupportedEncodingException e) {
               // Should never happen, UTF-8 is always supported
               throw new RuntimeException(e);
@@ -535,61 +548,62 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 {{/supportUrlQuery}}
 {{#parcelableModel}}
 
-  public void writeToParcel(Parcel out, int flags) {
-{{#model}}
-{{#isArray}}
-    out.writeList(this);
-{{/isArray}}
-{{^isArray}}
-{{#parent}}
-    super.writeToParcel(out, flags);
-{{/parent}}
-{{#vars}}
-    out.writeValue({{name}});
-{{/vars}}
-{{/isArray}}
-{{/model}}
-  }
+    public void writeToParcel(Parcel out, int flags) {
+  {{#model}}
+    {{#isArray}}
+        out.writeList(this);
+    {{/isArray}}
+    {{^isArray}}
+      {{#parent}}
+          super.writeToParcel(out, flags);
+      {{/parent}}
+      {{#vars}}
+          out.writeValue({{name}});
+      {{/vars}}
+    {{/isArray}}
+  {{/model}}
+    }
 
   {{classname}}(Parcel in) {
-{{#isArray}}
-    in.readTypedList(this, {{arrayModelType}}.CREATOR);
-{{/isArray}}
-{{^isArray}}
-{{#parent}}
-    super(in);
-{{/parent}}
-{{#vars}}
-{{#isPrimitiveType}}
-    {{name}} = ({{{datatypeWithEnum}}})in.readValue(null);
-{{/isPrimitiveType}}
-{{^isPrimitiveType}}
-    {{name}} = ({{{datatypeWithEnum}}})in.readValue({{complexType}}.class.getClassLoader());
-{{/isPrimitiveType}}
-{{/vars}}
-{{/isArray}}
-  }
+  {{#isArray}}
+      in.readTypedList(this, {{arrayModelType}}.CREATOR);
+  {{/isArray}}
+  {{^isArray}}
+    {{#parent}}
+        super(in);
+    {{/parent}}
+    {{#vars}}
+      {{#isPrimitiveType}}
+        {{name}} = ({{{datatypeWithEnum}}})in.readValue(null);
+      {{/isPrimitiveType}}
+      {{^isPrimitiveType}}
+        {{name}} = ({{{datatypeWithEnum}}})in.readValue({{complexType}}.class.getClassLoader());
+      {{/isPrimitiveType}}
+    {{/vars}}
+  {{/isArray}}
+    }
 
-  public int describeContents() {
+    public int describeContents() {
     return 0;
-  }
+    }
 
-  public static final Parcelable.Creator<{{classname}}> CREATOR = new Parcelable.Creator<{{classname}}>() {
+    public static final Parcelable.Creator<{{classname}}> CREATOR = new Parcelable.Creator<{{classname}}>() {
     public {{classname}} createFromParcel(Parcel in) {
-{{#model}}
-{{#isArray}}
+  {{#model}}
+    {{#isArray}}
       {{classname}} result = new {{classname}}();
-      result.addAll(in.readArrayList({{arrayModelType}}.class.getClassLoader()));
-      return result;
-{{/isArray}}
-{{^isArray}}
-      return new {{classname}}(in);
-{{/isArray}}
-{{/model}}
+        result.addAll(in.readArrayList({{arrayModelType}}.class.getClassLoader()));
+        return result;
+    {{/isArray}}
+    {{^isArray}}
+        return new {{classname}}(in);
+    {{/isArray}}
+  {{/model}}
     }
     public {{classname}}[] newArray(int size) {
-      return new {{classname}}[size];
+    return new {{classname}}[size];
     }
-  };
+    };
 {{/parcelableModel}}
-}
+
+  }

--- a/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
@@ -1,25 +1,27 @@
 /**
- * {{description}}{{^description}}{{classname}}{{/description}}
- */
+* {{description}}{{^description}}{{classname}}{{/description}}
+*/
 {{>additionalModelTypeAnnotations}}
 {{#description}}
-{{#swagger1AnnotationLibrary}}
-@ApiModel(description = "{{{description}}}")
-{{/swagger1AnnotationLibrary}}
-{{#swagger2AnnotationLibrary}}
-@Schema({{#name}}name = "{{name}}", {{/name}}description = "{{{description}}}")
-{{/swagger2AnnotationLibrary}}
+  {{#swagger1AnnotationLibrary}}
+    @ApiModel(description = "{{{description}}}")
+  {{/swagger1AnnotationLibrary}}
+  {{#swagger2AnnotationLibrary}}
+    @Schema({{#name}}name = "{{name}}", {{/name}}description = "{{{description}}}")
+  {{/swagger2AnnotationLibrary}}
 {{/description}}
 {{#discriminator}}
-{{>typeInfoAnnotation}}
+  {{>typeInfoAnnotation}}
 {{/discriminator}}
 {{#jackson}}
-{{#isClassnameSanitized}}
-@JsonTypeName("{{name}}")
-{{/isClassnameSanitized}}
+  {{#isClassnameSanitized}}
+    {{^hasDiscriminatorWithNonEmptyMapping}}
+      @JsonTypeName("{{name}}")
+    {{/hasDiscriminatorWithNonEmptyMapping}}
+  {{/isClassnameSanitized}}
 {{/jackson}}
 {{#withXml}}
-{{>xmlAnnotation}}
+  {{>xmlAnnotation}}
 {{/withXml}}
 {{>generatedAnnotation}}
 {{#useLombokAnnotations}}
@@ -27,33 +29,32 @@
 @lombok.ToString(onlyExplicitlyIncluded = true, doNotUseGetters = true{{#parent}}, callSuper = true{{/parent}})
 {{/useLombokAnnotations}}
 {{#vendorExtensions.x-class-extra-annotation}}
-{{{vendorExtensions.x-class-extra-annotation}}}
+  {{{vendorExtensions.x-class-extra-annotation}}}
 {{/vendorExtensions.x-class-extra-annotation}}
 public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}{{#hateoas}} extends RepresentationModel<{{classname}}> {{/hateoas}}{{/parent}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
 {{#serializableModel}}
 
   private static final long serialVersionUID = 1L;
 {{/serializableModel}}
-  {{#vars}}
+{{#vars}}
 
-    {{#isEnum}}
+  {{#isEnum}}
     {{^isContainer}}
-{{>enumClass}}
+      {{>enumClass}}
     {{/isContainer}}
     {{#isContainer}}
-    {{#mostInnerItems}}
-{{>enumClass}}
-    {{/mostInnerItems}}
+      {{#mostInnerItems}}
+        {{>enumClass}}
+      {{/mostInnerItems}}
     {{/isContainer}}
-    {{/isEnum}}
+  {{/isEnum}}
   {{#jackson}}
-  @JsonProperty("{{baseName}}")
-  {{#withXml}}
-  @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}localName = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
-  {{/withXml}}
+    {{#withXml}}
+      @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{.}}", {{/xmlNamespace}}localName = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    {{/withXml}}
   {{/jackson}}
   {{#gson}}
-  @SerializedName("{{baseName}}")
+    @SerializedName("{{baseName}}")
   {{/gson}}
   {{#useLombokAnnotations}}
   @lombok.Getter{{#swagger1AnnotationLibrary}}(onMethod_ = @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}")){{/swagger1AnnotationLibrary}}
@@ -62,234 +63,267 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
   @lombok.ToString.Include
   {{#vendorExtensions.x-extra-annotation}}
   {{#indent4}}{{{vendorExtensions.x-extra-annotation}}}{{/indent4}}{{/vendorExtensions.x-extra-annotation}}
-  {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}
   {{/useLombokAnnotations}}
   {{#vendorExtensions.x-field-extra-annotation}}
-  {{{vendorExtensions.x-field-extra-annotation}}}
+    {{{vendorExtensions.x-field-extra-annotation}}}
   {{/vendorExtensions.x-field-extra-annotation}}
   {{#isContainer}}
-  {{#openApiNullable}}
-  private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
-  {{/openApiNullable}}
-  {{^openApiNullable}}
-  private {{>nullableDataType}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
-  {{/openApiNullable}}
+    {{#useBeanValidation}}@Valid{{/useBeanValidation}}
+    {{#openApiNullable}}
+      private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
+    {{/openApiNullable}}
+    {{^openApiNullable}}
+      private {{>nullableDataType}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+    {{/openApiNullable}}
   {{/isContainer}}
   {{^isContainer}}
-  {{#isDate}}
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-  {{/isDate}}
-  {{#isDateTime}}
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  {{/isDateTime}}
-  {{#openApiNullable}}
-  private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
-  {{/openApiNullable}}
-  {{^openApiNullable}}
-  private {{>nullableDataType}} {{name}}{{#isNullable}} = null{{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
-  {{/openApiNullable}}
+    {{#isDate}}
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    {{/isDate}}
+    {{#isDateTime}}
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    {{/isDateTime}}
+    {{#openApiNullable}}
+      private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
+    {{/openApiNullable}}
+    {{^openApiNullable}}
+      private {{>nullableDataType}} {{name}}{{#isNullable}} = null{{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
+    {{/openApiNullable}}
   {{/isContainer}}
-  {{/vars}}
-  {{#vars}}
+{{/vars}}
+{{#generatedConstructorWithRequiredArgs}}
+  {{#hasRequired}}
+
+    /**
+    * Default constructor
+    * @deprecated Use {@link {{classname}}#{{classname}}({{#requiredVars}}{{{datatypeWithEnum}}}{{^-last}}, {{/-last}}{{/requiredVars}})}
+    */
+    @Deprecated
+    public {{classname}}() {
+    super();
+    }
+
+    /**
+    * Constructor with only required parameters
+    */
+    public {{classname}}({{#requiredVars}}{{{datatypeWithEnum}}} {{name}}{{^-last}}, {{/-last}}{{/requiredVars}}) {
+    {{#parent}}
+      super({{#parentRequiredVars}}{{name}}{{^-last}}, {{/-last}}{{/parentRequiredVars}});
+    {{/parent}}
+    {{#vars}}
+      {{#required}}
+        {{#openApiNullable}}
+          this.{{name}} = {{#isNullable}}JsonNullable.of({{name}}){{/isNullable}}{{^isNullable}}{{name}}{{/isNullable}};
+        {{/openApiNullable}}
+        {{^openApiNullable}}
+          this.{{name}} = {{name}};
+        {{/openApiNullable}}
+      {{/required}}
+    {{/vars}}
+    }
+  {{/hasRequired}}
+{{/generatedConstructorWithRequiredArgs}}
+{{#vars}}
 
   {{! begin feature: fluent setter methods }}
   public {{classname}} {{#useWithModifiers}}with{{nameInCamelCase}}{{/useWithModifiers}}{{^useWithModifiers}}{{name}}{{/useWithModifiers}}({{{datatypeWithEnum}}} {{name}}) {
     {{#openApiNullable}}
     this.{{name}} = {{#isNullable}}JsonNullable.of({{name}}){{/isNullable}}{{^isNullable}}{{name}}{{/isNullable}};
-    {{/openApiNullable}}
-    {{^openApiNullable}}
+  {{/openApiNullable}}
+  {{^openApiNullable}}
     this.{{name}} = {{name}};
-    {{/openApiNullable}}
-    return this;
+  {{/openApiNullable}}
+  return this;
   }
   {{#isArray}}
 
-  public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
     {{#openApiNullable}}
-    {{^required}}
-    if (this.{{name}} == null{{#isNullable}} || !this.{{name}}.isPresent(){{/isNullable}}) {
-        this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}}{{#isNullable}}){{/isNullable}};
-    }
-    {{/required}}
-    this.{{name}}{{#isNullable}}.get(){{/isNullable}}.add({{name}}Item);
+      if (this.{{name}} == null{{#isNullable}} || !this.{{name}}.isPresent(){{/isNullable}}) {
+      this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}}{{#isNullable}}){{/isNullable}};
+      }
+      this.{{name}}{{#isNullable}}.get(){{/isNullable}}.add({{name}}Item);
     {{/openApiNullable}}
     {{^openApiNullable}}
-    if (this.{{name}} == null) {
+      if (this.{{name}} == null) {
       this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
-    }
-    this.{{name}}.add({{name}}Item);
+      }
+      this.{{name}}.add({{name}}Item);
     {{/openApiNullable}}
     return this;
-  }
+    }
   {{/isArray}}
   {{#isMap}}
 
-  {{#openApiNullable}}
-  {{#isNullable}}
-  public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
-  {{^required}}
-      if (this.{{name}} == null) {
-        this.{{name}} = JsonNullable.of({{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}});
-      }
-  {{/required}}
-      this.{{name}}.get().put(key, {{name}}Item);
-      return this;
-  }
-  {{/isNullable}}
-  {{^isNullable}}
-  public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
-  {{^required}}
+    {{#openApiNullable}}
+      {{#isNullable}}
+        public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+        {{^required}}
+          if (this.{{name}} == null) {
+          this.{{name}} = JsonNullable.of({{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}});
+          }
+        {{/required}}
+        this.{{name}}.get().put(key, {{name}}Item);
+        return this;
+        }
+      {{/isNullable}}
+      {{^isNullable}}
+        public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+        {{^required}}
 
-      if (this.{{name}} == null) {
+          if (this.{{name}} == null) {
+          this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}};
+          }
+        {{/required}}
+        this.{{name}}.put(key, {{name}}Item);
+        return this;
+        }
+      {{/isNullable}}
+    {{/openApiNullable}}
+    {{^openApiNullable}}
+      public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+      {{^required}}
+
+        if (this.{{name}} == null) {
         this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}};
-      }
-  {{/required}}
+        }
+      {{/required}}
       this.{{name}}.put(key, {{name}}Item);
       return this;
-  }
-  {{/isNullable}}
-  {{/openApiNullable}}
-  {{^openApiNullable}}
-      public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
-  {{^required}}
-
-      if (this.{{name}} == null) {
-      this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new HashMap<>(){{/defaultValue}};
       }
-  {{/required}}
-    this.{{name}}.put(key, {{name}}Item);
-    return this;
-  }
-  {{/openApiNullable}}
-{{/isMap}}
+    {{/openApiNullable}}
+  {{/isMap}}
   {{! end feature: fluent setter methods }}
   {{! begin feature: getter and setter }}
 
 {{^useLombokAnnotations}}
   /**
   {{#description}}
-   * {{{.}}}
+    * {{{.}}}
   {{/description}}
   {{^description}}
-   * Get {{name}}
+    * Get {{name}}
   {{/description}}
   {{#minimum}}
-   * minimum: {{.}}
+    * minimum: {{.}}
   {{/minimum}}
   {{#maximum}}
-   * maximum: {{.}}
+    * maximum: {{.}}
   {{/maximum}}
-   * @return {{name}}
+  * @return {{name}}
   */
   {{#vendorExtensions.x-extra-annotation}}
-  {{{vendorExtensions.x-extra-annotation}}}
+    {{{vendorExtensions.x-extra-annotation}}}
   {{/vendorExtensions.x-extra-annotation}}
   {{#useBeanValidation}}
-  {{>beanValidation}}
+    {{>beanValidation}}
   {{/useBeanValidation}}
   {{^useBeanValidation}}
-  {{#required}}@NotNull{{/required}}
+    {{#required}}@NotNull{{/required}}
   {{/useBeanValidation}}
   {{#swagger2AnnotationLibrary}}
     @Schema(name = "{{{baseName}}}"{{#isReadOnly}}, accessMode = Schema.AccessMode.READ_ONLY{{/isReadOnly}}{{#example}}, example = "{{{.}}}"{{/example}}{{#description}}, description = "{{{.}}}"{{/description}}, requiredMode = {{#required}}Schema.RequiredMode.REQUIRED{{/required}}{{^required}}Schema.RequiredMode.NOT_REQUIRED{{/required}})
   {{/swagger2AnnotationLibrary}}
   {{#swagger1AnnotationLibrary}}
-  @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}")
+    @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}")
   {{/swagger1AnnotationLibrary}}
+  {{#jackson}}
+    @JsonProperty("{{baseName}}")
+  {{/jackson}}
   public {{>nullableDataType}} {{getter}}() {
-    return {{name}};
+  return {{name}};
   }
 
   {{#vendorExtensions.x-setter-extra-annotation}}
-  {{{vendorExtensions.x-setter-extra-annotation}}}
+    {{{vendorExtensions.x-setter-extra-annotation}}}
   {{/vendorExtensions.x-setter-extra-annotation}}
   public void {{setter}}({{>nullableDataType}} {{name}}) {
-    this.{{name}} = {{name}};
+  this.{{name}} = {{name}};
   }
   {{/useLombokAnnotations}}
   {{! end feature: getter and setter }}
   {{/vars}}
   {{#parentVars}}
 
-  {{! begin feature: fluent setter methods for inherited properties }}
+{{! begin feature: fluent setter methods for inherited properties }}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
-    super.{{setter}}({{name}});
-    return this;
+  super.{{setter}}({{name}});
+  return this;
   }
   {{#isArray}}
 
-  public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
     super.add{{nameInCamelCase}}Item({{name}}Item);
     return this;
-  }
+    }
   {{/isArray}}
   {{#isMap}}
 
-  public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+    public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
     super.put{{nameInCamelCase}}Item(key, {{name}}Item);
     return this;
-  }
+    }
   {{/isMap}}
-  {{! end feature: fluent setter methods for inherited properties }}
-  {{/parentVars}}
+{{! end feature: fluent setter methods for inherited properties }}
+{{/parentVars}}
 
 {{^useLombokAnnotations}}
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }{{#hasVars}}
+  if (this == o) {
+  return true;
+  }
+  if (o == null || getClass() != o.getClass()) {
+  return false;
+  }{{#hasVars}}
     {{classname}} {{classVarName}} = ({{classname}}) o;
     return {{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}equalsNullable(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}} &&
-        {{/-last}}{{/vars}}{{#parent}} &&
-        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    {{/-last}}{{/vars}}{{#parent}} &&
+    super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
     return true;{{/hasVars}}
   }
   {{#vendorExtensions.x-jackson-optional-nullable-helpers}}
 
-  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
-    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
-  }
+    private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+      return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+      }
   {{/vendorExtensions.x-jackson-optional-nullable-helpers}}
 
-  @Override
-  public int hashCode() {
+    @Override
+    public int hashCode() {
     return Objects.hash({{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}hashCodeNullable({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
-  }
+    }
   {{#vendorExtensions.x-jackson-optional-nullable-helpers}}
 
-  private static <T> int hashCodeNullable(JsonNullable<T> a) {
-    if (a == null) {
+      private static <T> int hashCodeNullable(JsonNullable<T> a) {
+      if (a == null) {
       return 1;
-    }
-    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
-  }
+      }
+      return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+      }
   {{/vendorExtensions.x-jackson-optional-nullable-helpers}}
 
-  @Override
-  public String toString() {
+    @Override
+    public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class {{classname}} {\n");
-    {{#parent}}
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-    {{/parent}}
-    {{#vars}}sb.append("    {{name}}: ").append(toIndentedString({{name}})).append("\n");
-    {{/vars}}sb.append("}");
+  {{#parent}}
+      sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+  {{/parent}}
+  {{#vars}}sb.append("    {{name}}: ").append(toIndentedString({{name}})).append("\n");
+  {{/vars}}sb.append("}");
     return sb.toString();
-  }
+    }
 
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(Object o) {
     if (o == null) {
-      return "null";
+    return "null";
     }
     return o.toString().replace("\n", "\n    ");
-  }
+    }
   {{/useLombokAnnotations}}
 }


### PR DESCRIPTION
With every openapi-generator bump, we should review the mustache templates. Those templates which contain custom changes like `useLombokAnnotations` are more prone to error with new updates. In this PR pojo templates have been updated.