### PR TITLE
Fix single, string typed example on media type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The project is very much Work In Progress and will be published on maven central
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.17.5
+* Boat engine
+  * Fix: Processing of a single string type example on media-type.
 ## 0.17.4
 * Boat Angular generator
   * New format for Angular mocks, which are now export an array with responses.

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExampleHolder.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExampleHolder.java
@@ -121,6 +121,24 @@ public abstract class ExampleHolder<T> {
         }
     }
 
+    private static class StringExampleHolder extends ExampleHolder<String> {
+
+        private StringExampleHolder(String name, String value) {
+            super(name, value);
+            setContent(value);
+        }
+
+        @Override
+        String getRef() {
+            return null;
+        }
+
+        @Override
+        void replaceRef(String ref) {
+            // do nothing
+        }
+    }
+
     private final String name;
 
     private T example;
@@ -163,8 +181,11 @@ public abstract class ExampleHolder<T> {
             }
         } else if( o instanceof ArrayNode) {
             return new ArrayNodeExampleHolder(name, (ArrayNode) o);
+        } else if (o instanceof String) {
+            return new StringExampleHolder(name, o.toString());
         } else {
-            throw new TransformerException("Unknown type backing example " + o.getClass().getName());
+            throw new TransformerException(String.format(
+                    "Unknown type backing example %s (%s) '%s'", name, o.getClass().getName(), o));
         }
     }
 

--- a/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
+++ b/boat-engine/src/test/resources/openapi/bundler-examples-test-api/openapi.yaml
@@ -22,6 +22,10 @@ paths:
                 $ref: '#/components/schemas/UserPostResponse'
               example:
                 $ref: ./examples/user-post-response.json
+            csv:
+              example: |-
+                UserId,Username 
+                aaaa-bbbb-cccc,John
     post:
       summary: Single example
       requestBody:


### PR DESCRIPTION
copy of https://github.com/Backbase/backbase-openapi-tools/pull/576 to `main`