### PR TITLE
Add support for 'with modifier' in java template

### DIFF
--- a/boat-scaffold/src/main/templates/boat-java/pojo.mustache
+++ b/boat-scaffold/src/main/templates/boat-java/pojo.mustache
@@ -274,7 +274,7 @@ public {{classname}}() {
   {{#allVars}}
     {{#isOverridden}}
       @Override
-      public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
+      public {{classname}} {{#useWithModifiers}}with{{nameInCamelCase}}{{/useWithModifiers}}{{^useWithModifiers}}{{name}}{{/useWithModifiers}}({{{datatypeWithEnum}}} {{name}}) {
       {{#vendorExtensions.x-is-jackson-optional-nullable}}
         this.{{setter}}(JsonNullable.<{{{datatypeWithEnum}}}>of({{name}}));
       {{/vendorExtensions.x-is-jackson-optional-nullable}}


### PR DESCRIPTION
To ensure compatibility between `spring-boot` server stubs and `resttemplate` client code, (in case of using inheritance) method names have to be generated the same, meaning 'withModifier' needs to be supported on both.