### PR TITLE
Fix single, string typed example on media type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The project is very much Work In Progress and will be published on maven central
 
 # Release Notes
 BOAT is still under development and subject to change.
+
+## Unreleased
+* Boat engine
+  * Fix: Processing of a single string type example on media-type.
 ## 0.16.14
 * Boat Angular generator
   * New format for Angular mocks, which are now export an array with responses.

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExampleHolder.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExampleHolder.java
@@ -121,6 +121,24 @@ public abstract class ExampleHolder<T> {
         }
     }
 
+    private static class StringExampleHolder extends ExampleHolder<String> {
+
+        private StringExampleHolder(String name, String value) {
+            super(name, value);
+            setContent(value);
+        }
+
+        @Override
+        String getRef() {
+            return null;
+        }
+
+        @Override
+        void replaceRef(String ref) {
+            // do nothing
+        }
+    }
+
     private final String name;
 
     private T example;
@@ -163,8 +181,11 @@ public abstract class ExampleHolder<T> {
             }
         } else if( o instanceof ArrayNode) {
             return new ArrayNodeExampleHolder(name, (ArrayNode) o);
+        } else if (o instanceof String) {
+            return new StringExampleHolder(name, o.toString());
         } else {
-            throw new TransformerException("Unknown type backing example " + o.getClass().getName());
+            throw new TransformerException(String.format(
+                    "Unknown type backing example %s (%s) '%s'", name, o.getClass().getName(), o));
         }
     }
 

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
@@ -22,6 +22,10 @@ paths:
                 $ref: '#/components/schemas/UserPostResponse'
               example:
                 $ref: ./examples/user-post-response.json
+            csv:
+              example: |-
+                UserId,Username 
+                aaaa-bbbb-cccc,John
     post:
       summary: Single example
       requestBody:


### PR DESCRIPTION
According to open api spec, the single example on a media type can be Any type.  eg
```
  /users:
    get:
      responses:
        '200':
          content:
            csv:
              example: |-
                UserId,Username 
                aaaa-bbbb-cccc,John
```
When the spec contains a string value, the bundling (or code generation) could fail with

```
[ERROR] com.backbase.oss.boat.transformers.TransformerException: Unknown type backing example java.lang.String
    at com.backbase.oss.boat.transformers.bundler.ExampleHolder.of (ExampleHolder.java:167)
    at com.backbase.oss.boat.transformers.bundler.ExamplesProcessor.processMediaType (ExamplesProcessor.java:115) <...>
```