### PR TITLE
Add {} to avoid escaping <>

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ It currently consists of
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.17.19
+* boat-spring
+  * Fix [List of Maps of Strings generated code does not compile. ,https://github.com/Backbase/backbase-openapi-tools/issues/647]
 ## 0.17.18
 * boat-spring
   * Fix [Regression on putting valid annotation on FQCN,https://github.com/Backbase/backbase-openapi-tools/issues/619]

--- a/boat-scaffold/src/main/templates/boat-spring/collectionDataType.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/collectionDataType.mustache
@@ -17,7 +17,7 @@
 {{items.packageName}}
 {{/useBeanValidation}}
 {{! apply collection item type }}
-{{items.simpleName}}>
+{{{items.simpleName}}}>
 {{#openApiNullable}}
   {{#isNullable}}>{{/isNullable}}
 {{/openApiNullable}}

--- a/boat-scaffold/src/test/resources/boat-spring/openapi.yaml
+++ b/boat-scaffold/src/test/resources/boat-spring/openapi.yaml
@@ -45,6 +45,29 @@ paths:
                 $ref: '#/components/schemas/ValidatedPojos'
               example:
                 name: "valid name"
+  /lists-of-maps-of-strings:
+    put:
+      tags:
+        - lists-of-maps-of-strings
+      summary: get
+      description: Get an object with a list property that contains maps of string to string.
+      operationId: getMapsOfStringsObjects
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  maps:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties:
+                        type: string
+              example:
+                name: "valid name"
 
   /transactions:
     patch:


### PR DESCRIPTION
Fixes: https://github.com/Backbase/backbase-openapi-tools/issues/647