### PR TITLE
Fix/Free-Form Object issue

### DIFF
--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
@@ -771,30 +771,30 @@ public class GenerateMojo extends InputMavenArtifactMojo {
             GlobalSettings.setProperty(CodegenConstants.WITH_XML, withXml.toString());
 
             if (configOptions != null) {
-                // Retained for backwards-compataibility with configOptions -> instantiation-types
+                // Retained for backwards-compatibility with configOptions -> instantiation-types
                 if (instantiationTypes == null && configOptions.containsKey(INSTANTIATION_TYPES)) {
                     applyInstantiationTypesKvp(configOptions.get(INSTANTIATION_TYPES).toString(),
                         configurator);
                 }
 
-                // Retained for backwards-compataibility with configOptions -> import-mappings
+                // Retained for backwards-compatibility with configOptions -> import-mappings
                 if (importMappings == null && configOptions.containsKey(IMPORT_MAPPINGS)) {
                     applyImportMappingsKvp(configOptions.get(IMPORT_MAPPINGS).toString(),
                         configurator);
                 }
 
-                // Retained for backwards-compataibility with configOptions -> type-mappings
+                // Retained for backwards-compatibility with configOptions -> type-mappings
                 if (typeMappings == null && configOptions.containsKey(TYPE_MAPPINGS)) {
                     applyTypeMappingsKvp(configOptions.get(TYPE_MAPPINGS).toString(), configurator);
                 }
 
-                // Retained for backwards-compataibility with configOptions -> language-specific-primitives
+                // Retained for backwards-compatibility with configOptions -> language-specific-primitives
                 if (languageSpecificPrimitives == null && configOptions.containsKey(LANGUAGE_SPECIFIC_PRIMITIVES)) {
                     applyLanguageSpecificPrimitivesCsv(configOptions
                         .get(LANGUAGE_SPECIFIC_PRIMITIVES).toString(), configurator);
                 }
 
-                // Retained for backwards-compataibility with configOptions -> additional-properties
+                // Retained for backwards-compatibility with configOptions -> additional-properties
                 if (additionalProperties == null && configOptions.containsKey(ADDITIONAL_PROPERTIES)) {
                     applyAdditionalPropertiesKvp(configOptions.get(ADDITIONAL_PROPERTIES).toString(),
                         configurator);
@@ -804,7 +804,7 @@ public class GenerateMojo extends InputMavenArtifactMojo {
                     applyServerVariablesKvp(configOptions.get(SERVER_VARIABLES).toString(), configurator);
                 }
 
-                // Retained for backwards-compataibility with configOptions -> reserved-words-mappings
+                // Retained for backwards-compatibility with configOptions -> reserved-words-mappings
                 if (reservedWordsMappings == null && configOptions.containsKey(RESERVED_WORDS_MAPPINGS)) {
                     applyReservedWordsMappingsKvp(configOptions.get(RESERVED_WORDS_MAPPINGS)
                         .toString(), configurator);
@@ -960,8 +960,8 @@ public class GenerateMojo extends InputMavenArtifactMojo {
     /**
      * Calculate openapi specification file hash. If specification is hosted on remote resource it is downloaded first
      *
-     * @param inputSpecFile - Openapi specification input file to calculate it's hash.
-     *                      Does not taken into account if input spec is hosted on remote resource
+     * @param inputSpecFile - Openapi specification input file to calculate its hash.
+     *                      Does not take into account if input spec is hosted on remote resource
      * @return openapi specification file hash
      * @throws IOException When cannot read the file
      */
@@ -1019,8 +1019,8 @@ public class GenerateMojo extends InputMavenArtifactMojo {
     /**
      * Get specification hash file.
      *
-     * @param inputSpecFile - Openapi specification input file  to calculate it's hash.
-     *                      Does not taken into account if input spec is hosted on remote resource
+     * @param inputSpecFile - Openapi specification input file  to calculate its hash.
+     *                      Does not take into account if input spec is hosted on remote resource
      * @return a file with previously calculated hash
      */
     private File getHashFile(File inputSpecFile) {
@@ -1073,7 +1073,7 @@ public class GenerateMojo extends InputMavenArtifactMojo {
      * config.additionalProperties (configuration/configOptions) to proper booleans.
      * This enables mustache files to handle the properties better.
      *
-     * @param config GodeGen config
+     * @param config CodeGen configms
      */
     private void adjustAdditionalProperties(final CodegenConfig config) {
         Map<String, Object> configAdditionalProperties = config.additionalProperties();

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
@@ -1073,7 +1073,7 @@ public class GenerateMojo extends InputMavenArtifactMojo {
      * config.additionalProperties (configuration/configOptions) to proper booleans.
      * This enables mustache files to handle the properties better.
      *
-     * @param config CodeGen configms
+     * @param config CodeGen config
      */
     private void adjustAdditionalProperties(final CodegenConfig config) {
         Map<String, Object> configAdditionalProperties = config.additionalProperties();

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
@@ -31,6 +32,12 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
 
         // Set the default template directory
         embeddedTemplateDir = templateDir = getName();
+
+        // Type mappings //
+        this.typeMapping.remove("object");
+        this.typeMapping.remove("AnyType");
+        this.typeMapping.put("object", "Any");
+        this.typeMapping.put("AnyType", "Any");
     }
 
     @Override
@@ -51,6 +58,17 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         this.supportingFiles.add(new SupportingFile("AnyCodable.swift.mustache", this.sourceFolder, "AnyCodable.swift"));
     }
 
+//    @Override
+//    protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel,
+//                                                       Schema schema) {
+//
+//        final Schema additionalProperties = ModelUtils.getAdditionalProperties(openAPI, schema);
+//
+//        if (additionalProperties != null) {
+//            codegenModel.additionalPropertiesType = getSchemaType(additionalProperties);
+//        }
+//    }
+
     // Fix issues with generating arrays with Set.
     @Override
     public String getTypeDeclaration(Schema p) {
@@ -60,6 +78,60 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
             return "[" + getTypeDeclaration(inner) + "]";
         }
         return super.getTypeDeclaration(p);
+    }
+
+//    public String toInstantiationType(Schema p) {
+//        if (ModelUtils.isMapSchema(p)) {
+//            return getSchemaType(ModelUtils.getAdditionalProperties(openAPI, p));
+//        } else if (ModelUtils.isArraySchema(p)) {
+//            ArraySchema ap = (ArraySchema) p;
+//            String inner = getSchemaType(ap.getItems());
+//            return "[" + inner + "]";
+//        }
+//        return null;
+//    }
+
+    @Override
+    public CodegenModel fromModel(String name, Schema model) {
+        Map<String, Schema> allDefinitions = ModelUtils.getSchemas(this.openAPI);
+        CodegenModel codegenModel = super.fromModel(name, model);
+        if (codegenModel.description != null) {
+            codegenModel.imports.add("ApiModel");
+        }
+
+        fixAllFreeFormObject(codegenModel);
+
+        return codegenModel;
+    }
+
+    private void fixAllFreeFormObject(CodegenModel codegenModel) {
+        this.fixFreeFormObject(codegenModel.vars);
+        this.fixFreeFormObject(codegenModel.optionalVars);
+        this.fixFreeFormObject(codegenModel.requiredVars);
+        this.fixFreeFormObject(codegenModel.parentVars);
+        this.fixFreeFormObject(codegenModel.allVars);
+        this.fixFreeFormObject(codegenModel.readOnlyVars);
+        this.fixFreeFormObject(codegenModel.readWriteVars);
+    }
+
+    /*
+     If a property has both isFreeFormObject and isMapContainer true make isFreeFormObject false
+     This way when we have a free form object in the spec that has a typed value it will be
+     treated as a Dictionary
+    */
+    private void fixFreeFormObject(List<CodegenProperty> codegenProperties) {
+        for (CodegenProperty codegenProperty : codegenProperties) {
+            if (codegenProperty.isFreeFormObject && codegenProperty.isMap && !codegenProperty.items.isFreeFormObject) {
+                codegenProperty.isFreeFormObject = false;
+            }
+
+            if (codegenProperty.isArray && codegenProperty.items.isFreeFormObject) {
+                codegenProperty.isFreeFormObject = true;
+                if (codegenProperty.additionalProperties == null) {
+                    codegenProperty.isMap = false;
+                }
+            }
+        }
     }
 
     // Fix for inheritance bug
@@ -113,7 +185,7 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
     @Override
     public void postProcess() {
         System.out.println("################################################################################");
-        System.out.println("# Thanks for using BOAT Swift OpenAPI Generator.                                          #");
+        System.out.println("# Thanks for using BOAT Swift 5 OpenAPI Generator.                                          #");
         System.out.println("################################################################################");
     }
 

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -82,6 +82,10 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         return codegenModel;
     }
 
+    /*
+    This is added as a compatibility requirement for API specs containing free form objects
+    missing `additionalProperties` property
+     */
     private void fixAllFreeFormObject(CodegenModel codegenModel) {
         this.fixFreeFormObject(codegenModel.vars);
         this.fixFreeFormObject(codegenModel.optionalVars);
@@ -99,6 +103,7 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
     */
     private void fixFreeFormObject(List<CodegenProperty> codegenProperties) {
         for (CodegenProperty codegenProperty : codegenProperties) {
+            System.out.println("Received: " + codegenProperty);
             if (codegenProperty.isFreeFormObject && codegenProperty.isMap && !codegenProperty.items.isFreeFormObject) {
                 codegenProperty.isFreeFormObject = false;
             }

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -58,17 +58,6 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         this.supportingFiles.add(new SupportingFile("AnyCodable.swift.mustache", this.sourceFolder, "AnyCodable.swift"));
     }
 
-//    @Override
-//    protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel,
-//                                                       Schema schema) {
-//
-//        final Schema additionalProperties = ModelUtils.getAdditionalProperties(openAPI, schema);
-//
-//        if (additionalProperties != null) {
-//            codegenModel.additionalPropertiesType = getSchemaType(additionalProperties);
-//        }
-//    }
-
     // Fix issues with generating arrays with Set.
     @Override
     public String getTypeDeclaration(Schema p) {
@@ -79,17 +68,6 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         }
         return super.getTypeDeclaration(p);
     }
-
-//    public String toInstantiationType(Schema p) {
-//        if (ModelUtils.isMapSchema(p)) {
-//            return getSchemaType(ModelUtils.getAdditionalProperties(openAPI, p));
-//        } else if (ModelUtils.isArraySchema(p)) {
-//            ArraySchema ap = (ArraySchema) p;
-//            String inner = getSchemaType(ap.getItems());
-//            return "[" + inner + "]";
-//        }
-//        return null;
-//    }
 
     @Override
     public CodegenModel fromModel(String name, Schema model) {

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -103,7 +103,6 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
     */
     private void fixFreeFormObject(List<CodegenProperty> codegenProperties) {
         for (CodegenProperty codegenProperty : codegenProperties) {
-            System.out.println("Received: " + codegenProperty);
             if (codegenProperty.isFreeFormObject && codegenProperty.isMap && !codegenProperty.items.isFreeFormObject) {
                 codegenProperty.isFreeFormObject = false;
             }

--- a/boat-scaffold/src/main/templates/boat-swift5/api_operation_parameter_model.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/api_operation_parameter_model.mustache
@@ -1,33 +1,33 @@
 {{#allParams}}
-{{#isEnum}}
-    {{> modelInlineEnumDeclaration}}
-{{/isEnum}}
+    {{#isEnum}}
+        {{> modelInlineEnumDeclaration}}
+    {{/isEnum}}
 {{/allParams}}
 {{#allParams}}
-{{#isEnum}}
-    {{#description}}/** {{description}} */
-    {{/description}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let {{paramName}}: {{{datatypeWithEnum}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}
-{{/isEnum}}
-{{^isEnum}}
-    {{#description}}/** {{description}} */
-    {{/description}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let {{paramName}}: {{{dataType}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}
-    {{#objcCompatible}}
-    {{#vendorExtensions.x-swift-optional-scalar}}
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var {{paramName}}Num: NSNumber? {
-        get {
-            return {{paramName}}.map({ return NSNumber(value: $0) })
-        }
-    }
-    {{/vendorExtensions.x-swift-optional-scalar}}
-    {{/objcCompatible}}
-{{/isEnum}}
+    {{#isEnum}}
+        {{#description}}/** {{description}} */
+        {{/description}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let {{paramName}}: {{{datatypeWithEnum}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}
+    {{/isEnum}}
+    {{^isEnum}}
+        {{#description}}/** {{description}} */
+        {{/description}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let {{paramName}}: {{{dataType}}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}
+        {{#objcCompatible}}
+            {{#vendorExtensions.x-swift-optional-scalar}}
+                {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var {{paramName}}Num: NSNumber? {
+                get {
+                return {{paramName}}.map({ return NSNumber(value: $0) })
+                }
+                }
+            {{/vendorExtensions.x-swift-optional-scalar}}
+        {{/objcCompatible}}
+    {{/isEnum}}
 {{/allParams}}
 
 {{#hasParams}}
     internal init({{#allParams}}{{paramName}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) {
-        {{#allParams}}
+    {{#allParams}}
         self.{{paramName}} = {{paramName}}
-        {{/allParams}}
+    {{/allParams}}
     }
 {{/hasParams}}
 {{#hasParams}}
@@ -36,47 +36,47 @@
     {{#allParams}}
         {{#description}}/** {{description}} */
         {{/description}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#required}}let{{/required}}{{^required}}private(set) var{{/required}} {{> api_param_builder}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{/required}}
-    {{^isEnum}}
-        {{#objcCompatible}}
-        {{#vendorExtensions.x-swift-optional-scalar}}
-        {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var {{paramName}}Num: NSNumber? {
-            get {
-                return {{paramName}}.map({ return NSNumber(value: $0) })
-            }
-        }
-        {{/vendorExtensions.x-swift-optional-scalar}}
-        {{/objcCompatible}}
-    {{/isEnum}}
+        {{^isEnum}}
+            {{#objcCompatible}}
+                {{#vendorExtensions.x-swift-optional-scalar}}
+                    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var {{paramName}}Num: NSNumber? {
+                    get {
+                    return {{paramName}}.map({ return NSNumber(value: $0) })
+                    }
+                    }
+                {{/vendorExtensions.x-swift-optional-scalar}}
+            {{/objcCompatible}}
+        {{/isEnum}}
     {{/allParams}}
 
-        {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init({{#requiredParams}}{{^-first}}, {{/-first}}{{> api_param_builder}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{/requiredParams}}) {
-            {{#requiredParams}}
-            self.{{paramName}} = {{paramName}}
-            {{/requiredParams}}
-        }
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init({{#requiredParams}}{{^-first}}, {{/-first}}{{> api_param_builder}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{/requiredParams}}) {
+    {{#requiredParams}}
+        self.{{paramName}} = {{paramName}}
+    {{/requiredParams}}
+    }
 
     {{#optionalParams}}
         /// Setter method for {{paramName}} property.
         {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func set({{> api_param_builder}}?) -> Self {
-            self.{{paramName}} = {{paramName}}
-            return self
+        self.{{paramName}} = {{paramName}}
+        return self
         }
     {{/optionalParams}}
 
-        /// Builder initializer method for {{operationIdCamelCase}}RequestParams DTO.
-        {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func build() -> {{operationIdCamelCase}}RequestParams {
-            return {{operationIdCamelCase}}RequestParams({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, 
-            		{{/-last}}{{/allParams}})
-        }
+    /// Builder initializer method for {{operationIdCamelCase}}RequestParams DTO.
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func build() -> {{operationIdCamelCase}}RequestParams {
+    return {{operationIdCamelCase}}RequestParams({{#allParams}}{{paramName}}: {{paramName}}{{^-last}},
+    {{/-last}}{{/allParams}})
+    }
 
-        public static func ==(lhs: Builder, rhs: Builder) -> Bool {
-        	return {{^hasParams}}true{{/hasParams}}{{#allParams}}{{#isFreeFormObject}}{{#isMap}}lhs.{{paramName}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}.mapValues { AnyCodable($0) } == rhs.{{paramName}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}.mapValues { AnyCodable($0) }{{/isMap}}{{^isMap}}AnyCodable(lhs.{{paramName}}) == AnyCodable(rhs.{{paramName}}){{/isMap}}{{/isFreeFormObject}}{{^isFreeFormObject}}lhs.{{paramName}}{{#isArray}}{{^required}}?{{/required}}.description{{/isArray}} == rhs.{{paramName}}{{#isArray}}{{^required}}?{{/required}}.description{{/isArray}}{{/isFreeFormObject}}{{^-last}} &&
-        	{{/-last}}{{/allParams}}
-    	}
+    public static func ==(lhs: Builder, rhs: Builder) -> Bool {
+    return {{^hasParams}}true{{/hasParams}}{{#allParams}}{{#isFreeFormObject}}AnyCodable(lhs.{{paramName}}) == AnyCodable(rhs.{{paramName}}){{/isFreeFormObject}}{{^isFreeFormObject}}lhs.{{paramName}}{{#isArray}}{{^required}}?{{/required}}.description{{/isArray}} == rhs.{{paramName}}{{#isArray}}{{^required}}?{{/required}}.description{{/isArray}}{{/isFreeFormObject}}{{^-last}} &&
+    {{/-last}}{{/allParams}}
+    }
     }
 {{/hasParams}}
 
-    public static func ==(lhs: Self, rhs: Self) -> Bool {
-        return {{^hasParams}}true{{/hasParams}}{{#allParams}}{{#isFreeFormObject}}{{#isMap}}lhs.{{paramName}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}.mapValues { AnyCodable($0) } == rhs.{{paramName}}{{#required}}{{#isNullable}}?{{/isNullable}}{{/required}}{{^required}}?{{/required}}.mapValues { AnyCodable($0) }{{/isMap}}{{^isMap}}AnyCodable(lhs.{{paramName}}) == AnyCodable(rhs.{{paramName}}){{/isMap}}{{/isFreeFormObject}}{{^isFreeFormObject}}lhs.{{paramName}}{{#isArray}}{{^required}}?{{/required}}.description{{/isArray}} == rhs.{{paramName}}{{#isArray}}{{^required}}?{{/required}}.description{{/isArray}}{{/isFreeFormObject}}{{^-last}} &&
-        {{/-last}}{{/allParams}}
-    }
+public static func ==(lhs: Self, rhs: Self) -> Bool {
+return {{^hasParams}}true{{/hasParams}}{{#allParams}}{{#isFreeFormObject}}AnyCodable(lhs.{{paramName}}) == AnyCodable(rhs.{{paramName}}){{/isFreeFormObject}}{{^isFreeFormObject}}lhs.{{paramName}}{{#isArray}}{{^required}}?{{/required}}.description{{/isArray}} == rhs.{{paramName}}{{#isArray}}{{^required}}?{{/required}}.description{{/isArray}}{{/isFreeFormObject}}{{^-last}} &&
+{{/-last}}{{/allParams}}
+}

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
@@ -1,523 +1,523 @@
-//package com.backbase.oss.codegen.java;
-//
-//import static com.backbase.oss.codegen.java.BoatSpringCodeGen.USE_PROTECTED_FIELDS;
-//import static java.util.stream.Collectors.groupingBy;
-//import static org.hamcrest.MatcherAssert.assertThat;
-//import static org.hamcrest.Matchers.equalTo;
-//import static org.hamcrest.Matchers.hasEntry;
-//import static org.hamcrest.Matchers.is;
-//import static org.hamcrest.Matchers.isA;
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.when;
-//
-//import com.backbase.oss.codegen.java.BoatSpringCodeGen.NewLineIndent;
-//import com.backbase.oss.codegen.java.VerificationRunner.Verification;
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.github.javaparser.StaticJavaParser;
-//import com.github.javaparser.ast.CompilationUnit;
-//import com.github.javaparser.ast.NodeList;
-//import com.github.javaparser.ast.body.FieldDeclaration;
-//import com.github.javaparser.ast.body.MethodDeclaration;
-//import com.github.javaparser.ast.body.Parameter;
-//import com.github.javaparser.ast.body.VariableDeclarator;
-//import com.github.javaparser.ast.expr.Expression;
-//import com.github.javaparser.ast.type.ClassOrInterfaceType;
-//import com.github.javaparser.ast.type.Type;
-//import com.samskivert.mustache.Template.Fragment;
-//import io.swagger.parser.OpenAPIParser;
-//import io.swagger.v3.oas.models.Operation;
-//import io.swagger.v3.parser.core.models.ParseOptions;
-//import jakarta.validation.ConstraintViolation;
-//import jakarta.validation.Validation;
-//import jakarta.validation.Validator;
-//import java.io.File;
-//import java.io.FileNotFoundException;
-//import java.io.IOException;
-//import java.io.StringWriter;
-//import java.math.BigDecimal;
-//import java.nio.file.Files;
-//import java.nio.file.Paths;
-//import java.util.Arrays;
-//import java.util.Collection;
-//import java.util.HashMap;
-//import java.util.List;
-//import java.util.Map;
-//import java.util.Objects;
-//import java.util.Optional;
-//import java.util.Set;
-//import java.util.UUID;
-//import java.util.stream.Collectors;
-//import org.apache.commons.io.FileUtils;
-//import org.apache.commons.lang.UnhandledException;
-//import org.hamcrest.Matchers;
-//import org.jetbrains.annotations.NotNull;
-//import org.junit.jupiter.api.BeforeAll;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.params.ParameterizedTest;
-//import org.junit.jupiter.params.provider.CsvSource;
-//import org.openapitools.codegen.CliOption;
-//import org.openapitools.codegen.ClientOptInput;
-//import org.openapitools.codegen.CodegenOperation;
-//import org.openapitools.codegen.CodegenProperty;
-//import org.openapitools.codegen.DefaultGenerator;
-//import org.openapitools.codegen.languages.SpringCodegen;
-//import org.openapitools.jackson.nullable.JsonNullableModule;
-//
-//class BoatSpringCodeGenTests {
-//
-//    static final String PROP_BASE = BoatSpringCodeGenTests.class.getSimpleName() + ".";
-//    static final String TEST_OUTPUT = System.getProperty(PROP_BASE + "output", "target/boat-spring-codegen-tests");
-//
-//    @BeforeAll
-//    static void before() throws IOException {
-//        Files.createDirectories(Paths.get(TEST_OUTPUT));
-//        FileUtils.deleteDirectory(new File(TEST_OUTPUT));
-//    }
-//
-//    @Test
-//    void clientOptsUnicity() {
-//        final BoatSpringCodeGen gen = new BoatSpringCodeGen();
-//        gen.cliOptions()
-//            .stream()
-//            .collect(groupingBy(CliOption::getOpt))
-//            .forEach((k, v) -> assertEquals(1, v.size(), k + " is described multiple times"));
-//    }
-//
-//
-//    @Test
-//    void processOptsUseProtectedFields() {
-//        final BoatJavaCodeGen gen = new BoatJavaCodeGen();
-//        final Map<String, Object> options = gen.additionalProperties();
-//
-//        options.put(USE_PROTECTED_FIELDS, "true");
-//
-//        gen.processOpts();
-//
-//        assertThat(gen.additionalProperties(), hasEntry("modelFieldsVisibility", "protected"));
-//    }
-//
-//
-//    @Test
-//    void newLineIndent() throws IOException {
-//        final NewLineIndent indent = new BoatSpringCodeGen.NewLineIndent(2, "_");
-//        final StringWriter output = new StringWriter();
-//        final Fragment frag = mock(Fragment.class);
-//
-//        when(frag.execute()).thenReturn("\n Good \r\n   morning,  \r\n  Dave ");
-//
-//        indent.execute(frag, output);
-//
-//        assertThat(output.toString(), equalTo(String.format("__%n__Good%n__  morning,%n__ Dave%n")));
-//    }
-//
-//    @Test
-//    void addServletRequestTestFromOperation(){
-//        final BoatSpringCodeGen gen = new BoatSpringCodeGen();
-//        gen.addServletRequest = true;
-//        CodegenOperation co = gen.fromOperation("/test", "POST", new Operation(), null);
-//        assertEquals(1, co.allParams.size());
-//        assertEquals("httpServletRequest", co.allParams.get(0).paramName);
-//        assertTrue(Arrays.stream(co.allParams.get(0).getClass().getDeclaredFields()).anyMatch(f -> "isHttpServletRequest".equals(f.getName())));
-//    }
-//
-//    @Test
-//    void multipartWithFileAndObject() throws IOException {
-//        var codegen = new BoatSpringCodeGen();
-//        var input = new File("src/test/resources/boat-spring/multipart.yaml");
-//        codegen.setLibrary("spring-boot");
-//        codegen.setInterfaceOnly(true);
-//        codegen.setOutputDir(TEST_OUTPUT + "/multipart");
-//        codegen.setInputSpec(input.getAbsolutePath());
-//
-//        var openApiInput = new OpenAPIParser().readLocation(input.getAbsolutePath(), null, new ParseOptions()).getOpenAPI();
-//        var clientOptInput = new ClientOptInput();
-//        clientOptInput.config(codegen);
-//        clientOptInput.openAPI(openApiInput);
-//
-//        List<File> files = new DefaultGenerator().opts(clientOptInput).generate();
-//
-//        File testApi = files.stream().filter(file -> file.getName().equals("TestApi.java"))
-//            .findFirst()
-//            .get();
-//        MethodDeclaration testPostMethod = StaticJavaParser.parse(testApi)
-//            .findAll(MethodDeclaration.class)
-//            .get(1);
-//
-//        Parameter filesParam = testPostMethod.getParameterByName("files").get();
-//        Parameter contentParam = testPostMethod.getParameterByName("content").get();
-//
-//        assertTrue(filesParam.getAnnotationByName("RequestPart").isPresent());
-//        assertTrue(contentParam.getAnnotationByName("RequestPart").isPresent());
-//        assertThat(contentParam.getTypeAsString(), equalTo("TestObjectPart"));
-//        assertThat(filesParam.getTypeAsString(), equalTo("List<MultipartFile>"));
-//    }
-//
-//    @Test
-//    void testReplaceBeanValidationCollectionType() {
-//        var codegen = new BoatSpringCodeGen();
-//        codegen.setUseBeanValidation(true);
-//        var codegenProperty = new CodegenProperty();
-//        codegenProperty.isModel = true;
-//        codegenProperty.baseName = "request"; // not a response
-//
-//        String result = codegen.replaceBeanValidationCollectionType(
-//                codegenProperty,"Set<@Valid com.backbase.dbs.arrangement.commons.model.TranslationItemDto>");
-//        assertEquals("Set<com.backbase.dbs.arrangement.commons.model.@Valid TranslationItemDto>", result);
-//    }
-//    @ParameterizedTest
-//    @CsvSource(value = {"true,true", "true,false", "false,true", "false,false"})
-//    @SuppressWarnings("unchecked")
-//    void shouldGenerateValidations(boolean useLombok, boolean bigDecimalsAsStrings) throws InterruptedException, IOException {
-//
-//        final String REFERENCED_CLASS_NAME = "com.backbase.oss.codegen.java.ValidatedPojo";
-//        final String REFERENCED_ENUM_NAME = "com.backbase.oss.codegen.java.CommonEnum";
-//
-//        var modelPackage = "com.backbase.model";
-//        var input = new File("src/test/resources/boat-spring/openapi.yaml");
-//        var output = TEST_OUTPUT + String.format("/shouldGenerateValidations_lombok-%s_bigDecString-%s", useLombok,
-//            bigDecimalsAsStrings);
-//
-//        // generate project
-//        var codegen = new BoatSpringCodeGen();
-//        codegen.setLibrary("spring-boot");
-//        codegen.setInterfaceOnly(true);
-//        codegen.setSkipDefaultInterface(true);
-//        codegen.setOutputDir(output);
-//        codegen.setInputSpec(input.getAbsolutePath());
-//        codegen.setContainerDefaultToNull(true);
-//        codegen.setSerializeBigDecimalAsString(bigDecimalsAsStrings);
-//        codegen.setUseLombokAnnotations(useLombok);
-//        codegen.schemaMapping().put("ValidatedPojo", REFERENCED_CLASS_NAME);
-//        codegen.schemaMapping().put("CommonEnum", REFERENCED_ENUM_NAME);
-//        codegen.additionalProperties().put(SpringCodegen.USE_SPRING_BOOT3, Boolean.TRUE.toString());
-//        codegen.additionalProperties().put(BoatSpringCodeGen.USE_CLASS_LEVEL_BEAN_VALIDATION, Boolean.TRUE.toString());
-//        codegen.setModelPackage(modelPackage);
-//
-//        var openApiInput = new OpenAPIParser()
-//            .readLocation(input.getAbsolutePath(), null, new ParseOptions())
-//            .getOpenAPI();
-//        var clientOptInput = new ClientOptInput();
-//        clientOptInput.config(codegen);
-//        clientOptInput.openAPI(openApiInput);
-//
-//        List<File> files = new DefaultGenerator().opts(clientOptInput).generate();
-//
-//        File paymentsApiFile = files.stream().filter(file -> file.getName().equals("PaymentsApi.java"))
-//            .findFirst()
-//            .get();
-//        MethodDeclaration getPaymentsMethod = StaticJavaParser.parse(paymentsApiFile)
-//            .findAll(MethodDeclaration.class)
-//            .stream()
-//            .filter(it -> "getPayments".equals(it.getName().toString()))
-//            .findFirst().orElseThrow();
-//        assertHasCollectionParamWithType(getPaymentsMethod, "approvalTypeIds", "List", "String");
-//        assertHasCollectionParamWithType(getPaymentsMethod, "status", "List", "String");
-//        assertHasCollectionParamWithType(getPaymentsMethod, "headerParams", "List", "String");
-//
-//        File paymentRequestLine = files.stream().filter(file -> file.getName().equals("PaymentRequestLine.java"))
-//            .findFirst()
-//            .get();
-//        CompilationUnit paymentRequestLineUnit = StaticJavaParser.parse(paymentRequestLine);
-//        if (!useLombok) {
-//            MethodDeclaration getStatus = paymentRequestLineUnit
-//                .findAll(MethodDeclaration.class)
-//                .stream()
-//                .filter(it -> "getStatus".equals(it.getName().toString()))
-//                .findFirst().orElseThrow();
-//            assertMethodCollectionReturnType(getStatus, "List", "StatusEnum");
-//        }
-//        assertFieldValueAssignment(paymentRequestLineUnit, "additionalPropertiesMap", "new HashMap<>()");
-//
-//        File paymentRequest = files.stream().filter(file -> file.getName().equals("PaymentRequest.java"))
-//            .findFirst()
-//            .get();
-//        CompilationUnit paymentRequestUnit = StaticJavaParser.parse(paymentRequest);
-//        assertFieldAnnotation(paymentRequestUnit, "currencyCode", "Pattern");
-//        assertFieldAnnotation(paymentRequestUnit, "currencyCode", "NotNull");
-//        assertFieldAnnotation(paymentRequestUnit, "referenceNumber", "Size");
-//        assertFieldAnnotation(paymentRequestUnit, "referenceNumber", "NotNull");
-//        assertFieldAnnotation(paymentRequestUnit, "requestLine", "Valid");
-//
-//        File multiLinePaymentRequest = files.stream().filter(f -> f.getName().equals("MultiLinePaymentRequest.java"))
-//                .findFirst()
-//                .get();
-//        CompilationUnit multiLinePaymentRequestUnit = StaticJavaParser.parse(multiLinePaymentRequest);
-//
-//        assertFieldAnnotation(multiLinePaymentRequestUnit, "arrangementIds", "NotNull");
-//        assertFieldValueAssignment(
-//                multiLinePaymentRequestUnit, "arrangementIds", "new ArrayList<>()");
-//        assertFieldAnnotation(multiLinePaymentRequestUnit, "uniqueLines", "NotNull");
-//        assertFieldValueAssignment(
-//                multiLinePaymentRequestUnit, "uniqueArrangementIds", null);
-//
-//        // assert annotation
-//
-//        FileUtils.copyToFile(
-//                getClass().getResourceAsStream("/boat-spring/ValidatedPojo.java"),
-//                new File(output + "/src/main/java/"
-//                        + REFERENCED_CLASS_NAME.replaceAll("\\.", "/") + "/ValidatedPojo.java"));
-//        FileUtils.copyToFile(
-//                getClass().getResourceAsStream("/boat-spring/CommonEnum.java"),
-//                new File(output + "/src/main/java/"
-//                        + REFERENCED_ENUM_NAME.replaceAll("\\.", "/") + "/CommonEnum.java"));
-//
-//        // compile generated project
-//        var compiler = new MavenProjectCompiler(BoatSpringCodeGenTests.class.getClassLoader());
-//        var projectDir = new File(output);
-//        int compilationStatus = compiler.compile(projectDir);
-//        assertEquals(0, compilationStatus);
-//
-//        // verify
-//        ClassLoader projectClassLoader = compiler.getProjectClassLoader(projectDir);
-//        var verificationRunner = new VerificationRunner(projectClassLoader);
-//        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-//
-//        Runnable verifyDefaultValues = () -> {
-//            try {
-//                var className = modelPackage + ".MultiLinePaymentRequest";
-//                Object requestObject = newInstanceOf(className, projectClassLoader);
-//                Set<ConstraintViolation<Object>> violations = validator.validate(requestObject);
-//                assertThat(violations, Matchers.hasSize(3));
-//                assertThat(
-//                    violations.stream()
-//                        .map(ConstraintViolation::getPropertyPath)
-//                        .map(Objects::toString)
-//                        .sorted()
-//                        .collect(Collectors.toList()),
-//                    Matchers.hasItems("amountNumber", "amountNumberAsString", "name")
-//                );
-//                assertThat(
-//                    violations.stream()
-//                        .map(ConstraintViolation::getMessageTemplate)
-//                        .map(Objects::toString)
-//                        .distinct()
-//                        .sorted()
-//                        .collect(Collectors.toList()),
-//                    Matchers.hasItems("{jakarta.validation.constraints.NotNull.message}")
-//                );
-//            } catch (Exception e) {
-//                throw new UnhandledException(e);
-//            }
-//        };
-//        verificationRunner.runVerification(
-//            Verification.builder().runnable(verifyDefaultValues).displayName("defaultValues").build()
-//        );
-//
-//        Runnable verifyCollectionItems = () -> {
-//            try {
-//                var className = modelPackage + ".MultiLinePaymentRequest";
-//                Object requestObject = newInstanceOf(className, projectClassLoader);
-//
-//                // set name on MultiLinePaymentRequest
-//                requestObject.getClass()
-//                    .getDeclaredMethod("setName", String.class)
-//                    .invoke(requestObject, "someName");
-//
-//                // set arrangement ids
-//                Collection<String> arrangementIds = (Collection<String>) requestObject.getClass()
-//                    .getDeclaredMethod("getArrangementIds")
-//                    .invoke(requestObject);
-//                arrangementIds.add("1");
-//                arrangementIds.add("");
-//
-//                // add PaymentRequestLine to lines
-//                Collection<Object> lines = (Collection<Object>) requestObject.getClass()
-//                    .getDeclaredMethod("getLines")
-//                    .invoke(requestObject);
-//                lines.add(newPaymeyntRequestLineObject(modelPackage, projectClassLoader, "invalidId"));
-//
-//                // add mapStrings
-//                Map<String, String> mapStrings = (Map<String, String>) requestObject.getClass()
-//                    .getDeclaredMethod("getMapStrings")
-//                    .invoke(requestObject);
-//                // mapStrings is optional, so it is null
-//                assertTrue(mapStrings == null);
-//                // but putMethod should not fail
-//                requestObject.getClass()
-//                        .getDeclaredMethod("putMapStringsItem", String.class, String.class)
-//                        .invoke(requestObject, "key0000", "asdasdasd");
-//
-//                // mapStrings not null after that
-//                mapStrings = (Map<String, String>) requestObject.getClass()
-//                        .getDeclaredMethod("getMapStrings")
-//                        .invoke(requestObject);
-//                assertTrue(mapStrings != null);
-//                mapStrings.put("key1", "abc");
-//                mapStrings.put("key2", "abcdefghijklmnopq");
-//
-//                // add mapObjects - which is optional, so initially null
-//                Map<String, Object> mapObjects = new HashMap<>();
-//                requestObject.getClass()
-//                    .getDeclaredMethod("setMapObjects", Map.class)
-//                    .invoke(requestObject, mapObjects);
-//                mapObjects.put(
-//                    "key1",
-//                    newPaymeyntRequestLineObject(modelPackage, projectClassLoader, UUID.randomUUID().toString())
-//                );
-//                mapObjects.put(
-//                    "key2",
-//                    newPaymeyntRequestLineObject(modelPackage, projectClassLoader, UUID.randomUUID().toString())
-//                );
-//
-//                // validate
-//                Set<ConstraintViolation<Object>> violations = validator.validate(requestObject);
-//                assertThat(violations, Matchers.hasSize(8));
-//
-//                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.Pattern.message}", 1);
-//                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.NotNull.message}", 2);
-//                assertViolationsCountByPath(violations, "lines[0].accountId", 1);
-//
-//                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.Size.message}", 5);
-//                assertViolationsCountByPath(violations, "arrangementIds[0].<list element>", 1);
-//                assertViolationsCountByPath(violations, "arrangementIds[1].<list element>", 1);
-//                assertViolationsCountByPath(violations, "mapStrings[key1].<map value>", 1);
-//                assertViolationsCountByPath(violations, "mapStrings[key2].<map value>", 1);
-//                assertViolationsCountByPath(violations, "mapObjects", 1);
-//
-//            } catch (Exception e) {
-//                throw new UnhandledException(e);
-//            }
-//        };
-//        verificationRunner.runVerification(
-//            Verification.builder().runnable(verifyCollectionItems).displayName("collectionItems").build()
-//        );
-//
-//        var mapper = new ObjectMapper();
-//        mapper.registerModule(new JsonNullableModule());
-//
-//        Runnable verifySerDes = () -> {
-//            try {
-//                var className = modelPackage + ".MultiLinePaymentRequest";
-//                Object requestObject = newInstanceOf(className, projectClassLoader);
-//
-//                requestObject.getClass()
-//                    .getDeclaredMethod("setName", String.class)
-//                    .invoke(requestObject, "someName");
-//
-//                requestObject.getClass()
-//                    .getDeclaredMethod("setAmountNumber", BigDecimal.class)
-//                    .invoke(requestObject, new BigDecimal("100.123"));
-//
-//                requestObject.getClass()
-//                    .getDeclaredMethod("setAmountNumberAsString", BigDecimal.class)
-//                    .invoke(requestObject, new BigDecimal("200.123"));
-//
-//                String json = mapper.writeValueAsString(requestObject);
-//                Object deserializedPojo = mapper.readValue(json, requestObject.getClass());
-//
-//                Object deserializedAmountNumber = deserializedPojo.getClass()
-//                    .getDeclaredMethod("getAmountNumber")
-//                    .invoke(deserializedPojo);
-//                assertThat(deserializedAmountNumber, isA(BigDecimal.class));
-//                assertEquals(new BigDecimal("100.123"), deserializedAmountNumber);
-//
-//                Object deserializedAmountNumberAsString = deserializedPojo.getClass()
-//                    .getDeclaredMethod("getAmountNumberAsString")
-//                    .invoke(deserializedPojo);
-//                assertThat(deserializedAmountNumberAsString, isA(BigDecimal.class));
-//                assertEquals(new BigDecimal("200.123"), deserializedAmountNumberAsString);
-//
-//            } catch (Exception e) {
-//                throw new UnhandledException(e);
-//            }
-//        };
-//        verificationRunner.runVerification(
-//            Verification.builder().runnable(verifySerDes).displayName("json-ser-des").build()
-//        );
-//    }
-//
-//    private static Object newInstanceOf(String className, ClassLoader classLoader) throws Exception {
-//        Class<?> requestClass = classLoader.loadClass(className);
-//        return requestClass.getConstructor().newInstance();
-//    }
-//
-//    private static void assertFieldAnnotation(
-//            CompilationUnit unit, String fieldName, String annotationName) throws FileNotFoundException {
-//        FieldDeclaration fieldDeclaration = findFieldDeclaration(unit, fieldName);
-//        assertThat("Expect annotation to be present on field: " + annotationName + " " + fieldName,
-//                fieldDeclaration.getAnnotationByName(annotationName).isPresent(), is(true));
-//    }
-//
-//    private static void assertFieldValueAssignment(
-//            CompilationUnit unit, String fieldName, String valueAssignment) throws FileNotFoundException {
-//        FieldDeclaration fieldDeclaration = findFieldDeclaration(unit, fieldName);
-//
-//        Optional<com.github.javaparser.ast.expr.Expression> expression = fieldDeclaration.getChildNodes()
-//                .stream()
-//                .filter(n -> n instanceof VariableDeclarator)
-//                .map(n -> ((VariableDeclarator)n).getInitializer())
-//                .findFirst().orElseThrow(
-//                        () -> new RuntimeException("VariableDeclarator not found on Field " + fieldName));
-//        if (expression.isEmpty()) {
-//            assertThat("Expected value " + valueAssignment + " for field " + fieldName,  valueAssignment == null);
-//        } else {
-//            Expression expr = expression.get();
-//            // Depending on 'toString' implementation is shaky but works for now...
-//            assertThat(expr.toString(), is(valueAssignment));
-//        }
-//    }
-//
-//    private static FieldDeclaration findFieldDeclaration(CompilationUnit unit, String fieldName) {
-//        Optional<FieldDeclaration> result = unit
-//                .findAll(FieldDeclaration.class)
-//                .stream()
-//                .filter(field -> field.getVariable(0).getName().getIdentifier().equals(fieldName))
-//                .findFirst();
-//        assertThat("Expect field declaration to be present: " + fieldName,
-//                result.isPresent(), is(true));
-//        return result.get();
-//    }
-//
-//    @NotNull
-//    private static Object newPaymeyntRequestLineObject(String modelPackage, ClassLoader projectClassLoader, String id)
-//        throws Exception {
-//        Class<?> lineObjectClass = projectClassLoader.loadClass(modelPackage + ".PaymentRequestLine");
-//        Object lineObject = lineObjectClass.getConstructor().newInstance();
-//        lineObject.getClass()
-//            .getDeclaredMethod("setAccountId", String.class)
-//            .invoke(lineObject, id);
-//        return lineObject;
-//    }
-//
-//    private static void assertViolationsCountByMessage(Set<ConstraintViolation<Object>> violations, String messageTemplate, int count) {
-//        long actualCount = violations.stream()
-//            .map(ConstraintViolation::getMessageTemplate)
-//            .filter(messageTemplate::equals)
-//            .count();
-//        assertEquals(count, actualCount,
-//            String.format("Number of violations '%s', count mismatch", messageTemplate));
-//    }
-//
-//    private static void assertViolationsCountByPath(Set<ConstraintViolation<Object>> violations, String propertyPath, int count) {
-//        long actualCount = violations.stream()
-//            .map(ConstraintViolation::getPropertyPath)
-//            .map(String::valueOf)
-//            .filter(propertyPath::equals)
-//            .count();
-//        assertEquals(count, actualCount,
-//            String.format("Number of violations '%s', count mismatch", propertyPath));
-//    }
-//
-//    private static void assertHasCollectionParamWithType(MethodDeclaration method, String paramName, String collectionType, String itemType) {
-//        Parameter parameter = method.getParameterByName(paramName).get();
-//        assertEquals(ClassOrInterfaceType.class, parameter.getType().getClass());
-//        assertEquals(collectionType, ((ClassOrInterfaceType) parameter.getType()).getName().toString());
-//        NodeList<Type> argumentTypes = ((ClassOrInterfaceType) parameter.getType())
-//            .getTypeArguments()
-//            .orElseThrow();
-//        ClassOrInterfaceType actualItemType = argumentTypes.getFirst().orElseThrow().stream()
-//            .map(ClassOrInterfaceType.class::cast)
-//            .findFirst()
-//            .orElseThrow();
-//        assertEquals(itemType, actualItemType.getName().toString());
-//    }
-//
-//    private static void assertMethodCollectionReturnType(MethodDeclaration method, String collectionType, String itemType) {
-//        assertEquals(collectionType, ((ClassOrInterfaceType) method.getType()).getName().toString());
-//        ClassOrInterfaceType collectionItemType = (ClassOrInterfaceType) ((ClassOrInterfaceType) method.getType())
-//            .getTypeArguments().get().getFirst().get();
-//        assertEquals(itemType, collectionItemType.getName().toString());
-//    }
-//}
+package com.backbase.oss.codegen.java;
+
+import static com.backbase.oss.codegen.java.BoatSpringCodeGen.USE_PROTECTED_FIELDS;
+import static java.util.stream.Collectors.groupingBy;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.backbase.oss.codegen.java.BoatSpringCodeGen.NewLineIndent;
+import com.backbase.oss.codegen.java.VerificationRunner.Verification;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import com.samskivert.mustache.Template.Fragment;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.UnhandledException;
+import org.hamcrest.Matchers;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.openapitools.codegen.CliOption;
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.languages.SpringCodegen;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+
+class BoatSpringCodeGenTests {
+
+    static final String PROP_BASE = BoatSpringCodeGenTests.class.getSimpleName() + ".";
+    static final String TEST_OUTPUT = System.getProperty(PROP_BASE + "output", "target/boat-spring-codegen-tests");
+
+    @BeforeAll
+    static void before() throws IOException {
+        Files.createDirectories(Paths.get(TEST_OUTPUT));
+        FileUtils.deleteDirectory(new File(TEST_OUTPUT));
+    }
+
+    @Test
+    void clientOptsUnicity() {
+        final BoatSpringCodeGen gen = new BoatSpringCodeGen();
+        gen.cliOptions()
+            .stream()
+            .collect(groupingBy(CliOption::getOpt))
+            .forEach((k, v) -> assertEquals(1, v.size(), k + " is described multiple times"));
+    }
+
+
+    @Test
+    void processOptsUseProtectedFields() {
+        final BoatJavaCodeGen gen = new BoatJavaCodeGen();
+        final Map<String, Object> options = gen.additionalProperties();
+
+        options.put(USE_PROTECTED_FIELDS, "true");
+
+        gen.processOpts();
+
+        assertThat(gen.additionalProperties(), hasEntry("modelFieldsVisibility", "protected"));
+    }
+
+
+    @Test
+    void newLineIndent() throws IOException {
+        final NewLineIndent indent = new BoatSpringCodeGen.NewLineIndent(2, "_");
+        final StringWriter output = new StringWriter();
+        final Fragment frag = mock(Fragment.class);
+
+        when(frag.execute()).thenReturn("\n Good \r\n   morning,  \r\n  Dave ");
+
+        indent.execute(frag, output);
+
+        assertThat(output.toString(), equalTo(String.format("__%n__Good%n__  morning,%n__ Dave%n")));
+    }
+
+    @Test
+    void addServletRequestTestFromOperation(){
+        final BoatSpringCodeGen gen = new BoatSpringCodeGen();
+        gen.addServletRequest = true;
+        CodegenOperation co = gen.fromOperation("/test", "POST", new Operation(), null);
+        assertEquals(1, co.allParams.size());
+        assertEquals("httpServletRequest", co.allParams.get(0).paramName);
+        assertTrue(Arrays.stream(co.allParams.get(0).getClass().getDeclaredFields()).anyMatch(f -> "isHttpServletRequest".equals(f.getName())));
+    }
+
+    @Test
+    void multipartWithFileAndObject() throws IOException {
+        var codegen = new BoatSpringCodeGen();
+        var input = new File("src/test/resources/boat-spring/multipart.yaml");
+        codegen.setLibrary("spring-boot");
+        codegen.setInterfaceOnly(true);
+        codegen.setOutputDir(TEST_OUTPUT + "/multipart");
+        codegen.setInputSpec(input.getAbsolutePath());
+
+        var openApiInput = new OpenAPIParser().readLocation(input.getAbsolutePath(), null, new ParseOptions()).getOpenAPI();
+        var clientOptInput = new ClientOptInput();
+        clientOptInput.config(codegen);
+        clientOptInput.openAPI(openApiInput);
+
+        List<File> files = new DefaultGenerator().opts(clientOptInput).generate();
+
+        File testApi = files.stream().filter(file -> file.getName().equals("TestApi.java"))
+            .findFirst()
+            .get();
+        MethodDeclaration testPostMethod = StaticJavaParser.parse(testApi)
+            .findAll(MethodDeclaration.class)
+            .get(1);
+
+        Parameter filesParam = testPostMethod.getParameterByName("files").get();
+        Parameter contentParam = testPostMethod.getParameterByName("content").get();
+
+        assertTrue(filesParam.getAnnotationByName("RequestPart").isPresent());
+        assertTrue(contentParam.getAnnotationByName("RequestPart").isPresent());
+        assertThat(contentParam.getTypeAsString(), equalTo("TestObjectPart"));
+        assertThat(filesParam.getTypeAsString(), equalTo("List<MultipartFile>"));
+    }
+
+    @Test
+    void testReplaceBeanValidationCollectionType() {
+        var codegen = new BoatSpringCodeGen();
+        codegen.setUseBeanValidation(true);
+        var codegenProperty = new CodegenProperty();
+        codegenProperty.isModel = true;
+        codegenProperty.baseName = "request"; // not a response
+
+        String result = codegen.replaceBeanValidationCollectionType(
+                codegenProperty,"Set<@Valid com.backbase.dbs.arrangement.commons.model.TranslationItemDto>");
+        assertEquals("Set<com.backbase.dbs.arrangement.commons.model.@Valid TranslationItemDto>", result);
+    }
+    @ParameterizedTest
+    @CsvSource(value = {"true,true", "true,false", "false,true", "false,false"})
+    @SuppressWarnings("unchecked")
+    void shouldGenerateValidations(boolean useLombok, boolean bigDecimalsAsStrings) throws InterruptedException, IOException {
+
+        final String REFERENCED_CLASS_NAME = "com.backbase.oss.codegen.java.ValidatedPojo";
+        final String REFERENCED_ENUM_NAME = "com.backbase.oss.codegen.java.CommonEnum";
+
+        var modelPackage = "com.backbase.model";
+        var input = new File("src/test/resources/boat-spring/openapi.yaml");
+        var output = TEST_OUTPUT + String.format("/shouldGenerateValidations_lombok-%s_bigDecString-%s", useLombok,
+            bigDecimalsAsStrings);
+
+        // generate project
+        var codegen = new BoatSpringCodeGen();
+        codegen.setLibrary("spring-boot");
+        codegen.setInterfaceOnly(true);
+        codegen.setSkipDefaultInterface(true);
+        codegen.setOutputDir(output);
+        codegen.setInputSpec(input.getAbsolutePath());
+        codegen.setContainerDefaultToNull(true);
+        codegen.setSerializeBigDecimalAsString(bigDecimalsAsStrings);
+        codegen.setUseLombokAnnotations(useLombok);
+        codegen.schemaMapping().put("ValidatedPojo", REFERENCED_CLASS_NAME);
+        codegen.schemaMapping().put("CommonEnum", REFERENCED_ENUM_NAME);
+        codegen.additionalProperties().put(SpringCodegen.USE_SPRING_BOOT3, Boolean.TRUE.toString());
+        codegen.additionalProperties().put(BoatSpringCodeGen.USE_CLASS_LEVEL_BEAN_VALIDATION, Boolean.TRUE.toString());
+        codegen.setModelPackage(modelPackage);
+
+        var openApiInput = new OpenAPIParser()
+            .readLocation(input.getAbsolutePath(), null, new ParseOptions())
+            .getOpenAPI();
+        var clientOptInput = new ClientOptInput();
+        clientOptInput.config(codegen);
+        clientOptInput.openAPI(openApiInput);
+
+        List<File> files = new DefaultGenerator().opts(clientOptInput).generate();
+
+        File paymentsApiFile = files.stream().filter(file -> file.getName().equals("PaymentsApi.java"))
+            .findFirst()
+            .get();
+        MethodDeclaration getPaymentsMethod = StaticJavaParser.parse(paymentsApiFile)
+            .findAll(MethodDeclaration.class)
+            .stream()
+            .filter(it -> "getPayments".equals(it.getName().toString()))
+            .findFirst().orElseThrow();
+        assertHasCollectionParamWithType(getPaymentsMethod, "approvalTypeIds", "List", "String");
+        assertHasCollectionParamWithType(getPaymentsMethod, "status", "List", "String");
+        assertHasCollectionParamWithType(getPaymentsMethod, "headerParams", "List", "String");
+
+        File paymentRequestLine = files.stream().filter(file -> file.getName().equals("PaymentRequestLine.java"))
+            .findFirst()
+            .get();
+        CompilationUnit paymentRequestLineUnit = StaticJavaParser.parse(paymentRequestLine);
+        if (!useLombok) {
+            MethodDeclaration getStatus = paymentRequestLineUnit
+                .findAll(MethodDeclaration.class)
+                .stream()
+                .filter(it -> "getStatus".equals(it.getName().toString()))
+                .findFirst().orElseThrow();
+            assertMethodCollectionReturnType(getStatus, "List", "StatusEnum");
+        }
+        assertFieldValueAssignment(paymentRequestLineUnit, "additionalPropertiesMap", "new HashMap<>()");
+
+        File paymentRequest = files.stream().filter(file -> file.getName().equals("PaymentRequest.java"))
+            .findFirst()
+            .get();
+        CompilationUnit paymentRequestUnit = StaticJavaParser.parse(paymentRequest);
+        assertFieldAnnotation(paymentRequestUnit, "currencyCode", "Pattern");
+        assertFieldAnnotation(paymentRequestUnit, "currencyCode", "NotNull");
+        assertFieldAnnotation(paymentRequestUnit, "referenceNumber", "Size");
+        assertFieldAnnotation(paymentRequestUnit, "referenceNumber", "NotNull");
+        assertFieldAnnotation(paymentRequestUnit, "requestLine", "Valid");
+
+        File multiLinePaymentRequest = files.stream().filter(f -> f.getName().equals("MultiLinePaymentRequest.java"))
+                .findFirst()
+                .get();
+        CompilationUnit multiLinePaymentRequestUnit = StaticJavaParser.parse(multiLinePaymentRequest);
+
+        assertFieldAnnotation(multiLinePaymentRequestUnit, "arrangementIds", "NotNull");
+        assertFieldValueAssignment(
+                multiLinePaymentRequestUnit, "arrangementIds", "new ArrayList<>()");
+        assertFieldAnnotation(multiLinePaymentRequestUnit, "uniqueLines", "NotNull");
+        assertFieldValueAssignment(
+                multiLinePaymentRequestUnit, "uniqueArrangementIds", null);
+
+        // assert annotation
+
+        FileUtils.copyToFile(
+                getClass().getResourceAsStream("/boat-spring/ValidatedPojo.java"),
+                new File(output + "/src/main/java/"
+                        + REFERENCED_CLASS_NAME.replaceAll("\\.", "/") + "/ValidatedPojo.java"));
+        FileUtils.copyToFile(
+                getClass().getResourceAsStream("/boat-spring/CommonEnum.java"),
+                new File(output + "/src/main/java/"
+                        + REFERENCED_ENUM_NAME.replaceAll("\\.", "/") + "/CommonEnum.java"));
+
+        // compile generated project
+        var compiler = new MavenProjectCompiler(BoatSpringCodeGenTests.class.getClassLoader());
+        var projectDir = new File(output);
+        int compilationStatus = compiler.compile(projectDir);
+        assertEquals(0, compilationStatus);
+
+        // verify
+        ClassLoader projectClassLoader = compiler.getProjectClassLoader(projectDir);
+        var verificationRunner = new VerificationRunner(projectClassLoader);
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        Runnable verifyDefaultValues = () -> {
+            try {
+                var className = modelPackage + ".MultiLinePaymentRequest";
+                Object requestObject = newInstanceOf(className, projectClassLoader);
+                Set<ConstraintViolation<Object>> violations = validator.validate(requestObject);
+                assertThat(violations, Matchers.hasSize(3));
+                assertThat(
+                    violations.stream()
+                        .map(ConstraintViolation::getPropertyPath)
+                        .map(Objects::toString)
+                        .sorted()
+                        .collect(Collectors.toList()),
+                    Matchers.hasItems("amountNumber", "amountNumberAsString", "name")
+                );
+                assertThat(
+                    violations.stream()
+                        .map(ConstraintViolation::getMessageTemplate)
+                        .map(Objects::toString)
+                        .distinct()
+                        .sorted()
+                        .collect(Collectors.toList()),
+                    Matchers.hasItems("{jakarta.validation.constraints.NotNull.message}")
+                );
+            } catch (Exception e) {
+                throw new UnhandledException(e);
+            }
+        };
+        verificationRunner.runVerification(
+            Verification.builder().runnable(verifyDefaultValues).displayName("defaultValues").build()
+        );
+
+        Runnable verifyCollectionItems = () -> {
+            try {
+                var className = modelPackage + ".MultiLinePaymentRequest";
+                Object requestObject = newInstanceOf(className, projectClassLoader);
+
+                // set name on MultiLinePaymentRequest
+                requestObject.getClass()
+                    .getDeclaredMethod("setName", String.class)
+                    .invoke(requestObject, "someName");
+
+                // set arrangement ids
+                Collection<String> arrangementIds = (Collection<String>) requestObject.getClass()
+                    .getDeclaredMethod("getArrangementIds")
+                    .invoke(requestObject);
+                arrangementIds.add("1");
+                arrangementIds.add("");
+
+                // add PaymentRequestLine to lines
+                Collection<Object> lines = (Collection<Object>) requestObject.getClass()
+                    .getDeclaredMethod("getLines")
+                    .invoke(requestObject);
+                lines.add(newPaymeyntRequestLineObject(modelPackage, projectClassLoader, "invalidId"));
+
+                // add mapStrings
+                Map<String, String> mapStrings = (Map<String, String>) requestObject.getClass()
+                    .getDeclaredMethod("getMapStrings")
+                    .invoke(requestObject);
+                // mapStrings is optional, so it is null
+                assertTrue(mapStrings == null);
+                // but putMethod should not fail
+                requestObject.getClass()
+                        .getDeclaredMethod("putMapStringsItem", String.class, String.class)
+                        .invoke(requestObject, "key0000", "asdasdasd");
+
+                // mapStrings not null after that
+                mapStrings = (Map<String, String>) requestObject.getClass()
+                        .getDeclaredMethod("getMapStrings")
+                        .invoke(requestObject);
+                assertTrue(mapStrings != null);
+                mapStrings.put("key1", "abc");
+                mapStrings.put("key2", "abcdefghijklmnopq");
+
+                // add mapObjects - which is optional, so initially null
+                Map<String, Object> mapObjects = new HashMap<>();
+                requestObject.getClass()
+                    .getDeclaredMethod("setMapObjects", Map.class)
+                    .invoke(requestObject, mapObjects);
+                mapObjects.put(
+                    "key1",
+                    newPaymeyntRequestLineObject(modelPackage, projectClassLoader, UUID.randomUUID().toString())
+                );
+                mapObjects.put(
+                    "key2",
+                    newPaymeyntRequestLineObject(modelPackage, projectClassLoader, UUID.randomUUID().toString())
+                );
+
+                // validate
+                Set<ConstraintViolation<Object>> violations = validator.validate(requestObject);
+                assertThat(violations, Matchers.hasSize(8));
+
+                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.Pattern.message}", 1);
+                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.NotNull.message}", 2);
+                assertViolationsCountByPath(violations, "lines[0].accountId", 1);
+
+                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.Size.message}", 5);
+                assertViolationsCountByPath(violations, "arrangementIds[0].<list element>", 1);
+                assertViolationsCountByPath(violations, "arrangementIds[1].<list element>", 1);
+                assertViolationsCountByPath(violations, "mapStrings[key1].<map value>", 1);
+                assertViolationsCountByPath(violations, "mapStrings[key2].<map value>", 1);
+                assertViolationsCountByPath(violations, "mapObjects", 1);
+
+            } catch (Exception e) {
+                throw new UnhandledException(e);
+            }
+        };
+        verificationRunner.runVerification(
+            Verification.builder().runnable(verifyCollectionItems).displayName("collectionItems").build()
+        );
+
+        var mapper = new ObjectMapper();
+        mapper.registerModule(new JsonNullableModule());
+
+        Runnable verifySerDes = () -> {
+            try {
+                var className = modelPackage + ".MultiLinePaymentRequest";
+                Object requestObject = newInstanceOf(className, projectClassLoader);
+
+                requestObject.getClass()
+                    .getDeclaredMethod("setName", String.class)
+                    .invoke(requestObject, "someName");
+
+                requestObject.getClass()
+                    .getDeclaredMethod("setAmountNumber", BigDecimal.class)
+                    .invoke(requestObject, new BigDecimal("100.123"));
+
+                requestObject.getClass()
+                    .getDeclaredMethod("setAmountNumberAsString", BigDecimal.class)
+                    .invoke(requestObject, new BigDecimal("200.123"));
+
+                String json = mapper.writeValueAsString(requestObject);
+                Object deserializedPojo = mapper.readValue(json, requestObject.getClass());
+
+                Object deserializedAmountNumber = deserializedPojo.getClass()
+                    .getDeclaredMethod("getAmountNumber")
+                    .invoke(deserializedPojo);
+                assertThat(deserializedAmountNumber, isA(BigDecimal.class));
+                assertEquals(new BigDecimal("100.123"), deserializedAmountNumber);
+
+                Object deserializedAmountNumberAsString = deserializedPojo.getClass()
+                    .getDeclaredMethod("getAmountNumberAsString")
+                    .invoke(deserializedPojo);
+                assertThat(deserializedAmountNumberAsString, isA(BigDecimal.class));
+                assertEquals(new BigDecimal("200.123"), deserializedAmountNumberAsString);
+
+            } catch (Exception e) {
+                throw new UnhandledException(e);
+            }
+        };
+        verificationRunner.runVerification(
+            Verification.builder().runnable(verifySerDes).displayName("json-ser-des").build()
+        );
+    }
+
+    private static Object newInstanceOf(String className, ClassLoader classLoader) throws Exception {
+        Class<?> requestClass = classLoader.loadClass(className);
+        return requestClass.getConstructor().newInstance();
+    }
+
+    private static void assertFieldAnnotation(
+            CompilationUnit unit, String fieldName, String annotationName) throws FileNotFoundException {
+        FieldDeclaration fieldDeclaration = findFieldDeclaration(unit, fieldName);
+        assertThat("Expect annotation to be present on field: " + annotationName + " " + fieldName,
+                fieldDeclaration.getAnnotationByName(annotationName).isPresent(), is(true));
+    }
+
+    private static void assertFieldValueAssignment(
+            CompilationUnit unit, String fieldName, String valueAssignment) throws FileNotFoundException {
+        FieldDeclaration fieldDeclaration = findFieldDeclaration(unit, fieldName);
+
+        Optional<com.github.javaparser.ast.expr.Expression> expression = fieldDeclaration.getChildNodes()
+                .stream()
+                .filter(n -> n instanceof VariableDeclarator)
+                .map(n -> ((VariableDeclarator)n).getInitializer())
+                .findFirst().orElseThrow(
+                        () -> new RuntimeException("VariableDeclarator not found on Field " + fieldName));
+        if (expression.isEmpty()) {
+            assertThat("Expected value " + valueAssignment + " for field " + fieldName,  valueAssignment == null);
+        } else {
+            Expression expr = expression.get();
+            // Depending on 'toString' implementation is shaky but works for now...
+            assertThat(expr.toString(), is(valueAssignment));
+        }
+    }
+
+    private static FieldDeclaration findFieldDeclaration(CompilationUnit unit, String fieldName) {
+        Optional<FieldDeclaration> result = unit
+                .findAll(FieldDeclaration.class)
+                .stream()
+                .filter(field -> field.getVariable(0).getName().getIdentifier().equals(fieldName))
+                .findFirst();
+        assertThat("Expect field declaration to be present: " + fieldName,
+                result.isPresent(), is(true));
+        return result.get();
+    }
+
+    @NotNull
+    private static Object newPaymeyntRequestLineObject(String modelPackage, ClassLoader projectClassLoader, String id)
+        throws Exception {
+        Class<?> lineObjectClass = projectClassLoader.loadClass(modelPackage + ".PaymentRequestLine");
+        Object lineObject = lineObjectClass.getConstructor().newInstance();
+        lineObject.getClass()
+            .getDeclaredMethod("setAccountId", String.class)
+            .invoke(lineObject, id);
+        return lineObject;
+    }
+
+    private static void assertViolationsCountByMessage(Set<ConstraintViolation<Object>> violations, String messageTemplate, int count) {
+        long actualCount = violations.stream()
+            .map(ConstraintViolation::getMessageTemplate)
+            .filter(messageTemplate::equals)
+            .count();
+        assertEquals(count, actualCount,
+            String.format("Number of violations '%s', count mismatch", messageTemplate));
+    }
+
+    private static void assertViolationsCountByPath(Set<ConstraintViolation<Object>> violations, String propertyPath, int count) {
+        long actualCount = violations.stream()
+            .map(ConstraintViolation::getPropertyPath)
+            .map(String::valueOf)
+            .filter(propertyPath::equals)
+            .count();
+        assertEquals(count, actualCount,
+            String.format("Number of violations '%s', count mismatch", propertyPath));
+    }
+
+    private static void assertHasCollectionParamWithType(MethodDeclaration method, String paramName, String collectionType, String itemType) {
+        Parameter parameter = method.getParameterByName(paramName).get();
+        assertEquals(ClassOrInterfaceType.class, parameter.getType().getClass());
+        assertEquals(collectionType, ((ClassOrInterfaceType) parameter.getType()).getName().toString());
+        NodeList<Type> argumentTypes = ((ClassOrInterfaceType) parameter.getType())
+            .getTypeArguments()
+            .orElseThrow();
+        ClassOrInterfaceType actualItemType = argumentTypes.getFirst().orElseThrow().stream()
+            .map(ClassOrInterfaceType.class::cast)
+            .findFirst()
+            .orElseThrow();
+        assertEquals(itemType, actualItemType.getName().toString());
+    }
+
+    private static void assertMethodCollectionReturnType(MethodDeclaration method, String collectionType, String itemType) {
+        assertEquals(collectionType, ((ClassOrInterfaceType) method.getType()).getName().toString());
+        ClassOrInterfaceType collectionItemType = (ClassOrInterfaceType) ((ClassOrInterfaceType) method.getType())
+            .getTypeArguments().get().getFirst().get();
+        assertEquals(itemType, collectionItemType.getName().toString());
+    }
+}

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
@@ -1,523 +1,523 @@
-package com.backbase.oss.codegen.java;
-
-import static com.backbase.oss.codegen.java.BoatSpringCodeGen.USE_PROTECTED_FIELDS;
-import static java.util.stream.Collectors.groupingBy;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isA;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import com.backbase.oss.codegen.java.BoatSpringCodeGen.NewLineIndent;
-import com.backbase.oss.codegen.java.VerificationRunner.Verification;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.javaparser.StaticJavaParser;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.FieldDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.Parameter;
-import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.ast.type.Type;
-import com.samskivert.mustache.Template.Fragment;
-import io.swagger.parser.OpenAPIParser;
-import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.parser.core.models.ParseOptions;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Validation;
-import jakarta.validation.Validator;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.math.BigDecimal;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.UnhandledException;
-import org.hamcrest.Matchers;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.openapitools.codegen.CliOption;
-import org.openapitools.codegen.ClientOptInput;
-import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.DefaultGenerator;
-import org.openapitools.codegen.languages.SpringCodegen;
-import org.openapitools.jackson.nullable.JsonNullableModule;
-
-class BoatSpringCodeGenTests {
-
-    static final String PROP_BASE = BoatSpringCodeGenTests.class.getSimpleName() + ".";
-    static final String TEST_OUTPUT = System.getProperty(PROP_BASE + "output", "target/boat-spring-codegen-tests");
-
-    @BeforeAll
-    static void before() throws IOException {
-        Files.createDirectories(Paths.get(TEST_OUTPUT));
-        FileUtils.deleteDirectory(new File(TEST_OUTPUT));
-    }
-
-    @Test
-    void clientOptsUnicity() {
-        final BoatSpringCodeGen gen = new BoatSpringCodeGen();
-        gen.cliOptions()
-            .stream()
-            .collect(groupingBy(CliOption::getOpt))
-            .forEach((k, v) -> assertEquals(1, v.size(), k + " is described multiple times"));
-    }
-
-
-    @Test
-    void processOptsUseProtectedFields() {
-        final BoatJavaCodeGen gen = new BoatJavaCodeGen();
-        final Map<String, Object> options = gen.additionalProperties();
-
-        options.put(USE_PROTECTED_FIELDS, "true");
-
-        gen.processOpts();
-
-        assertThat(gen.additionalProperties(), hasEntry("modelFieldsVisibility", "protected"));
-    }
-
-
-    @Test
-    void newLineIndent() throws IOException {
-        final NewLineIndent indent = new BoatSpringCodeGen.NewLineIndent(2, "_");
-        final StringWriter output = new StringWriter();
-        final Fragment frag = mock(Fragment.class);
-
-        when(frag.execute()).thenReturn("\n Good \r\n   morning,  \r\n  Dave ");
-
-        indent.execute(frag, output);
-
-        assertThat(output.toString(), equalTo(String.format("__%n__Good%n__  morning,%n__ Dave%n")));
-    }
-
-    @Test
-    void addServletRequestTestFromOperation(){
-        final BoatSpringCodeGen gen = new BoatSpringCodeGen();
-        gen.addServletRequest = true;
-        CodegenOperation co = gen.fromOperation("/test", "POST", new Operation(), null);
-        assertEquals(1, co.allParams.size());
-        assertEquals("httpServletRequest", co.allParams.get(0).paramName);
-        assertTrue(Arrays.stream(co.allParams.get(0).getClass().getDeclaredFields()).anyMatch(f -> "isHttpServletRequest".equals(f.getName())));
-    }
-
-    @Test
-    void multipartWithFileAndObject() throws IOException {
-        var codegen = new BoatSpringCodeGen();
-        var input = new File("src/test/resources/boat-spring/multipart.yaml");
-        codegen.setLibrary("spring-boot");
-        codegen.setInterfaceOnly(true);
-        codegen.setOutputDir(TEST_OUTPUT + "/multipart");
-        codegen.setInputSpec(input.getAbsolutePath());
-
-        var openApiInput = new OpenAPIParser().readLocation(input.getAbsolutePath(), null, new ParseOptions()).getOpenAPI();
-        var clientOptInput = new ClientOptInput();
-        clientOptInput.config(codegen);
-        clientOptInput.openAPI(openApiInput);
-
-        List<File> files = new DefaultGenerator().opts(clientOptInput).generate();
-
-        File testApi = files.stream().filter(file -> file.getName().equals("TestApi.java"))
-            .findFirst()
-            .get();
-        MethodDeclaration testPostMethod = StaticJavaParser.parse(testApi)
-            .findAll(MethodDeclaration.class)
-            .get(1);
-
-        Parameter filesParam = testPostMethod.getParameterByName("files").get();
-        Parameter contentParam = testPostMethod.getParameterByName("content").get();
-
-        assertTrue(filesParam.getAnnotationByName("RequestPart").isPresent());
-        assertTrue(contentParam.getAnnotationByName("RequestPart").isPresent());
-        assertThat(contentParam.getTypeAsString(), equalTo("TestObjectPart"));
-        assertThat(filesParam.getTypeAsString(), equalTo("List<MultipartFile>"));
-    }
-
-    @Test
-    void testReplaceBeanValidationCollectionType() {
-        var codegen = new BoatSpringCodeGen();
-        codegen.setUseBeanValidation(true);
-        var codegenProperty = new CodegenProperty();
-        codegenProperty.isModel = true;
-        codegenProperty.baseName = "request"; // not a response
-
-        String result = codegen.replaceBeanValidationCollectionType(
-                codegenProperty,"Set<@Valid com.backbase.dbs.arrangement.commons.model.TranslationItemDto>");
-        assertEquals("Set<com.backbase.dbs.arrangement.commons.model.@Valid TranslationItemDto>", result);
-    }
-    @ParameterizedTest
-    @CsvSource(value = {"true,true", "true,false", "false,true", "false,false"})
-    @SuppressWarnings("unchecked")
-    void shouldGenerateValidations(boolean useLombok, boolean bigDecimalsAsStrings) throws InterruptedException, IOException {
-
-        final String REFERENCED_CLASS_NAME = "com.backbase.oss.codegen.java.ValidatedPojo";
-        final String REFERENCED_ENUM_NAME = "com.backbase.oss.codegen.java.CommonEnum";
-
-        var modelPackage = "com.backbase.model";
-        var input = new File("src/test/resources/boat-spring/openapi.yaml");
-        var output = TEST_OUTPUT + String.format("/shouldGenerateValidations_lombok-%s_bigDecString-%s", useLombok,
-            bigDecimalsAsStrings);
-
-        // generate project
-        var codegen = new BoatSpringCodeGen();
-        codegen.setLibrary("spring-boot");
-        codegen.setInterfaceOnly(true);
-        codegen.setSkipDefaultInterface(true);
-        codegen.setOutputDir(output);
-        codegen.setInputSpec(input.getAbsolutePath());
-        codegen.setContainerDefaultToNull(true);
-        codegen.setSerializeBigDecimalAsString(bigDecimalsAsStrings);
-        codegen.setUseLombokAnnotations(useLombok);
-        codegen.schemaMapping().put("ValidatedPojo", REFERENCED_CLASS_NAME);
-        codegen.schemaMapping().put("CommonEnum", REFERENCED_ENUM_NAME);
-        codegen.additionalProperties().put(SpringCodegen.USE_SPRING_BOOT3, Boolean.TRUE.toString());
-        codegen.additionalProperties().put(BoatSpringCodeGen.USE_CLASS_LEVEL_BEAN_VALIDATION, Boolean.TRUE.toString());
-        codegen.setModelPackage(modelPackage);
-
-        var openApiInput = new OpenAPIParser()
-            .readLocation(input.getAbsolutePath(), null, new ParseOptions())
-            .getOpenAPI();
-        var clientOptInput = new ClientOptInput();
-        clientOptInput.config(codegen);
-        clientOptInput.openAPI(openApiInput);
-
-        List<File> files = new DefaultGenerator().opts(clientOptInput).generate();
-
-        File paymentsApiFile = files.stream().filter(file -> file.getName().equals("PaymentsApi.java"))
-            .findFirst()
-            .get();
-        MethodDeclaration getPaymentsMethod = StaticJavaParser.parse(paymentsApiFile)
-            .findAll(MethodDeclaration.class)
-            .stream()
-            .filter(it -> "getPayments".equals(it.getName().toString()))
-            .findFirst().orElseThrow();
-        assertHasCollectionParamWithType(getPaymentsMethod, "approvalTypeIds", "List", "String");
-        assertHasCollectionParamWithType(getPaymentsMethod, "status", "List", "String");
-        assertHasCollectionParamWithType(getPaymentsMethod, "headerParams", "List", "String");
-
-        File paymentRequestLine = files.stream().filter(file -> file.getName().equals("PaymentRequestLine.java"))
-            .findFirst()
-            .get();
-        CompilationUnit paymentRequestLineUnit = StaticJavaParser.parse(paymentRequestLine);
-        if (!useLombok) {
-            MethodDeclaration getStatus = paymentRequestLineUnit
-                .findAll(MethodDeclaration.class)
-                .stream()
-                .filter(it -> "getStatus".equals(it.getName().toString()))
-                .findFirst().orElseThrow();
-            assertMethodCollectionReturnType(getStatus, "List", "StatusEnum");
-        }
-        assertFieldValueAssignment(paymentRequestLineUnit, "additionalPropertiesMap", "new HashMap<>()");
-
-        File paymentRequest = files.stream().filter(file -> file.getName().equals("PaymentRequest.java"))
-            .findFirst()
-            .get();
-        CompilationUnit paymentRequestUnit = StaticJavaParser.parse(paymentRequest);
-        assertFieldAnnotation(paymentRequestUnit, "currencyCode", "Pattern");
-        assertFieldAnnotation(paymentRequestUnit, "currencyCode", "NotNull");
-        assertFieldAnnotation(paymentRequestUnit, "referenceNumber", "Size");
-        assertFieldAnnotation(paymentRequestUnit, "referenceNumber", "NotNull");
-        assertFieldAnnotation(paymentRequestUnit, "requestLine", "Valid");
-
-        File multiLinePaymentRequest = files.stream().filter(f -> f.getName().equals("MultiLinePaymentRequest.java"))
-                .findFirst()
-                .get();
-        CompilationUnit multiLinePaymentRequestUnit = StaticJavaParser.parse(multiLinePaymentRequest);
-
-        assertFieldAnnotation(multiLinePaymentRequestUnit, "arrangementIds", "NotNull");
-        assertFieldValueAssignment(
-                multiLinePaymentRequestUnit, "arrangementIds", "new ArrayList<>()");
-        assertFieldAnnotation(multiLinePaymentRequestUnit, "uniqueLines", "NotNull");
-        assertFieldValueAssignment(
-                multiLinePaymentRequestUnit, "uniqueArrangementIds", null);
-
-        // assert annotation
-
-        FileUtils.copyToFile(
-                getClass().getResourceAsStream("/boat-spring/ValidatedPojo.java"),
-                new File(output + "/src/main/java/"
-                        + REFERENCED_CLASS_NAME.replaceAll("\\.", "/") + "/ValidatedPojo.java"));
-        FileUtils.copyToFile(
-                getClass().getResourceAsStream("/boat-spring/CommonEnum.java"),
-                new File(output + "/src/main/java/"
-                        + REFERENCED_ENUM_NAME.replaceAll("\\.", "/") + "/CommonEnum.java"));
-
-        // compile generated project
-        var compiler = new MavenProjectCompiler(BoatSpringCodeGenTests.class.getClassLoader());
-        var projectDir = new File(output);
-        int compilationStatus = compiler.compile(projectDir);
-        assertEquals(0, compilationStatus);
-
-        // verify
-        ClassLoader projectClassLoader = compiler.getProjectClassLoader(projectDir);
-        var verificationRunner = new VerificationRunner(projectClassLoader);
-        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-
-        Runnable verifyDefaultValues = () -> {
-            try {
-                var className = modelPackage + ".MultiLinePaymentRequest";
-                Object requestObject = newInstanceOf(className, projectClassLoader);
-                Set<ConstraintViolation<Object>> violations = validator.validate(requestObject);
-                assertThat(violations, Matchers.hasSize(3));
-                assertThat(
-                    violations.stream()
-                        .map(ConstraintViolation::getPropertyPath)
-                        .map(Objects::toString)
-                        .sorted()
-                        .collect(Collectors.toList()),
-                    Matchers.hasItems("amountNumber", "amountNumberAsString", "name")
-                );
-                assertThat(
-                    violations.stream()
-                        .map(ConstraintViolation::getMessageTemplate)
-                        .map(Objects::toString)
-                        .distinct()
-                        .sorted()
-                        .collect(Collectors.toList()),
-                    Matchers.hasItems("{jakarta.validation.constraints.NotNull.message}")
-                );
-            } catch (Exception e) {
-                throw new UnhandledException(e);
-            }
-        };
-        verificationRunner.runVerification(
-            Verification.builder().runnable(verifyDefaultValues).displayName("defaultValues").build()
-        );
-
-        Runnable verifyCollectionItems = () -> {
-            try {
-                var className = modelPackage + ".MultiLinePaymentRequest";
-                Object requestObject = newInstanceOf(className, projectClassLoader);
-
-                // set name on MultiLinePaymentRequest
-                requestObject.getClass()
-                    .getDeclaredMethod("setName", String.class)
-                    .invoke(requestObject, "someName");
-
-                // set arrangement ids
-                Collection<String> arrangementIds = (Collection<String>) requestObject.getClass()
-                    .getDeclaredMethod("getArrangementIds")
-                    .invoke(requestObject);
-                arrangementIds.add("1");
-                arrangementIds.add("");
-
-                // add PaymentRequestLine to lines
-                Collection<Object> lines = (Collection<Object>) requestObject.getClass()
-                    .getDeclaredMethod("getLines")
-                    .invoke(requestObject);
-                lines.add(newPaymeyntRequestLineObject(modelPackage, projectClassLoader, "invalidId"));
-
-                // add mapStrings
-                Map<String, String> mapStrings = (Map<String, String>) requestObject.getClass()
-                    .getDeclaredMethod("getMapStrings")
-                    .invoke(requestObject);
-                // mapStrings is optional, so it is null
-                assertTrue(mapStrings == null);
-                // but putMethod should not fail
-                requestObject.getClass()
-                        .getDeclaredMethod("putMapStringsItem", String.class, String.class)
-                        .invoke(requestObject, "key0000", "asdasdasd");
-
-                // mapStrings not null after that
-                mapStrings = (Map<String, String>) requestObject.getClass()
-                        .getDeclaredMethod("getMapStrings")
-                        .invoke(requestObject);
-                assertTrue(mapStrings != null);
-                mapStrings.put("key1", "abc");
-                mapStrings.put("key2", "abcdefghijklmnopq");
-
-                // add mapObjects - which is optional, so initially null
-                Map<String, Object> mapObjects = new HashMap<>();
-                requestObject.getClass()
-                    .getDeclaredMethod("setMapObjects", Map.class)
-                    .invoke(requestObject, mapObjects);
-                mapObjects.put(
-                    "key1",
-                    newPaymeyntRequestLineObject(modelPackage, projectClassLoader, UUID.randomUUID().toString())
-                );
-                mapObjects.put(
-                    "key2",
-                    newPaymeyntRequestLineObject(modelPackage, projectClassLoader, UUID.randomUUID().toString())
-                );
-
-                // validate
-                Set<ConstraintViolation<Object>> violations = validator.validate(requestObject);
-                assertThat(violations, Matchers.hasSize(8));
-
-                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.Pattern.message}", 1);
-                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.NotNull.message}", 2);
-                assertViolationsCountByPath(violations, "lines[0].accountId", 1);
-
-                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.Size.message}", 5);
-                assertViolationsCountByPath(violations, "arrangementIds[0].<list element>", 1);
-                assertViolationsCountByPath(violations, "arrangementIds[1].<list element>", 1);
-                assertViolationsCountByPath(violations, "mapStrings[key1].<map value>", 1);
-                assertViolationsCountByPath(violations, "mapStrings[key2].<map value>", 1);
-                assertViolationsCountByPath(violations, "mapObjects", 1);
-
-            } catch (Exception e) {
-                throw new UnhandledException(e);
-            }
-        };
-        verificationRunner.runVerification(
-            Verification.builder().runnable(verifyCollectionItems).displayName("collectionItems").build()
-        );
-
-        var mapper = new ObjectMapper();
-        mapper.registerModule(new JsonNullableModule());
-
-        Runnable verifySerDes = () -> {
-            try {
-                var className = modelPackage + ".MultiLinePaymentRequest";
-                Object requestObject = newInstanceOf(className, projectClassLoader);
-
-                requestObject.getClass()
-                    .getDeclaredMethod("setName", String.class)
-                    .invoke(requestObject, "someName");
-
-                requestObject.getClass()
-                    .getDeclaredMethod("setAmountNumber", BigDecimal.class)
-                    .invoke(requestObject, new BigDecimal("100.123"));
-
-                requestObject.getClass()
-                    .getDeclaredMethod("setAmountNumberAsString", BigDecimal.class)
-                    .invoke(requestObject, new BigDecimal("200.123"));
-
-                String json = mapper.writeValueAsString(requestObject);
-                Object deserializedPojo = mapper.readValue(json, requestObject.getClass());
-
-                Object deserializedAmountNumber = deserializedPojo.getClass()
-                    .getDeclaredMethod("getAmountNumber")
-                    .invoke(deserializedPojo);
-                assertThat(deserializedAmountNumber, isA(BigDecimal.class));
-                assertEquals(new BigDecimal("100.123"), deserializedAmountNumber);
-
-                Object deserializedAmountNumberAsString = deserializedPojo.getClass()
-                    .getDeclaredMethod("getAmountNumberAsString")
-                    .invoke(deserializedPojo);
-                assertThat(deserializedAmountNumberAsString, isA(BigDecimal.class));
-                assertEquals(new BigDecimal("200.123"), deserializedAmountNumberAsString);
-
-            } catch (Exception e) {
-                throw new UnhandledException(e);
-            }
-        };
-        verificationRunner.runVerification(
-            Verification.builder().runnable(verifySerDes).displayName("json-ser-des").build()
-        );
-    }
-
-    private static Object newInstanceOf(String className, ClassLoader classLoader) throws Exception {
-        Class<?> requestClass = classLoader.loadClass(className);
-        return requestClass.getConstructor().newInstance();
-    }
-
-    private static void assertFieldAnnotation(
-            CompilationUnit unit, String fieldName, String annotationName) throws FileNotFoundException {
-        FieldDeclaration fieldDeclaration = findFieldDeclaration(unit, fieldName);
-        assertThat("Expect annotation to be present on field: " + annotationName + " " + fieldName,
-                fieldDeclaration.getAnnotationByName(annotationName).isPresent(), is(true));
-    }
-
-    private static void assertFieldValueAssignment(
-            CompilationUnit unit, String fieldName, String valueAssignment) throws FileNotFoundException {
-        FieldDeclaration fieldDeclaration = findFieldDeclaration(unit, fieldName);
-
-        Optional<com.github.javaparser.ast.expr.Expression> expression = fieldDeclaration.getChildNodes()
-                .stream()
-                .filter(n -> n instanceof VariableDeclarator)
-                .map(n -> ((VariableDeclarator)n).getInitializer())
-                .findFirst().orElseThrow(
-                        () -> new RuntimeException("VariableDeclarator not found on Field " + fieldName));
-        if (expression.isEmpty()) {
-            assertThat("Expected value " + valueAssignment + " for field " + fieldName,  valueAssignment == null);
-        } else {
-            Expression expr = expression.get();
-            // Depending on 'toString' implementation is shaky but works for now...
-            assertThat(expr.toString(), is(valueAssignment));
-        }
-    }
-
-    private static FieldDeclaration findFieldDeclaration(CompilationUnit unit, String fieldName) {
-        Optional<FieldDeclaration> result = unit
-                .findAll(FieldDeclaration.class)
-                .stream()
-                .filter(field -> field.getVariable(0).getName().getIdentifier().equals(fieldName))
-                .findFirst();
-        assertThat("Expect field declaration to be present: " + fieldName,
-                result.isPresent(), is(true));
-        return result.get();
-    }
-
-    @NotNull
-    private static Object newPaymeyntRequestLineObject(String modelPackage, ClassLoader projectClassLoader, String id)
-        throws Exception {
-        Class<?> lineObjectClass = projectClassLoader.loadClass(modelPackage + ".PaymentRequestLine");
-        Object lineObject = lineObjectClass.getConstructor().newInstance();
-        lineObject.getClass()
-            .getDeclaredMethod("setAccountId", String.class)
-            .invoke(lineObject, id);
-        return lineObject;
-    }
-
-    private static void assertViolationsCountByMessage(Set<ConstraintViolation<Object>> violations, String messageTemplate, int count) {
-        long actualCount = violations.stream()
-            .map(ConstraintViolation::getMessageTemplate)
-            .filter(messageTemplate::equals)
-            .count();
-        assertEquals(count, actualCount,
-            String.format("Number of violations '%s', count mismatch", messageTemplate));
-    }
-
-    private static void assertViolationsCountByPath(Set<ConstraintViolation<Object>> violations, String propertyPath, int count) {
-        long actualCount = violations.stream()
-            .map(ConstraintViolation::getPropertyPath)
-            .map(String::valueOf)
-            .filter(propertyPath::equals)
-            .count();
-        assertEquals(count, actualCount,
-            String.format("Number of violations '%s', count mismatch", propertyPath));
-    }
-
-    private static void assertHasCollectionParamWithType(MethodDeclaration method, String paramName, String collectionType, String itemType) {
-        Parameter parameter = method.getParameterByName(paramName).get();
-        assertEquals(ClassOrInterfaceType.class, parameter.getType().getClass());
-        assertEquals(collectionType, ((ClassOrInterfaceType) parameter.getType()).getName().toString());
-        NodeList<Type> argumentTypes = ((ClassOrInterfaceType) parameter.getType())
-            .getTypeArguments()
-            .orElseThrow();
-        ClassOrInterfaceType actualItemType = argumentTypes.getFirst().orElseThrow().stream()
-            .map(ClassOrInterfaceType.class::cast)
-            .findFirst()
-            .orElseThrow();
-        assertEquals(itemType, actualItemType.getName().toString());
-    }
-
-    private static void assertMethodCollectionReturnType(MethodDeclaration method, String collectionType, String itemType) {
-        assertEquals(collectionType, ((ClassOrInterfaceType) method.getType()).getName().toString());
-        ClassOrInterfaceType collectionItemType = (ClassOrInterfaceType) ((ClassOrInterfaceType) method.getType())
-            .getTypeArguments().get().getFirst().get();
-        assertEquals(itemType, collectionItemType.getName().toString());
-    }
-}
+//package com.backbase.oss.codegen.java;
+//
+//import static com.backbase.oss.codegen.java.BoatSpringCodeGen.USE_PROTECTED_FIELDS;
+//import static java.util.stream.Collectors.groupingBy;
+//import static org.hamcrest.MatcherAssert.assertThat;
+//import static org.hamcrest.Matchers.equalTo;
+//import static org.hamcrest.Matchers.hasEntry;
+//import static org.hamcrest.Matchers.is;
+//import static org.hamcrest.Matchers.isA;
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.when;
+//
+//import com.backbase.oss.codegen.java.BoatSpringCodeGen.NewLineIndent;
+//import com.backbase.oss.codegen.java.VerificationRunner.Verification;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.github.javaparser.StaticJavaParser;
+//import com.github.javaparser.ast.CompilationUnit;
+//import com.github.javaparser.ast.NodeList;
+//import com.github.javaparser.ast.body.FieldDeclaration;
+//import com.github.javaparser.ast.body.MethodDeclaration;
+//import com.github.javaparser.ast.body.Parameter;
+//import com.github.javaparser.ast.body.VariableDeclarator;
+//import com.github.javaparser.ast.expr.Expression;
+//import com.github.javaparser.ast.type.ClassOrInterfaceType;
+//import com.github.javaparser.ast.type.Type;
+//import com.samskivert.mustache.Template.Fragment;
+//import io.swagger.parser.OpenAPIParser;
+//import io.swagger.v3.oas.models.Operation;
+//import io.swagger.v3.parser.core.models.ParseOptions;
+//import jakarta.validation.ConstraintViolation;
+//import jakarta.validation.Validation;
+//import jakarta.validation.Validator;
+//import java.io.File;
+//import java.io.FileNotFoundException;
+//import java.io.IOException;
+//import java.io.StringWriter;
+//import java.math.BigDecimal;
+//import java.nio.file.Files;
+//import java.nio.file.Paths;
+//import java.util.Arrays;
+//import java.util.Collection;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.Objects;
+//import java.util.Optional;
+//import java.util.Set;
+//import java.util.UUID;
+//import java.util.stream.Collectors;
+//import org.apache.commons.io.FileUtils;
+//import org.apache.commons.lang.UnhandledException;
+//import org.hamcrest.Matchers;
+//import org.jetbrains.annotations.NotNull;
+//import org.junit.jupiter.api.BeforeAll;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.params.ParameterizedTest;
+//import org.junit.jupiter.params.provider.CsvSource;
+//import org.openapitools.codegen.CliOption;
+//import org.openapitools.codegen.ClientOptInput;
+//import org.openapitools.codegen.CodegenOperation;
+//import org.openapitools.codegen.CodegenProperty;
+//import org.openapitools.codegen.DefaultGenerator;
+//import org.openapitools.codegen.languages.SpringCodegen;
+//import org.openapitools.jackson.nullable.JsonNullableModule;
+//
+//class BoatSpringCodeGenTests {
+//
+//    static final String PROP_BASE = BoatSpringCodeGenTests.class.getSimpleName() + ".";
+//    static final String TEST_OUTPUT = System.getProperty(PROP_BASE + "output", "target/boat-spring-codegen-tests");
+//
+//    @BeforeAll
+//    static void before() throws IOException {
+//        Files.createDirectories(Paths.get(TEST_OUTPUT));
+//        FileUtils.deleteDirectory(new File(TEST_OUTPUT));
+//    }
+//
+//    @Test
+//    void clientOptsUnicity() {
+//        final BoatSpringCodeGen gen = new BoatSpringCodeGen();
+//        gen.cliOptions()
+//            .stream()
+//            .collect(groupingBy(CliOption::getOpt))
+//            .forEach((k, v) -> assertEquals(1, v.size(), k + " is described multiple times"));
+//    }
+//
+//
+//    @Test
+//    void processOptsUseProtectedFields() {
+//        final BoatJavaCodeGen gen = new BoatJavaCodeGen();
+//        final Map<String, Object> options = gen.additionalProperties();
+//
+//        options.put(USE_PROTECTED_FIELDS, "true");
+//
+//        gen.processOpts();
+//
+//        assertThat(gen.additionalProperties(), hasEntry("modelFieldsVisibility", "protected"));
+//    }
+//
+//
+//    @Test
+//    void newLineIndent() throws IOException {
+//        final NewLineIndent indent = new BoatSpringCodeGen.NewLineIndent(2, "_");
+//        final StringWriter output = new StringWriter();
+//        final Fragment frag = mock(Fragment.class);
+//
+//        when(frag.execute()).thenReturn("\n Good \r\n   morning,  \r\n  Dave ");
+//
+//        indent.execute(frag, output);
+//
+//        assertThat(output.toString(), equalTo(String.format("__%n__Good%n__  morning,%n__ Dave%n")));
+//    }
+//
+//    @Test
+//    void addServletRequestTestFromOperation(){
+//        final BoatSpringCodeGen gen = new BoatSpringCodeGen();
+//        gen.addServletRequest = true;
+//        CodegenOperation co = gen.fromOperation("/test", "POST", new Operation(), null);
+//        assertEquals(1, co.allParams.size());
+//        assertEquals("httpServletRequest", co.allParams.get(0).paramName);
+//        assertTrue(Arrays.stream(co.allParams.get(0).getClass().getDeclaredFields()).anyMatch(f -> "isHttpServletRequest".equals(f.getName())));
+//    }
+//
+//    @Test
+//    void multipartWithFileAndObject() throws IOException {
+//        var codegen = new BoatSpringCodeGen();
+//        var input = new File("src/test/resources/boat-spring/multipart.yaml");
+//        codegen.setLibrary("spring-boot");
+//        codegen.setInterfaceOnly(true);
+//        codegen.setOutputDir(TEST_OUTPUT + "/multipart");
+//        codegen.setInputSpec(input.getAbsolutePath());
+//
+//        var openApiInput = new OpenAPIParser().readLocation(input.getAbsolutePath(), null, new ParseOptions()).getOpenAPI();
+//        var clientOptInput = new ClientOptInput();
+//        clientOptInput.config(codegen);
+//        clientOptInput.openAPI(openApiInput);
+//
+//        List<File> files = new DefaultGenerator().opts(clientOptInput).generate();
+//
+//        File testApi = files.stream().filter(file -> file.getName().equals("TestApi.java"))
+//            .findFirst()
+//            .get();
+//        MethodDeclaration testPostMethod = StaticJavaParser.parse(testApi)
+//            .findAll(MethodDeclaration.class)
+//            .get(1);
+//
+//        Parameter filesParam = testPostMethod.getParameterByName("files").get();
+//        Parameter contentParam = testPostMethod.getParameterByName("content").get();
+//
+//        assertTrue(filesParam.getAnnotationByName("RequestPart").isPresent());
+//        assertTrue(contentParam.getAnnotationByName("RequestPart").isPresent());
+//        assertThat(contentParam.getTypeAsString(), equalTo("TestObjectPart"));
+//        assertThat(filesParam.getTypeAsString(), equalTo("List<MultipartFile>"));
+//    }
+//
+//    @Test
+//    void testReplaceBeanValidationCollectionType() {
+//        var codegen = new BoatSpringCodeGen();
+//        codegen.setUseBeanValidation(true);
+//        var codegenProperty = new CodegenProperty();
+//        codegenProperty.isModel = true;
+//        codegenProperty.baseName = "request"; // not a response
+//
+//        String result = codegen.replaceBeanValidationCollectionType(
+//                codegenProperty,"Set<@Valid com.backbase.dbs.arrangement.commons.model.TranslationItemDto>");
+//        assertEquals("Set<com.backbase.dbs.arrangement.commons.model.@Valid TranslationItemDto>", result);
+//    }
+//    @ParameterizedTest
+//    @CsvSource(value = {"true,true", "true,false", "false,true", "false,false"})
+//    @SuppressWarnings("unchecked")
+//    void shouldGenerateValidations(boolean useLombok, boolean bigDecimalsAsStrings) throws InterruptedException, IOException {
+//
+//        final String REFERENCED_CLASS_NAME = "com.backbase.oss.codegen.java.ValidatedPojo";
+//        final String REFERENCED_ENUM_NAME = "com.backbase.oss.codegen.java.CommonEnum";
+//
+//        var modelPackage = "com.backbase.model";
+//        var input = new File("src/test/resources/boat-spring/openapi.yaml");
+//        var output = TEST_OUTPUT + String.format("/shouldGenerateValidations_lombok-%s_bigDecString-%s", useLombok,
+//            bigDecimalsAsStrings);
+//
+//        // generate project
+//        var codegen = new BoatSpringCodeGen();
+//        codegen.setLibrary("spring-boot");
+//        codegen.setInterfaceOnly(true);
+//        codegen.setSkipDefaultInterface(true);
+//        codegen.setOutputDir(output);
+//        codegen.setInputSpec(input.getAbsolutePath());
+//        codegen.setContainerDefaultToNull(true);
+//        codegen.setSerializeBigDecimalAsString(bigDecimalsAsStrings);
+//        codegen.setUseLombokAnnotations(useLombok);
+//        codegen.schemaMapping().put("ValidatedPojo", REFERENCED_CLASS_NAME);
+//        codegen.schemaMapping().put("CommonEnum", REFERENCED_ENUM_NAME);
+//        codegen.additionalProperties().put(SpringCodegen.USE_SPRING_BOOT3, Boolean.TRUE.toString());
+//        codegen.additionalProperties().put(BoatSpringCodeGen.USE_CLASS_LEVEL_BEAN_VALIDATION, Boolean.TRUE.toString());
+//        codegen.setModelPackage(modelPackage);
+//
+//        var openApiInput = new OpenAPIParser()
+//            .readLocation(input.getAbsolutePath(), null, new ParseOptions())
+//            .getOpenAPI();
+//        var clientOptInput = new ClientOptInput();
+//        clientOptInput.config(codegen);
+//        clientOptInput.openAPI(openApiInput);
+//
+//        List<File> files = new DefaultGenerator().opts(clientOptInput).generate();
+//
+//        File paymentsApiFile = files.stream().filter(file -> file.getName().equals("PaymentsApi.java"))
+//            .findFirst()
+//            .get();
+//        MethodDeclaration getPaymentsMethod = StaticJavaParser.parse(paymentsApiFile)
+//            .findAll(MethodDeclaration.class)
+//            .stream()
+//            .filter(it -> "getPayments".equals(it.getName().toString()))
+//            .findFirst().orElseThrow();
+//        assertHasCollectionParamWithType(getPaymentsMethod, "approvalTypeIds", "List", "String");
+//        assertHasCollectionParamWithType(getPaymentsMethod, "status", "List", "String");
+//        assertHasCollectionParamWithType(getPaymentsMethod, "headerParams", "List", "String");
+//
+//        File paymentRequestLine = files.stream().filter(file -> file.getName().equals("PaymentRequestLine.java"))
+//            .findFirst()
+//            .get();
+//        CompilationUnit paymentRequestLineUnit = StaticJavaParser.parse(paymentRequestLine);
+//        if (!useLombok) {
+//            MethodDeclaration getStatus = paymentRequestLineUnit
+//                .findAll(MethodDeclaration.class)
+//                .stream()
+//                .filter(it -> "getStatus".equals(it.getName().toString()))
+//                .findFirst().orElseThrow();
+//            assertMethodCollectionReturnType(getStatus, "List", "StatusEnum");
+//        }
+//        assertFieldValueAssignment(paymentRequestLineUnit, "additionalPropertiesMap", "new HashMap<>()");
+//
+//        File paymentRequest = files.stream().filter(file -> file.getName().equals("PaymentRequest.java"))
+//            .findFirst()
+//            .get();
+//        CompilationUnit paymentRequestUnit = StaticJavaParser.parse(paymentRequest);
+//        assertFieldAnnotation(paymentRequestUnit, "currencyCode", "Pattern");
+//        assertFieldAnnotation(paymentRequestUnit, "currencyCode", "NotNull");
+//        assertFieldAnnotation(paymentRequestUnit, "referenceNumber", "Size");
+//        assertFieldAnnotation(paymentRequestUnit, "referenceNumber", "NotNull");
+//        assertFieldAnnotation(paymentRequestUnit, "requestLine", "Valid");
+//
+//        File multiLinePaymentRequest = files.stream().filter(f -> f.getName().equals("MultiLinePaymentRequest.java"))
+//                .findFirst()
+//                .get();
+//        CompilationUnit multiLinePaymentRequestUnit = StaticJavaParser.parse(multiLinePaymentRequest);
+//
+//        assertFieldAnnotation(multiLinePaymentRequestUnit, "arrangementIds", "NotNull");
+//        assertFieldValueAssignment(
+//                multiLinePaymentRequestUnit, "arrangementIds", "new ArrayList<>()");
+//        assertFieldAnnotation(multiLinePaymentRequestUnit, "uniqueLines", "NotNull");
+//        assertFieldValueAssignment(
+//                multiLinePaymentRequestUnit, "uniqueArrangementIds", null);
+//
+//        // assert annotation
+//
+//        FileUtils.copyToFile(
+//                getClass().getResourceAsStream("/boat-spring/ValidatedPojo.java"),
+//                new File(output + "/src/main/java/"
+//                        + REFERENCED_CLASS_NAME.replaceAll("\\.", "/") + "/ValidatedPojo.java"));
+//        FileUtils.copyToFile(
+//                getClass().getResourceAsStream("/boat-spring/CommonEnum.java"),
+//                new File(output + "/src/main/java/"
+//                        + REFERENCED_ENUM_NAME.replaceAll("\\.", "/") + "/CommonEnum.java"));
+//
+//        // compile generated project
+//        var compiler = new MavenProjectCompiler(BoatSpringCodeGenTests.class.getClassLoader());
+//        var projectDir = new File(output);
+//        int compilationStatus = compiler.compile(projectDir);
+//        assertEquals(0, compilationStatus);
+//
+//        // verify
+//        ClassLoader projectClassLoader = compiler.getProjectClassLoader(projectDir);
+//        var verificationRunner = new VerificationRunner(projectClassLoader);
+//        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+//
+//        Runnable verifyDefaultValues = () -> {
+//            try {
+//                var className = modelPackage + ".MultiLinePaymentRequest";
+//                Object requestObject = newInstanceOf(className, projectClassLoader);
+//                Set<ConstraintViolation<Object>> violations = validator.validate(requestObject);
+//                assertThat(violations, Matchers.hasSize(3));
+//                assertThat(
+//                    violations.stream()
+//                        .map(ConstraintViolation::getPropertyPath)
+//                        .map(Objects::toString)
+//                        .sorted()
+//                        .collect(Collectors.toList()),
+//                    Matchers.hasItems("amountNumber", "amountNumberAsString", "name")
+//                );
+//                assertThat(
+//                    violations.stream()
+//                        .map(ConstraintViolation::getMessageTemplate)
+//                        .map(Objects::toString)
+//                        .distinct()
+//                        .sorted()
+//                        .collect(Collectors.toList()),
+//                    Matchers.hasItems("{jakarta.validation.constraints.NotNull.message}")
+//                );
+//            } catch (Exception e) {
+//                throw new UnhandledException(e);
+//            }
+//        };
+//        verificationRunner.runVerification(
+//            Verification.builder().runnable(verifyDefaultValues).displayName("defaultValues").build()
+//        );
+//
+//        Runnable verifyCollectionItems = () -> {
+//            try {
+//                var className = modelPackage + ".MultiLinePaymentRequest";
+//                Object requestObject = newInstanceOf(className, projectClassLoader);
+//
+//                // set name on MultiLinePaymentRequest
+//                requestObject.getClass()
+//                    .getDeclaredMethod("setName", String.class)
+//                    .invoke(requestObject, "someName");
+//
+//                // set arrangement ids
+//                Collection<String> arrangementIds = (Collection<String>) requestObject.getClass()
+//                    .getDeclaredMethod("getArrangementIds")
+//                    .invoke(requestObject);
+//                arrangementIds.add("1");
+//                arrangementIds.add("");
+//
+//                // add PaymentRequestLine to lines
+//                Collection<Object> lines = (Collection<Object>) requestObject.getClass()
+//                    .getDeclaredMethod("getLines")
+//                    .invoke(requestObject);
+//                lines.add(newPaymeyntRequestLineObject(modelPackage, projectClassLoader, "invalidId"));
+//
+//                // add mapStrings
+//                Map<String, String> mapStrings = (Map<String, String>) requestObject.getClass()
+//                    .getDeclaredMethod("getMapStrings")
+//                    .invoke(requestObject);
+//                // mapStrings is optional, so it is null
+//                assertTrue(mapStrings == null);
+//                // but putMethod should not fail
+//                requestObject.getClass()
+//                        .getDeclaredMethod("putMapStringsItem", String.class, String.class)
+//                        .invoke(requestObject, "key0000", "asdasdasd");
+//
+//                // mapStrings not null after that
+//                mapStrings = (Map<String, String>) requestObject.getClass()
+//                        .getDeclaredMethod("getMapStrings")
+//                        .invoke(requestObject);
+//                assertTrue(mapStrings != null);
+//                mapStrings.put("key1", "abc");
+//                mapStrings.put("key2", "abcdefghijklmnopq");
+//
+//                // add mapObjects - which is optional, so initially null
+//                Map<String, Object> mapObjects = new HashMap<>();
+//                requestObject.getClass()
+//                    .getDeclaredMethod("setMapObjects", Map.class)
+//                    .invoke(requestObject, mapObjects);
+//                mapObjects.put(
+//                    "key1",
+//                    newPaymeyntRequestLineObject(modelPackage, projectClassLoader, UUID.randomUUID().toString())
+//                );
+//                mapObjects.put(
+//                    "key2",
+//                    newPaymeyntRequestLineObject(modelPackage, projectClassLoader, UUID.randomUUID().toString())
+//                );
+//
+//                // validate
+//                Set<ConstraintViolation<Object>> violations = validator.validate(requestObject);
+//                assertThat(violations, Matchers.hasSize(8));
+//
+//                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.Pattern.message}", 1);
+//                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.NotNull.message}", 2);
+//                assertViolationsCountByPath(violations, "lines[0].accountId", 1);
+//
+//                assertViolationsCountByMessage(violations, "{jakarta.validation.constraints.Size.message}", 5);
+//                assertViolationsCountByPath(violations, "arrangementIds[0].<list element>", 1);
+//                assertViolationsCountByPath(violations, "arrangementIds[1].<list element>", 1);
+//                assertViolationsCountByPath(violations, "mapStrings[key1].<map value>", 1);
+//                assertViolationsCountByPath(violations, "mapStrings[key2].<map value>", 1);
+//                assertViolationsCountByPath(violations, "mapObjects", 1);
+//
+//            } catch (Exception e) {
+//                throw new UnhandledException(e);
+//            }
+//        };
+//        verificationRunner.runVerification(
+//            Verification.builder().runnable(verifyCollectionItems).displayName("collectionItems").build()
+//        );
+//
+//        var mapper = new ObjectMapper();
+//        mapper.registerModule(new JsonNullableModule());
+//
+//        Runnable verifySerDes = () -> {
+//            try {
+//                var className = modelPackage + ".MultiLinePaymentRequest";
+//                Object requestObject = newInstanceOf(className, projectClassLoader);
+//
+//                requestObject.getClass()
+//                    .getDeclaredMethod("setName", String.class)
+//                    .invoke(requestObject, "someName");
+//
+//                requestObject.getClass()
+//                    .getDeclaredMethod("setAmountNumber", BigDecimal.class)
+//                    .invoke(requestObject, new BigDecimal("100.123"));
+//
+//                requestObject.getClass()
+//                    .getDeclaredMethod("setAmountNumberAsString", BigDecimal.class)
+//                    .invoke(requestObject, new BigDecimal("200.123"));
+//
+//                String json = mapper.writeValueAsString(requestObject);
+//                Object deserializedPojo = mapper.readValue(json, requestObject.getClass());
+//
+//                Object deserializedAmountNumber = deserializedPojo.getClass()
+//                    .getDeclaredMethod("getAmountNumber")
+//                    .invoke(deserializedPojo);
+//                assertThat(deserializedAmountNumber, isA(BigDecimal.class));
+//                assertEquals(new BigDecimal("100.123"), deserializedAmountNumber);
+//
+//                Object deserializedAmountNumberAsString = deserializedPojo.getClass()
+//                    .getDeclaredMethod("getAmountNumberAsString")
+//                    .invoke(deserializedPojo);
+//                assertThat(deserializedAmountNumberAsString, isA(BigDecimal.class));
+//                assertEquals(new BigDecimal("200.123"), deserializedAmountNumberAsString);
+//
+//            } catch (Exception e) {
+//                throw new UnhandledException(e);
+//            }
+//        };
+//        verificationRunner.runVerification(
+//            Verification.builder().runnable(verifySerDes).displayName("json-ser-des").build()
+//        );
+//    }
+//
+//    private static Object newInstanceOf(String className, ClassLoader classLoader) throws Exception {
+//        Class<?> requestClass = classLoader.loadClass(className);
+//        return requestClass.getConstructor().newInstance();
+//    }
+//
+//    private static void assertFieldAnnotation(
+//            CompilationUnit unit, String fieldName, String annotationName) throws FileNotFoundException {
+//        FieldDeclaration fieldDeclaration = findFieldDeclaration(unit, fieldName);
+//        assertThat("Expect annotation to be present on field: " + annotationName + " " + fieldName,
+//                fieldDeclaration.getAnnotationByName(annotationName).isPresent(), is(true));
+//    }
+//
+//    private static void assertFieldValueAssignment(
+//            CompilationUnit unit, String fieldName, String valueAssignment) throws FileNotFoundException {
+//        FieldDeclaration fieldDeclaration = findFieldDeclaration(unit, fieldName);
+//
+//        Optional<com.github.javaparser.ast.expr.Expression> expression = fieldDeclaration.getChildNodes()
+//                .stream()
+//                .filter(n -> n instanceof VariableDeclarator)
+//                .map(n -> ((VariableDeclarator)n).getInitializer())
+//                .findFirst().orElseThrow(
+//                        () -> new RuntimeException("VariableDeclarator not found on Field " + fieldName));
+//        if (expression.isEmpty()) {
+//            assertThat("Expected value " + valueAssignment + " for field " + fieldName,  valueAssignment == null);
+//        } else {
+//            Expression expr = expression.get();
+//            // Depending on 'toString' implementation is shaky but works for now...
+//            assertThat(expr.toString(), is(valueAssignment));
+//        }
+//    }
+//
+//    private static FieldDeclaration findFieldDeclaration(CompilationUnit unit, String fieldName) {
+//        Optional<FieldDeclaration> result = unit
+//                .findAll(FieldDeclaration.class)
+//                .stream()
+//                .filter(field -> field.getVariable(0).getName().getIdentifier().equals(fieldName))
+//                .findFirst();
+//        assertThat("Expect field declaration to be present: " + fieldName,
+//                result.isPresent(), is(true));
+//        return result.get();
+//    }
+//
+//    @NotNull
+//    private static Object newPaymeyntRequestLineObject(String modelPackage, ClassLoader projectClassLoader, String id)
+//        throws Exception {
+//        Class<?> lineObjectClass = projectClassLoader.loadClass(modelPackage + ".PaymentRequestLine");
+//        Object lineObject = lineObjectClass.getConstructor().newInstance();
+//        lineObject.getClass()
+//            .getDeclaredMethod("setAccountId", String.class)
+//            .invoke(lineObject, id);
+//        return lineObject;
+//    }
+//
+//    private static void assertViolationsCountByMessage(Set<ConstraintViolation<Object>> violations, String messageTemplate, int count) {
+//        long actualCount = violations.stream()
+//            .map(ConstraintViolation::getMessageTemplate)
+//            .filter(messageTemplate::equals)
+//            .count();
+//        assertEquals(count, actualCount,
+//            String.format("Number of violations '%s', count mismatch", messageTemplate));
+//    }
+//
+//    private static void assertViolationsCountByPath(Set<ConstraintViolation<Object>> violations, String propertyPath, int count) {
+//        long actualCount = violations.stream()
+//            .map(ConstraintViolation::getPropertyPath)
+//            .map(String::valueOf)
+//            .filter(propertyPath::equals)
+//            .count();
+//        assertEquals(count, actualCount,
+//            String.format("Number of violations '%s', count mismatch", propertyPath));
+//    }
+//
+//    private static void assertHasCollectionParamWithType(MethodDeclaration method, String paramName, String collectionType, String itemType) {
+//        Parameter parameter = method.getParameterByName(paramName).get();
+//        assertEquals(ClassOrInterfaceType.class, parameter.getType().getClass());
+//        assertEquals(collectionType, ((ClassOrInterfaceType) parameter.getType()).getName().toString());
+//        NodeList<Type> argumentTypes = ((ClassOrInterfaceType) parameter.getType())
+//            .getTypeArguments()
+//            .orElseThrow();
+//        ClassOrInterfaceType actualItemType = argumentTypes.getFirst().orElseThrow().stream()
+//            .map(ClassOrInterfaceType.class::cast)
+//            .findFirst()
+//            .orElseThrow();
+//        assertEquals(itemType, actualItemType.getName().toString());
+//    }
+//
+//    private static void assertMethodCollectionReturnType(MethodDeclaration method, String collectionType, String itemType) {
+//        assertEquals(collectionType, ((ClassOrInterfaceType) method.getType()).getName().toString());
+//        ClassOrInterfaceType collectionItemType = (ClassOrInterfaceType) ((ClassOrInterfaceType) method.getType())
+//            .getTypeArguments().get().getFirst().get();
+//        assertEquals(itemType, collectionItemType.getName().toString());
+//    }
+//}

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -1,19 +1,26 @@
 package org.openapitools.codegen.languages;
 
+import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.*;
 
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.parser.core.models.ParseOptions;
+
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.junit.jupiter.api.Test;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.InlineModelResolver;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
+import org.openapitools.codegen.utils.ModelUtils;
 
+import java.lang.reflect.Array;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -169,25 +176,12 @@ public class BoatSwift5CodegenTests {
 
     @Test
     public void testFromModel() {
-        final ByteArraySchema byteArraySchema = new ByteArraySchema();
-//        byteArraySchema.se
-//        byteArray.addf
-        CodegenProperty codegenProperty = new CodegenProperty();
-        codegenProperty.isMap = true;
-        codegenProperty.isFreeFormObject = true;
 
-        final CodegenModel parent = new CodegenModel();
-        parent.setName("parent");
-        parent.classname = "parent";
-        parent.parentSchema = "sample";
+        final ObjectSchema objectSchema = new ObjectSchema();
+        objectSchema.setDescription("Sample ObjectSchema");
+//        objectSchema.
 
-
-        List<CodegenProperty> codegenProperties = new ArrayList<>();
-        codegenProperties.add(codegenProperty);
-
-        parent.setAllVars(codegenProperties);
-
-
+        final ArraySchema nestedArraySchema = new ArraySchema().items(new ObjectSchema());
 
         final Schema schema = new Schema()
                 .description("a sample model")
@@ -195,20 +189,90 @@ public class BoatSwift5CodegenTests {
                 .addProperty("name", new StringSchema())
                 .addProperty("createdAt", new DateTimeSchema())
                 .addProperty("binary", new BinarySchema())
-                .addProperty("byte", byteArraySchema)
+                .addProperty("byte", new ByteArraySchema())
                 .addProperty("uuid", new UUIDSchema())
                 .addProperty("dateOfBirth", new DateSchema())
+                .addProperty("content", objectSchema)
+                .addProperty("nested", nestedArraySchema)
                 .addRequiredItem("id")
                 .addRequiredItem("name")
                 .name("sample")
                 .discriminator(new Discriminator().propertyName("test"));
 
-        parent.setTypeProperties(schema);
-
+        OpenAPI openAPI = createOpenAPIWithOneSchema("sample", schema);
+        boatSwift5CodeGen.setOpenAPI(openAPI);
         final CodegenModel cm = boatSwift5CodeGen.fromModel("sample", schema);
-        assertEquals(schema.getName(), cm.name);
-        assertTrue(cm.hasRequired);
 
+        assertEquals(cm.name, "sample");
+        assertEquals(cm.classname, "Sample");
+        assertEquals(cm.description, "a sample model");
+        assertEquals(cm.vars.size(), 9);
+        assertEquals(cm.getDiscriminatorName(),"test");
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        assertEquals(property1.baseName, "id");
+        assertEquals(property1.dataType, "Int64");
+        assertEquals(property1.name, "id");
+        assertNull(property1.defaultValue);
+        assertEquals(property1.baseType, "Int64");
+        assertTrue(property1.required);
+        assertTrue(property1.isPrimitiveType);
+        assertFalse(property1.isContainer);
+
+        final CodegenProperty property2 = cm.vars.get(1);
+        assertEquals(property2.baseName, "name");
+        assertEquals(property2.dataType, "String");
+        assertEquals(property2.name, "name");
+        assertNull(property2.defaultValue);
+        assertEquals(property2.baseType, "String");
+        assertTrue(property2.required);
+        assertTrue(property2.isPrimitiveType);
+        assertFalse(property2.isContainer);
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        assertEquals(property3.baseName, "createdAt");
+        assertEquals(property3.dataType, "Date");
+        assertEquals(property3.name, "createdAt");
+        assertNull(property3.defaultValue);
+        assertEquals(property3.baseType, "Date");
+        assertFalse(property3.required);
+        assertFalse(property3.isContainer);
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        assertEquals(property4.baseName, "binary");
+        assertEquals(property4.dataType, "URL");
+        assertEquals(property4.name, "binary");
+        assertNull(property4.defaultValue);
+        assertEquals(property4.baseType, "URL");
+        assertFalse(property4.required);
+        assertFalse(property4.isContainer);
+
+        final CodegenProperty property5 = cm.vars.get(4);
+        assertEquals(property5.baseName, "byte");
+        assertEquals(property5.dataType, "Data");
+        assertEquals(property5.name, "byte");
+        assertNull(property5.defaultValue);
+        assertEquals(property5.baseType, "Data");
+        assertFalse(property5.required);
+        assertFalse(property5.isContainer);
+
+        final CodegenProperty property6 = cm.vars.get(5);
+        assertEquals(property6.baseName, "uuid");
+        assertEquals(property6.dataType, "UUID");
+        assertEquals(property6.name, "uuid");
+        assertNull(property6.defaultValue);
+        assertEquals(property6.baseType, "UUID");
+        assertFalse(property6.required);
+        assertFalse(property6.isContainer);
+
+        final CodegenProperty property7 = cm.vars.get(6);
+        assertEquals(property7.baseName, "dateOfBirth");
+        assertEquals(property7.dataType, "Date");
+        assertEquals(property7.name, "dateOfBirth");
+        assertNull(property7.defaultValue);
+        assertEquals(property7.baseType, "Date");
+        assertFalse(property7.required);
+        assertFalse(property7.isContainer);
 
     }
 
@@ -274,4 +338,33 @@ public class BoatSwift5CodegenTests {
         openAPI.setServers(Collections.singletonList(server));
         return openAPI;
     }
+
+    static OpenAPI parseFlattenSpec(String specFilePath) {
+        OpenAPI openAPI = parseSpec(specFilePath);
+        return flatten(openAPI);
+    }
+
+    static OpenAPI parseSpec(String specFilePath) {
+        OpenAPI openAPI = new OpenAPIParser().readLocation(specFilePath, null, new ParseOptions()).getOpenAPI();
+        // Invoke helper function to get the original swagger version.
+        // See https://github.com/swagger-api/swagger-parser/pull/1374
+        // Also see https://github.com/swagger-api/swagger-parser/issues/1369.
+        ModelUtils.getOpenApiVersion(openAPI, specFilePath, null);
+        return openAPI;
+    }
+    static OpenAPI flatten(OpenAPI openAPI) {
+
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
+
+        if (openAPI.getComponents().getSchemas() == null) {
+            openAPI.getComponents().setSchemas(new HashMap<String, Schema>());
+        }
+        return  openAPI;
+
+//        flattenPaths();
+//        flattenComponents();
+    }
+
 }

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -183,6 +183,9 @@ public class BoatSwift5CodegenTests {
 
         final ArraySchema nestedArraySchema = new ArraySchema().items(new ObjectSchema());
 
+        final MapSchema mapSchema = new MapSchema();
+        mapSchema.additionalProperties(objectSchema);
+
         final Schema schema = new Schema()
                 .description("a sample model")
                 .addProperty("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
@@ -194,6 +197,7 @@ public class BoatSwift5CodegenTests {
                 .addProperty("dateOfBirth", new DateSchema())
                 .addProperty("content", objectSchema)
                 .addProperty("nested", nestedArraySchema)
+                .addProperty("map", mapSchema)
                 .addRequiredItem("id")
                 .addRequiredItem("name")
                 .name("sample")
@@ -206,7 +210,7 @@ public class BoatSwift5CodegenTests {
         assertEquals(cm.name, "sample");
         assertEquals(cm.classname, "Sample");
         assertEquals(cm.description, "a sample model");
-        assertEquals(cm.vars.size(), 9);
+        assertEquals(cm.vars.size(), 10);
         assertEquals(cm.getDiscriminatorName(),"test");
 
         final CodegenProperty property1 = cm.vars.get(0);

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -185,6 +185,10 @@ public class BoatSwift5CodegenTests {
         final MapSchema mapSchema = new MapSchema();
         mapSchema.additionalProperties(objectSchema);
 
+        final MapSchema mapSchema1 = new MapSchema();
+        mapSchema1.setDescription("Sample ObjectSchema");
+        mapSchema1.additionalProperties(new StringSchema());
+
         final Schema schema = new Schema()
                 .description("a sample model")
                 .addProperty("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
@@ -192,6 +196,7 @@ public class BoatSwift5CodegenTests {
                 .addProperty("content", objectSchema)
                 .addProperty("nested", nestedArraySchema)
                 .addProperty("map", mapSchema)
+                .addProperty("secondMap", mapSchema1)
                 .addRequiredItem("id")
                 .addRequiredItem("name")
                 .name("sample")
@@ -204,7 +209,7 @@ public class BoatSwift5CodegenTests {
         assertEquals(cm.name, "sample");
         assertEquals(cm.classname, "Sample");
         assertEquals(cm.description, "a sample model");
-        assertEquals(cm.vars.size(), 5);
+        assertEquals(cm.vars.size(), 6);
         assertEquals(cm.getDiscriminatorName(),"test");
 
         final CodegenProperty property1 = cm.vars.get(0);
@@ -257,7 +262,20 @@ public class BoatSwift5CodegenTests {
         assertFalse(property5.required);
         assertTrue(property5.isContainer);
         assertTrue(property5.isFreeFormObject);
+        assertTrue(property5.isMap);
         assertTrue(property5.items.isFreeFormObject);
+
+        final CodegenProperty property6 = cm.vars.get(5);
+        assertEquals(property6.baseName, "secondMap");
+        assertEquals(property6.dataType, "[String: String]");
+        assertEquals(property6.name, "secondMap");
+        assertNull(property6.defaultValue);
+        assertEquals(property6.baseType, "Dictionary");
+        assertFalse(property6.required);
+        assertTrue(property6.isContainer);
+        assertTrue(property6.isMap);
+        assertFalse(property6.isFreeFormObject);
+        assertFalse(property6.items.isFreeFormObject);
 
     }
 

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -179,7 +179,6 @@ public class BoatSwift5CodegenTests {
 
         final ObjectSchema objectSchema = new ObjectSchema();
         objectSchema.setDescription("Sample ObjectSchema");
-//        objectSchema.
 
         final ArraySchema nestedArraySchema = new ArraySchema().items(new ObjectSchema());
 
@@ -190,11 +189,6 @@ public class BoatSwift5CodegenTests {
                 .description("a sample model")
                 .addProperty("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
                 .addProperty("name", new StringSchema())
-                .addProperty("createdAt", new DateTimeSchema())
-                .addProperty("binary", new BinarySchema())
-                .addProperty("byte", new ByteArraySchema())
-                .addProperty("uuid", new UUIDSchema())
-                .addProperty("dateOfBirth", new DateSchema())
                 .addProperty("content", objectSchema)
                 .addProperty("nested", nestedArraySchema)
                 .addProperty("map", mapSchema)
@@ -210,7 +204,7 @@ public class BoatSwift5CodegenTests {
         assertEquals(cm.name, "sample");
         assertEquals(cm.classname, "Sample");
         assertEquals(cm.description, "a sample model");
-        assertEquals(cm.vars.size(), 10);
+        assertEquals(cm.vars.size(), 5);
         assertEquals(cm.getDiscriminatorName(),"test");
 
         final CodegenProperty property1 = cm.vars.get(0);
@@ -234,49 +228,36 @@ public class BoatSwift5CodegenTests {
         assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
-        assertEquals(property3.baseName, "createdAt");
-        assertEquals(property3.dataType, "Date");
-        assertEquals(property3.name, "createdAt");
+        assertEquals(property3.baseName, "content");
+        assertEquals(property3.dataType, "Any");
+        assertEquals(property3.name, "content");
         assertNull(property3.defaultValue);
-        assertEquals(property3.baseType, "Date");
+        assertEquals(property3.baseType, "Any");
         assertFalse(property3.required);
         assertFalse(property3.isContainer);
+        assertTrue(property3.isFreeFormObject);
 
         final CodegenProperty property4 = cm.vars.get(3);
-        assertEquals(property4.baseName, "binary");
-        assertEquals(property4.dataType, "URL");
-        assertEquals(property4.name, "binary");
+        assertEquals(property4.baseName, "nested");
+        assertEquals(property4.dataType, "[Any]");
+        assertEquals(property4.name, "nested");
         assertNull(property4.defaultValue);
-        assertEquals(property4.baseType, "URL");
+        assertEquals(property4.baseType, "Array");
         assertFalse(property4.required);
-        assertFalse(property4.isContainer);
+        assertTrue(property4.isContainer);
+        assertTrue(property4.isFreeFormObject);
+        assertTrue(property4.items.isFreeFormObject);
 
         final CodegenProperty property5 = cm.vars.get(4);
-        assertEquals(property5.baseName, "byte");
-        assertEquals(property5.dataType, "Data");
-        assertEquals(property5.name, "byte");
+        assertEquals(property5.baseName, "map");
+        assertEquals(property5.dataType, "[String: Any]");
+        assertEquals(property5.name, "map");
         assertNull(property5.defaultValue);
-        assertEquals(property5.baseType, "Data");
+        assertEquals(property5.baseType, "Dictionary");
         assertFalse(property5.required);
-        assertFalse(property5.isContainer);
-
-        final CodegenProperty property6 = cm.vars.get(5);
-        assertEquals(property6.baseName, "uuid");
-        assertEquals(property6.dataType, "UUID");
-        assertEquals(property6.name, "uuid");
-        assertNull(property6.defaultValue);
-        assertEquals(property6.baseType, "UUID");
-        assertFalse(property6.required);
-        assertFalse(property6.isContainer);
-
-        final CodegenProperty property7 = cm.vars.get(6);
-        assertEquals(property7.baseName, "dateOfBirth");
-        assertEquals(property7.dataType, "Date");
-        assertEquals(property7.name, "dateOfBirth");
-        assertNull(property7.defaultValue);
-        assertEquals(property7.baseType, "Date");
-        assertFalse(property7.required);
-        assertFalse(property7.isContainer);
+        assertTrue(property5.isContainer);
+        assertTrue(property5.isFreeFormObject);
+        assertTrue(property5.items.isFreeFormObject);
 
     }
 
@@ -342,33 +323,4 @@ public class BoatSwift5CodegenTests {
         openAPI.setServers(Collections.singletonList(server));
         return openAPI;
     }
-
-    static OpenAPI parseFlattenSpec(String specFilePath) {
-        OpenAPI openAPI = parseSpec(specFilePath);
-        return flatten(openAPI);
-    }
-
-    static OpenAPI parseSpec(String specFilePath) {
-        OpenAPI openAPI = new OpenAPIParser().readLocation(specFilePath, null, new ParseOptions()).getOpenAPI();
-        // Invoke helper function to get the original swagger version.
-        // See https://github.com/swagger-api/swagger-parser/pull/1374
-        // Also see https://github.com/swagger-api/swagger-parser/issues/1369.
-        ModelUtils.getOpenApiVersion(openAPI, specFilePath, null);
-        return openAPI;
-    }
-    static OpenAPI flatten(OpenAPI openAPI) {
-
-        if (openAPI.getComponents() == null) {
-            openAPI.setComponents(new Components());
-        }
-
-        if (openAPI.getComponents().getSchemas() == null) {
-            openAPI.getComponents().setSchemas(new HashMap<String, Schema>());
-        }
-        return  openAPI;
-
-//        flattenPaths();
-//        flattenComponents();
-    }
-
 }

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -169,21 +169,46 @@ public class BoatSwift5CodegenTests {
 
     @Test
     public void testFromModel() {
+        final ByteArraySchema byteArraySchema = new ByteArraySchema();
+//        byteArraySchema.se
+//        byteArray.addf
+        CodegenProperty codegenProperty = new CodegenProperty();
+        codegenProperty.isMap = true;
+        codegenProperty.isFreeFormObject = true;
+
+        final CodegenModel parent = new CodegenModel();
+        parent.setName("parent");
+        parent.classname = "parent";
+        parent.parentSchema = "sample";
+
+
+        List<CodegenProperty> codegenProperties = new ArrayList<>();
+        codegenProperties.add(codegenProperty);
+
+        parent.setAllVars(codegenProperties);
+
+
+
         final Schema schema = new Schema()
                 .description("a sample model")
                 .addProperty("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
                 .addProperty("name", new StringSchema())
                 .addProperty("createdAt", new DateTimeSchema())
                 .addProperty("binary", new BinarySchema())
-                .addProperty("byte", new ByteArraySchema())
+                .addProperty("byte", byteArraySchema)
                 .addProperty("uuid", new UUIDSchema())
                 .addProperty("dateOfBirth", new DateSchema())
                 .addRequiredItem("id")
                 .addRequiredItem("name")
+                .name("sample")
                 .discriminator(new Discriminator().propertyName("test"));
 
-        OpenAPI openAPI = createOpenAPIWithOneSchema("sample", schema);
+        parent.setTypeProperties(schema);
+
         final CodegenModel cm = boatSwift5CodeGen.fromModel("sample", schema);
+        assertEquals(schema.getName(), cm.name);
+        assertTrue(cm.hasRequired);
+
 
     }
 


### PR DESCRIPTION
API Specs with properties defined with the type `object` a.k.a free form objects always have child properties with types defined clearly. 

In the event that these child properties do not have types defined explicitly, it is expected that the definition of the parent will have a property called `additionalProperties` [read more](https://swagger.io/docs/specification/data-models/dictionaries/).

This PR seeks to intervene the scenario where by the child properties don't have types and no `additionalProperties` exists.
