### PR TITLE
Issue 211: Fix typo in changelogRenderer parameter in DiffMojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ It currently consists of
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.17.22
+* boat-maven-plugin
+  * Issue 211: Fix typo in changelogRenderer parameter in DiffMojo.java (#652) @talbot
 ## 0.17.21
 * boat-spring, boat-java
   * Issue 649: missing BigDecimalCustomSerializer.java (#650) @walaniam

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/DiffMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/DiffMojo.java
@@ -40,7 +40,7 @@ public class DiffMojo extends AbstractMojo {
     @Parameter(name = "writeChangelog", defaultValue = "false")
     private boolean writeChangelog;
 
-    @Parameter(name = "changeLogRenderer", defaultValue = "markdown")
+    @Parameter(name = "changelogRenderer", defaultValue = "markdown")
     private String changelogRenderer;
 
     @Parameter(name = "changelogOutput", defaultValue = "${project.build.directory}/changelog")


### PR DESCRIPTION
Fix typo in `changelogRenderer` parameter in _DiffMojo_ class of the Maven plugin.

Fixes Backbase/backbase-openapi-tools#211