### PR TITLE
Issue 211: Fix typo in changelogRenderer parameter in DiffMojo

### DIFF
--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/DiffMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/DiffMojo.java
@@ -40,7 +40,7 @@ public class DiffMojo extends AbstractMojo {
     @Parameter(name = "writeChangelog", defaultValue = "false")
     private boolean writeChangelog;
 
-    @Parameter(name = "changeLogRenderer", defaultValue = "markdown")
+    @Parameter(name = "changelogRenderer", defaultValue = "markdown")
     private String changelogRenderer;
 
     @Parameter(name = "changelogOutput", defaultValue = "${project.build.directory}/changelog")


### PR DESCRIPTION
Issue 211: Fix typo in `changelogRenderer` parameter in _DiffMojo_ class of the Maven plugin