### PR TITLE
Add validation on request params and map types

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ It currently consists of
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.17.14
+* boat-spring
+  * added validation constraints on primitive collection items types in request params (see `collectionDataTypeParam.mustache`)
+  * added validation constraints on primitive map value types (see `mapDataType.mustache`) 
 ## 0.17.13
 * boat-spring
   * Fix: generate validation constraints on primitive collection items types (updates in pojo.mustache and new collectionDataType.mustache)

--- a/boat-scaffold/src/main/templates/boat-spring/api.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/api.mustache
@@ -247,7 +247,7 @@ public interface {{classname}} {
         consumes = { {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }{{/hasConsumes}}{{/singleContentTypes}}
     )
     {{#jdk8-default-interface}}default {{/jdk8-default-interface}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{#delegate-method}}_{{/delegate-method}}{{operationId}}(
-        {{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{>cookieParams}}{{>httpServletParam}}{{^-last}},
+        {{#allParams}}{{#toOneLine}}{{>queryParams}}{{/toOneLine}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{>cookieParams}}{{>httpServletParam}}{{^-last}},
         {{/-last}}{{/allParams}}{{#reactive}}{{#hasParams}},
         {{/hasParams}}{{#swagger2AnnotationLibrary}}@Parameter(hidden = true){{/swagger2AnnotationLibrary}}{{#springFoxDocumentationProvider}}@ApiIgnore{{/springFoxDocumentationProvider}} final ServerWebExchange exchange{{/reactive}}{{#vendorExtensions.x-spring-paginated}}{{#hasParams}},
         {{/hasParams}}{{#springFoxDocumentationProvider}}@ApiIgnore {{/springFoxDocumentationProvider}}{{#springDocDocumentationProvider}}@ParameterObject {{/springDocDocumentationProvider}}final Pageable pageable{{/vendorExtensions.x-spring-paginated}}

--- a/boat-scaffold/src/main/templates/boat-spring/collectionDataType.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/collectionDataType.mustache
@@ -1,1 +1,20 @@
-{{#openApiNullable}}{{#isNullable}}JsonNullable<{{/isNullable}}{{/openApiNullable}}{{{baseType}}}<{{#items}}{{#isPrimitiveType}}{{>beanValidationCore}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{#useBeanValidation}}@Valid {{/useBeanValidation}}{{/isPrimitiveType}}{{/items}}{{{items.datatypeWithEnum}}}>{{#openApiNullable}}{{#isNullable}}>{{/isNullable}}{{/openApiNullable}}
+{{#openApiNullable}}
+  {{#isNullable}}JsonNullable<{{/isNullable}}
+{{/openApiNullable}}
+{{! apply collection type e.g. Set, List }}
+{{{baseType}}}<
+{{#useBeanValidation}}
+  {{#items}}
+    {{#isPrimitiveType}}
+      {{>beanValidationCore}}
+    {{/isPrimitiveType}}
+    {{^isPrimitiveType}}
+      @Valid
+    {{/isPrimitiveType}}
+  {{/items}}
+{{/useBeanValidation}}
+{{! apply collection item type }}
+{{{items.datatypeWithEnum}}}>
+{{#openApiNullable}}
+  {{#isNullable}}>{{/isNullable}}
+{{/openApiNullable}}

--- a/boat-scaffold/src/main/templates/boat-spring/collectionDataTypeParam.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/collectionDataTypeParam.mustache
@@ -1,0 +1,23 @@
+{{#isArray}}
+  {{#useBeanValidation}}
+    {{#uniqueItems}}java.util.Set{{/uniqueItems}}
+    {{^uniqueItems}}java.util.List{{/uniqueItems}}<
+    {{#items}}
+      {{#isPrimitiveType}}
+        {{>beanValidationCore}}
+      {{/isPrimitiveType}}
+      {{^isPrimitiveType}}
+        @Valid
+      {{/isPrimitiveType}}
+    {{/items}}
+    {{{items.datatypeWithEnum}}}>
+  {{/useBeanValidation}}
+  {{^useBeanValidation}}
+    {{#uniqueItems}}java.util.Set{{/uniqueItems}}
+    {{^uniqueItems}}java.util.List{{/uniqueItems}}
+    <{{{dataType}}}>
+  {{/useBeanValidation}}
+{{/isArray}}
+{{^isArray}}
+  {{{dataType}}}
+{{/isArray}}

--- a/boat-scaffold/src/main/templates/boat-spring/mapDataType.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/mapDataType.mustache
@@ -1,1 +1,21 @@
-{{#openApiNullable}}{{#isNullable}}JsonNullable<{{/isNullable}}{{/openApiNullable}}{{{baseType}}}{{#items}}<String, {{#isPrimitiveType}}{{>beanValidationCore}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{#useBeanValidation}}@Valid {{/useBeanValidation}}{{/isPrimitiveType}}{{/items}}{{{items.datatypeWithEnum}}}>{{#openApiNullable}}{{#isNullable}}>{{/isNullable}}{{/openApiNullable}}
+{{#openApiNullable}}
+  {{#isNullable}}JsonNullable<{{/isNullable}}
+{{/openApiNullable}}
+{{! apply map type with String as key type }}
+{{{baseType}}}<String,
+{{! apply validation on map values }}
+{{#useBeanValidation}}
+  {{#items}}
+    {{#isPrimitiveType}}
+      {{>beanValidationCore}}
+    {{/isPrimitiveType}}
+    {{^isPrimitiveType}}
+      @Valid
+    {{/isPrimitiveType}}
+  {{/items}}
+{{/useBeanValidation}}
+{{! apply map value type with closing bracket }}
+{{{items.datatypeWithEnum}}}>
+{{#openApiNullable}}
+  {{#isNullable}}>{{/isNullable}}
+{{/openApiNullable}}

--- a/boat-scaffold/src/main/templates/boat-spring/mapDataType.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/mapDataType.mustache
@@ -1,0 +1,1 @@
+{{#openApiNullable}}{{#isNullable}}JsonNullable<{{/isNullable}}{{/openApiNullable}}{{{baseType}}}{{#items}}<String, {{#isPrimitiveType}}{{>beanValidationCore}}{{/isPrimitiveType}}{{^isPrimitiveType}}{{#useBeanValidation}}@Valid {{/useBeanValidation}}{{/isPrimitiveType}}{{/items}}{{{items.datatypeWithEnum}}}>{{#openApiNullable}}{{#isNullable}}>{{/isNullable}}{{/openApiNullable}}

--- a/boat-scaffold/src/main/templates/boat-spring/optionalDataType.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/optionalDataType.mustache
@@ -1,1 +1,13 @@
-{{#useOptional}}{{#required}}{{{dataType}}}{{/required}}{{^required}}Optional<{{#useBeanValidation}}{{>beanValidationCore}}{{/useBeanValidation}}{{{dataType}}}>{{/required}}{{/useOptional}}{{^useOptional}}{{{dataType}}}{{/useOptional}}
+{{#toOneLine}}
+  {{#useOptional}}
+    {{#required}}
+      {{>collectionDataTypeParam}}
+    {{/required}}
+    {{^required}}
+      Optional<{{>collectionDataTypeParam}}>
+    {{/required}}
+  {{/useOptional}}
+  {{^useOptional}}
+    {{>collectionDataTypeParam}}
+  {{/useOptional}}
+{{/toOneLine}}

--- a/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
@@ -68,24 +68,35 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
     {{{vendorExtensions.x-field-extra-annotation}}}
   {{/vendorExtensions.x-field-extra-annotation}}
   {{#isContainer}}
-    {{#isArray}}
+    {{#isMap}}
       {{#useBeanValidation}}@Valid{{/useBeanValidation}}
       {{#openApiNullable}}
-        private {{>collectionDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
+        private {{>mapDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
       {{/openApiNullable}}
       {{^openApiNullable}}
-        private {{>collectionDataType}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+        private {{>mapDataType}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
       {{/openApiNullable}}
-    {{/isArray}}
-    {{^isArray}}
-      {{#useBeanValidation}}@Valid{{/useBeanValidation}}
-      {{#openApiNullable}}
-        private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
-      {{/openApiNullable}}
-      {{^openApiNullable}}
-        private {{>nullableDataType}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
-      {{/openApiNullable}}
-    {{/isArray}}
+    {{/isMap}}
+    {{^isMap}}
+      {{#isArray}}
+        {{#useBeanValidation}}@Valid{{/useBeanValidation}}
+        {{#openApiNullable}}
+          private {{>collectionDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
+        {{/openApiNullable}}
+        {{^openApiNullable}}
+          private {{>collectionDataType}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+        {{/openApiNullable}}
+      {{/isArray}}
+      {{^isArray}}
+        {{#useBeanValidation}}@Valid{{/useBeanValidation}}
+        {{#openApiNullable}}
+          private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
+        {{/openApiNullable}}
+        {{^openApiNullable}}
+          private {{>nullableDataType}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+        {{/openApiNullable}}
+      {{/isArray}}
+    {{/isMap}}
   {{/isContainer}}
   {{^isContainer}}
     {{#isDate}}

--- a/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
@@ -67,24 +67,25 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
   {{#vendorExtensions.x-field-extra-annotation}}
     {{{vendorExtensions.x-field-extra-annotation}}}
   {{/vendorExtensions.x-field-extra-annotation}}
+  {{#trimAndIndent4}}
   {{#isContainer}}
     {{#isMap}}
       {{#useBeanValidation}}@Valid{{/useBeanValidation}}
       {{#openApiNullable}}
-        private {{>mapDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
+        private {{#toOneLine}}{{>mapDataType}}{{/toOneLine}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
       {{/openApiNullable}}
       {{^openApiNullable}}
-        private {{>mapDataType}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+        private {{#toOneLine}}{{>mapDataType}}{{/toOneLine}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
       {{/openApiNullable}}
     {{/isMap}}
     {{^isMap}}
       {{#isArray}}
         {{#useBeanValidation}}@Valid{{/useBeanValidation}}
         {{#openApiNullable}}
-          private {{>collectionDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
+          private {{#toOneLine}}{{>collectionDataType}}{{/toOneLine}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
         {{/openApiNullable}}
         {{^openApiNullable}}
-          private {{>collectionDataType}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+          private {{#toOneLine}}{{>collectionDataType}}{{/toOneLine}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
         {{/openApiNullable}}
       {{/isArray}}
       {{^isArray}}
@@ -112,6 +113,7 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
       private {{>nullableDataType}} {{name}}{{#isNullable}} = null{{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
     {{/openApiNullable}}
   {{/isContainer}}
+  {{/trimAndIndent4}}
 {{/vars}}
 {{#generatedConstructorWithRequiredArgs}}
   {{#hasRequired}}

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringTemplatesTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringTemplatesTests.java
@@ -193,6 +193,10 @@ class BoatSpringTemplatesTests {
             equalTo(this.param.useBeanValidation||this.param.addBindingResult));
         assertThat(findPattern("/model/.+\\.java$", "@Valid"),
             equalTo(this.param.useBeanValidation||this.param.addBindingResult));
+        assertThat(findPattern("/model/MultiLinePaymentRequest.*\\.java$", "List<@Pattern\\(regexp"),
+            equalTo(this.param.useBeanValidation||this.param.addBindingResult));
+        assertThat(findPattern("/model/MultiLinePaymentRequest.*\\.java$", "Map<String, @Size\\(min = 7, max = 10\\)"),
+            equalTo(this.param.useBeanValidation||this.param.addBindingResult));
     }
 
     @Check

--- a/boat-scaffold/src/test/resources/boat-spring/openapi.yaml
+++ b/boat-scaffold/src/test/resources/boat-spring/openapi.yaml
@@ -94,6 +94,20 @@ paths:
             items:
               type: string
               pattern: "^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[1-5][0-9a-fA-F]{3}-?[89abAB][0-9a-fA-F]{3}-?[0-9a-fA-F]{12}$"
+        - name: headerParams
+          in: header
+          description: List of headers
+          required: false
+          style: form
+          explode: true
+          schema:
+            maxItems: 50
+            minItems: 1
+            type: array
+            description: List of headers
+            items:
+              type: string
+              pattern: "^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[1-5][0-9a-fA-F]{3}-?[89abAB][0-9a-fA-F]{3}-?[0-9a-fA-F]{12}$"
       responses:
         "200":
           description: OK

--- a/boat-scaffold/src/test/resources/boat-spring/openapi.yaml
+++ b/boat-scaffold/src/test/resources/boat-spring/openapi.yaml
@@ -172,6 +172,37 @@ components:
             type: string
             minLength: 5
             maxLength: 361
+        uniqueArrangementIds:
+          description: Unique internal arrangement ids
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            minLength: 1
+            maxLength: 224
+        uuidPatterns:
+          description: List of UUID patterns
+          type: array
+          items:
+            type: string
+            pattern: "^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[1-5][0-9a-fA-F]{3}-?[89abAB][0-9a-fA-F]{3}-?[0-9a-fA-F]{12}$"
+            description: UUID pattern
+        mapObjects:
+          minProperties: 0
+          maxProperties: 4
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/PaymentRequestLine'
+          description: "Transaction data map"
+        mapStrings:
+          minProperties: 0
+          maxProperties: 5
+          type: object
+          additionalProperties:
+            type: string
+            minLength: 7
+            maxLength: 10
+          description: "Transaction data string map"
     PaymentRequestLine:
       required:
         - accountId

--- a/boat-scaffold/src/test/resources/boat-spring/openapi.yaml
+++ b/boat-scaffold/src/test/resources/boat-spring/openapi.yaml
@@ -57,6 +57,46 @@ paths:
       responses:
         "204":
           description: OK
+    get:
+      tags:
+        - payments
+      summary: post
+      description: Get payments
+      operationId: getPayments
+      parameters:
+        - name: uuidParam
+          in: query
+          schema:
+            type: string
+            pattern: "^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[1-5][0-9a-fA-F]{3}-?[89abAB][0-9a-fA-F]{3}-?[0-9a-fA-F]{12}$"
+        - name: from
+          in: query
+          description: Page Number
+          required: false
+          style: form
+          explode: true
+          schema:
+            minimum: 0
+            type: integer
+            format: int32
+            default: 0
+        - name: approvalTypeIds
+          in: query
+          description: List of identifiers
+          required: true
+          style: form
+          explode: true
+          schema:
+            maxItems: 50
+            minItems: 1
+            type: array
+            description: List of identifiers
+            items:
+              type: string
+              pattern: "^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[1-5][0-9a-fA-F]{3}-?[89abAB][0-9a-fA-F]{3}-?[0-9a-fA-F]{12}$"
+      responses:
+        "200":
+          description: OK
 
 components:
   schemas:
@@ -189,7 +229,7 @@ components:
             description: UUID pattern
         mapObjects:
           minProperties: 0
-          maxProperties: 4
+          maxProperties: 1
           type: object
           additionalProperties:
             $ref: '#/components/schemas/PaymentRequestLine'


### PR DESCRIPTION
This PR fixes https://github.com/Backbase/backbase-openapi-tools/issues/622

Changes:
- added `collectionDataTypeParam.mustache` to fix missing validation constraints on request params
- added `mapDataType.mustache` to fix missing validation constraints on map field
- additionally improved formatting of touched templates and formatting of generated code