### PR TITLE
EACMR-612: Allow byte[] example and removed tag import

### DIFF
--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExampleHolder.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/bundler/ExampleHolder.java
@@ -183,6 +183,8 @@ public abstract class ExampleHolder<T> {
             return new ArrayNodeExampleHolder(name, (ArrayNode) o);
         } else if (o instanceof String) {
             return new StringExampleHolder(name, o.toString());
+        } else if (o instanceof byte[]) {
+            return new StringExampleHolder(name, new String((byte[]) o));
         } else {
             throw new TransformerException(String.format(
                     "Unknown type backing example %s (%s) '%s'", name, o.getClass().getName(), o));

--- a/boat-scaffold/src/main/templates/boat-spring/api.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/api.mustache
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 {{/swagger2AnnotationLibrary}}
 {{#swagger1AnnotationLibrary}}
 import io.swagger.annotations.*;
@@ -106,7 +105,7 @@ import javax.annotation.Generated;
 @Controller
 {{/useSpringController}}
 {{#swagger2AnnotationLibrary}}
-@Tag(name = "{{{baseName}}}", description = {{#tagDescription}}"{{{.}}}"{{/tagDescription}}{{^tagDescription}}"the {{{baseName}}} API"{{/tagDescription}})
+@io.swagger.v3.oas.annotations.tags.Tag(name = "{{{baseName}}}", description = {{#tagDescription}}"{{{.}}}"{{/tagDescription}}{{^tagDescription}}"the {{{baseName}}} API"{{/tagDescription}})
 {{/swagger2AnnotationLibrary}}
 {{#swagger1AnnotationLibrary}}
 @Api(value = "{{{baseName}}}", description = {{#tagDescription}}"{{{.}}}"{{/tagDescription}}{{^tagDescription}}"the {{{baseName}}} API"{{/tagDescription}})


### PR DESCRIPTION
Ticket: https://backbase.atlassian.net/browse/EACMR-612

Fixing issues caused by the SSDK 16 upgrade. 

1. Added support for byte[] example.
2. Removed Tag import so we can name a generated object Tag as we did before SSDK 16. 