### PR TITLE
add a workaround for default value instantiation

### DIFF
--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatJavaCodeGen.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatJavaCodeGen.java
@@ -1,34 +1,28 @@
 package com.backbase.oss.codegen.java;
 
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.Locale;
 import lombok.Getter;
 import lombok.Setter;
 import org.openapitools.codegen.CliOption;
-import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.languages.JavaClientCodegen;
+import org.openapitools.codegen.utils.ModelUtils;
 
 public class BoatJavaCodeGen extends JavaClientCodegen {
 
     public static final String NAME = "boat-java";
 
     public static final String USE_WITH_MODIFIERS = "useWithModifiers";
-    public static final String USE_SET_FOR_UNIQUE_ITEMS = "useSetForUniqueItems";
-
     public static final String USE_CLASS_LEVEL_BEAN_VALIDATION = "useClassLevelBeanValidation";
     public static final String USE_JACKSON_CONVERSION = "useJacksonConversion";
-
     public static final String USE_DEFAULT_API_CLIENT = "useDefaultApiClient";
     public static final String REST_TEMPLATE_BEAN_NAME = "restTemplateBeanName";
     public static final String CREATE_API_COMPONENT = "createApiComponent";
     public static final String USE_PROTECTED_FIELDS = "useProtectedFields";
-    private static final String JAVA_UTIL_SET = "java.util.Set";
-
     @Setter
     @Getter
     protected boolean useWithModifiers;
-    @Setter
-    @Getter
-    protected boolean useSetForUniqueItems;
     @Setter
     @Getter
     protected boolean useClassLevelBeanValidation;
@@ -76,26 +70,10 @@ public class BoatJavaCodeGen extends JavaClientCodegen {
     public void processOpts() {
         super.processOpts();
 
-        if (WEBCLIENT.equals(getLibrary())) {
-            this.useSetForUniqueItems = false;
-        }
-
         if (this.additionalProperties.containsKey(USE_WITH_MODIFIERS)) {
             this.useWithModifiers = convertPropertyToBoolean(USE_WITH_MODIFIERS);
         }
         writePropertyBack(USE_WITH_MODIFIERS, this.useWithModifiers);
-
-        if (this.additionalProperties.containsKey(USE_SET_FOR_UNIQUE_ITEMS)) {
-            this.useSetForUniqueItems = convertPropertyToBoolean(USE_SET_FOR_UNIQUE_ITEMS);
-        }
-        writePropertyBack(USE_SET_FOR_UNIQUE_ITEMS, this.useSetForUniqueItems);
-
-        if (this.useSetForUniqueItems) {
-            this.typeMapping.put("set", JAVA_UTIL_SET);
-
-            this.importMapping.put("Set", JAVA_UTIL_SET);
-            this.importMapping.put("LinkedHashSet", "java.util.LinkedHashSet");
-        }
 
         if (RESTTEMPLATE.equals(getLibrary())) {
             processRestTemplateOpts();
@@ -141,24 +119,23 @@ public class BoatJavaCodeGen extends JavaClientCodegen {
     }
 
     @Override
-    public void postProcessModelProperty(CodegenModel model, CodegenProperty p) {
-        super.postProcessModelProperty(model, p);
-
-        if (!fullJavaUtil) {
-            if ("array".equals(p.containerType)) {
-                model.imports.add(instantiationTypes.get("array"));
-            } else if ("set".equals(p.containerType)) {
-                model.imports.add(instantiationTypes.get("set"));
-                boolean canNotBeWrappedToNullable = !openApiNullable || !p.isNullable;
-                if (canNotBeWrappedToNullable) {
-                    model.imports.add("JsonDeserialize");
-                    p.vendorExtensions.put("x-setter-extra-annotation", "@JsonDeserialize(as = " + instantiationTypes.get("set") + ".class)");
+    public String toDefaultValue(CodegenProperty cp, Schema schema) {
+        schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
+        if (ModelUtils.isArraySchema(schema) && (schema.getDefault() == null)) {
+                if (cp.isNullable || containerDefaultToNull) {
+                    return null;
+                } else {
+                    if (ModelUtils.isSet(schema)) {
+                        return String.format(Locale.ROOT, "new %s<>()",
+                            instantiationTypes().getOrDefault("set", "LinkedHashSet"));
+                    } else {
+                        return String.format(Locale.ROOT, "new %s<>()",
+                            instantiationTypes().getOrDefault("array", "ArrayList"));
+                    }
                 }
-            } else if ("map".equals(p.containerType)) {
-                model.imports.add(instantiationTypes.get("map"));
-            }
-        }
 
+        }
+        return super.toDefaultValue(cp, schema);
     }
 
 }

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatJavaCodeGen.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatJavaCodeGen.java
@@ -122,20 +122,25 @@ public class BoatJavaCodeGen extends JavaClientCodegen {
     public String toDefaultValue(CodegenProperty cp, Schema schema) {
         schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
         if (ModelUtils.isArraySchema(schema) && (schema.getDefault() == null)) {
-                if (cp.isNullable || containerDefaultToNull) {
-                    return null;
-                } else {
-                    if (ModelUtils.isSet(schema)) {
-                        return String.format(Locale.ROOT, "new %s<>()",
-                            instantiationTypes().getOrDefault("set", "LinkedHashSet"));
-                    } else {
-                        return String.format(Locale.ROOT, "new %s<>()",
-                            instantiationTypes().getOrDefault("array", "ArrayList"));
-                    }
-                }
-
+            return getArrayDefaultValue(cp, schema, containerDefaultToNull,
+                instantiationTypes().getOrDefault("set", "LinkedHashSet"),
+                instantiationTypes().getOrDefault("array", "ArrayList"));
         }
         return super.toDefaultValue(cp, schema);
     }
 
+    public static String getArrayDefaultValue(CodegenProperty cp, Schema schema,
+        boolean containerDefaultToNull, String setType, String arrayType) {
+        if (cp.isNullable || containerDefaultToNull) {
+            return null;
+        } else {
+            if (ModelUtils.isSet(schema)) {
+                return String.format(Locale.ROOT, "new %s<>()",
+                    setType);
+            } else {
+                return String.format(Locale.ROOT, "new %s<>()",
+                    arrayType);
+            }
+        }
+    }
 }

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatSpringCodeGen.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatSpringCodeGen.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.models.servers.Server;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.IntStream;
 import lombok.Getter;
 import lombok.Setter;
@@ -261,18 +260,9 @@ public class BoatSpringCodeGen extends SpringCodegen {
     public String toDefaultValue(CodegenProperty cp, Schema schema) {
         schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
         if (ModelUtils.isArraySchema(schema) && (schema.getDefault() == null)) {
-                if (cp.isNullable || containerDefaultToNull) {
-                    return null;
-                } else {
-                    if (ModelUtils.isSet(schema)) {
-                        return String.format(Locale.ROOT, "new %s<>()",
-                            instantiationTypes().getOrDefault("set", "LinkedHashSet"));
-                    } else {
-                        return String.format(Locale.ROOT, "new %s<>()",
-                            instantiationTypes().getOrDefault("array", "ArrayList"));
-                    }
-                }
-
+            return BoatJavaCodeGen.getArrayDefaultValue(cp, schema, containerDefaultToNull,
+                instantiationTypes().getOrDefault("set", "LinkedHashSet"),
+                instantiationTypes().getOrDefault("array", "ArrayList"));
         }
         return super.toDefaultValue(cp, schema);
     }

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatJavaCodeGenTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatJavaCodeGenTests.java
@@ -38,7 +38,6 @@ class BoatJavaCodeGenTests {
         gen.processOpts();
 
         assertThat(gen.useWithModifiers, is(false));
-        assertThat(gen.useSetForUniqueItems, is(false));
         assertThat(gen.useClassLevelBeanValidation, is(false));
 
         assertThat(gen.useJacksonConversion, is(false));
@@ -53,7 +52,6 @@ class BoatJavaCodeGenTests {
 
         gen.setLibrary("resttemplate");
         options.put(USE_WITH_MODIFIERS, "true");
-        options.put(USE_SET_FOR_UNIQUE_ITEMS, "true");
         options.put(USE_CLASS_LEVEL_BEAN_VALIDATION, "true");
 
         options.put(USE_JACKSON_CONVERSION, "true");
@@ -63,7 +61,6 @@ class BoatJavaCodeGenTests {
         gen.processOpts();
 
         assertThat(gen.useWithModifiers, is(true));
-        assertThat(gen.useSetForUniqueItems, is(true));
         assertThat(gen.useClassLevelBeanValidation, is(true));
 
         assertThat(gen.useJacksonConversion, is(true));
@@ -77,7 +74,6 @@ class BoatJavaCodeGenTests {
         final Map<String, Object> options = gen.additionalProperties();
 
         options.put(USE_WITH_MODIFIERS, "true");
-        options.put(USE_SET_FOR_UNIQUE_ITEMS, "true");
         options.put(USE_CLASS_LEVEL_BEAN_VALIDATION, "true");
 
         options.put(USE_JACKSON_CONVERSION, "true");
@@ -87,7 +83,6 @@ class BoatJavaCodeGenTests {
         gen.processOpts();
 
         assertThat(gen.useWithModifiers, is(true));
-        assertThat(gen.useSetForUniqueItems, is(true));
         assertThat(gen.useClassLevelBeanValidation, is(false));
 
         assertThat(gen.useJacksonConversion, is(false));
@@ -120,112 +115,4 @@ class BoatJavaCodeGenTests {
         assertThat(gen.additionalProperties(), hasEntry("modelFieldsVisibility", "protected"));
     }
 
-    @Test
-    @Disabled("Since useSetForUniqueItems is not supported and it is enabled by default")
-    void uniquePropertyToSet() {
-        final BoatJavaCodeGen gen = new BoatJavaCodeGen();
-        final CodegenProperty prop = new CodegenProperty();
-
-        gen.useSetForUniqueItems = true;
-        prop.isContainer = true;
-        prop.setUniqueItems(true);
-        prop.items = new CodegenProperty();
-        prop.items.dataType = "String";
-        prop.baseType = "java.util.List";
-        prop.dataType = "java.util.List<String>";
-
-        gen.postProcessModelProperty(new CodegenModel(), prop);
-
-        assertThat(prop.containerType, is("set"));
-        assertThat(prop.baseType, is("java.util.Set"));
-        assertThat(prop.dataType, is("java.util.Set<String>"));
-    }
-
-    @Test
-    @Disabled("Since useSetForUniqueItems is not supported and it is enabled by default")
-    void uniqueParameterToSet() {
-        final BoatJavaCodeGen gen = new BoatJavaCodeGen();
-        final CodegenParameter param = new CodegenParameter();
-
-        gen.useSetForUniqueItems = true;
-        param.isContainer = true;
-        param.setUniqueItems(true);
-        param.items = new CodegenProperty();
-        param.items.dataType = "String";
-        param.baseType = "java.util.List<String>";
-        param.dataType = "java.util.List<String>";
-
-        gen.postProcessParameter(param);
-
-        assertThat(param.baseType, is("java.util.Set"));
-        assertThat(param.dataType, is("java.util.Set<String>"));
-    }
-
-    @Test
-    void setTypeMappingForList() {
-        final BoatJavaCodeGen gen = new BoatJavaCodeGen();
-        gen.setFullJavaUtil(false);
-        gen.instantiationTypes().put("set", "ArrayList");
-        gen.typeMapping().put("set", "List");
-
-        final CodegenProperty prop = new CodegenProperty();
-        prop.isContainer = true;
-        prop.containerType = "set";
-        prop.setUniqueItems(true);
-        prop.items = new CodegenProperty();
-        prop.items.dataType = "String";
-        prop.baseType = "java.util.Set";
-        prop.dataType = "java.util.HashSet<String>";
-
-        final var model = new CodegenModel();
-
-        gen.postProcessModelProperty(model, prop);
-
-        assertTrue(model.getImports().contains("ArrayList"));
-    }
-
-    @Test
-    void arrayTypeMappingForList() {
-        final BoatJavaCodeGen gen = new BoatJavaCodeGen();
-        gen.setFullJavaUtil(false);
-        gen.instantiationTypes().put("array", "ArrayList");
-        gen.typeMapping().put("array", "List");
-
-        final CodegenProperty prop = new CodegenProperty();
-        prop.isContainer = true;
-        prop.containerType = "array";
-        prop.setUniqueItems(true);
-        prop.items = new CodegenProperty();
-        prop.items.dataType = "String";
-        prop.baseType = "java.util.Set";
-        prop.dataType = "java.util.HashSet<String>";
-
-        final var model = new CodegenModel();
-
-        gen.postProcessModelProperty(model, prop);
-
-        assertTrue(model.getImports().contains("ArrayList"));
-    }
-
-    @Test
-    void mapTypeMappingForMap() {
-        final BoatJavaCodeGen gen = new BoatJavaCodeGen();
-        gen.setFullJavaUtil(false);
-        gen.instantiationTypes().put("map", "TreeMap");
-
-        final CodegenProperty prop = new CodegenProperty();
-        prop.isContainer = true;
-        prop.containerType = "map";
-        prop.setUniqueItems(true);
-        prop.items = new CodegenProperty();
-        prop.items.dataType = "String";
-        prop.baseType = "java.util.Set";
-        prop.dataType = "java.util.HashSet<String>";
-
-        final var model = new CodegenModel();
-
-        gen.postProcessModelProperty(model, prop);
-
-        assertTrue(model.getImports().contains("TreeMap"));
-    }
 }

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
@@ -38,44 +38,6 @@ class BoatSpringCodeGenTests {
             .forEach((k, v) -> assertEquals(1, v.size(), k + " is described multiple times"));
     }
 
-    @Test
-    void uniquePropertyToSet() {
-        final BoatSpringCodeGen gen = new BoatSpringCodeGen();
-        final CodegenProperty prop = new CodegenProperty();
-
-        gen.useSetForUniqueItems = true;
-        prop.isContainer = true;
-        prop.setUniqueItems(true);
-        prop.items = new CodegenProperty();
-        prop.items.dataType = "String";
-        prop.baseType = "java.util.List";
-        prop.dataType = "java.util.List<String>";
-
-        gen.postProcessModelProperty(new CodegenModel(), prop);
-
-        assertThat(prop.containerType, is("set"));
-        assertThat(prop.baseType, is("java.util.Set"));
-        assertThat(prop.dataType, is("java.util.Set<String>"));
-    }
-
-    @Test
-    void uniqueParameterToSet() {
-        final BoatSpringCodeGen gen = new BoatSpringCodeGen();
-        final CodegenParameter param = new CodegenParameter();
-
-        gen.useSetForUniqueItems = true;
-        param.isContainer = true;
-        param.setUniqueItems(true);
-        param.items = new CodegenProperty();
-        param.items.dataType = "String";
-        param.baseType = "java.util.List<String>";
-        param.dataType = "java.util.List<String>";
-
-        gen.postProcessParameter(param);
-
-        assertThat(param.baseType, is("java.util.Set"));
-        assertThat(param.dataType, is("java.util.Set<String>"));
-    }
 
     @Test
     void processOptsUseProtectedFields() {

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringTemplatesTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringTemplatesTests.java
@@ -48,7 +48,6 @@ import org.openapitools.codegen.languages.features.OptionalFeatures;
 /**
  * These tests verify that the code generation works for various combinations of configuration
  * parameters; the projects that are generated are later compiled in the integration test phase.
- *
  * The suite is generated dynamically, read below.
  * <p>
  * With Junit4, the test hierarchy was {@code root-> combination -> method}. The code relied on that
@@ -72,7 +71,7 @@ class BoatSpringTemplatesTests {
     }
 
     static class Combination {
-        static final List<String> CASES = asList("flx", "unq", "val", "opt", "req", "bin", "lmb", "nbl", "wth", "utl");
+        static final List<String> CASES = asList("flx", "val", "opt", "req", "bin", "lmb", "wth", "utl");
 
         final String name;
 
@@ -82,8 +81,6 @@ class BoatSpringTemplatesTests {
         final boolean addServletRequest;
         final boolean addBindingResult;
         final boolean useLombokAnnotations;
-        final boolean openApiNullable;
-        final boolean useSetForUniqueItems;
         final boolean useWithModifiers;
 
         final boolean reactive;
@@ -102,8 +99,6 @@ class BoatSpringTemplatesTests {
             this.useOptional = (mask & 1 << CASES.indexOf("opt")) != 0;
             this.addServletRequest = (mask & 1 << CASES.indexOf("req")) != 0;
             this.useLombokAnnotations = (mask & 1 << CASES.indexOf("lmb")) != 0;
-            this.openApiNullable = (mask & 1 << CASES.indexOf("nbl")) != 0;
-            this.useSetForUniqueItems = (mask & 1 << CASES.indexOf("unq")) != 0;
             this.useWithModifiers = (mask & 1 << CASES.indexOf("wth")) != 0;
             this.reactive = (mask & 1 << CASES.indexOf("flx")) != 0;
             this.apiUtil = (mask & 1 << CASES.indexOf("utl")) != 0;
@@ -220,22 +215,6 @@ class BoatSpringTemplatesTests {
     }
 
     @Check
-    void openApiNullable() {
-        assertThat(findPattern("/api/.+\\.java$", "JsonNullable<[^>]+>"),
-            is(false));
-        assertThat(findPattern("/model/.+\\.java$", "JsonNullable<[^>]+>"),
-            equalTo(this.param.openApiNullable));
-    }
-
-    @Check
-    void useSetForUniqueItems() {
-        assertThat(findPattern("/api/.+\\.java$", "java\\.util\\.Set<.+>"),
-            equalTo(this.param.useSetForUniqueItems));
-        assertThat(findPattern("/model/.+\\.java$", "java\\.util\\.Set<.+>"),
-            equalTo(this.param.useSetForUniqueItems));
-    }
-
-    @Check
     void useWithModifiers() {
         assertThat(findPattern("/api/.+\\.java$", "\\s+with\\p{Upper}"),
             is(false));
@@ -280,12 +259,7 @@ class BoatSpringTemplatesTests {
         GlobalSettings.setProperty(CodegenConstants.MODELS, "");
         GlobalSettings.setProperty(CodegenConstants.MODEL_TESTS, "true");
         GlobalSettings.setProperty(CodegenConstants.MODEL_DOCS, "true");
-
-//        if (this.param.apiUtil) {
-            GlobalSettings.setProperty(CodegenConstants.SUPPORTING_FILES, "ApiUtil.java,pom.xml,OpenApiGeneratorApplication.java");
-//        } else {
-//            GlobalSettings.setProperty(CodegenConstants.SUPPORTING_FILES, "pom.xml");
-//        }
+        GlobalSettings.setProperty(CodegenConstants.SUPPORTING_FILES, "ApiUtil.java,pom.xml,OpenApiGeneratorApplication.java");
 
 
         gcf.setApiNameSuffix("-api");
@@ -303,8 +277,7 @@ class BoatSpringTemplatesTests {
             gcf.addAdditionalProperty(BeanValidationFeatures.USE_BEANVALIDATION, this.param.useBeanValidation);
         }
         gcf.addAdditionalProperty(BoatSpringCodeGen.USE_LOMBOK_ANNOTATIONS, this.param.useLombokAnnotations);
-        gcf.addAdditionalProperty(BoatSpringCodeGen.USE_SET_FOR_UNIQUE_ITEMS, this.param.useSetForUniqueItems);
-        gcf.addAdditionalProperty(BoatSpringCodeGen.OPENAPI_NULLABLE, this.param.openApiNullable);
+        gcf.addAdditionalProperty(BoatSpringCodeGen.OPENAPI_NULLABLE, false);
         gcf.addAdditionalProperty(BoatSpringCodeGen.USE_WITH_MODIFIERS, this.param.useWithModifiers);
         gcf.addAdditionalProperty(SpringCodegen.REACTIVE, this.param.reactive);
 


### PR DESCRIPTION
When using `<typeMapping>set=List</typeMapping>` and the field is not required, the generated `addItem*` method for array is incorrect (incorrect instantiation type). This is workaround for this bug until it get fixed in openapi-generator.

Also some cleanups for unused old customizations.