### PR TITLE
Add `dependenciesAs` additional property to allow for `Podfile` generation

### DIFF
--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -14,7 +14,7 @@ import org.openapitools.codegen.utils.ModelUtils;
 import java.util.*;
 
 public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenConfig {
-    private static final String LIBRARY_DBS = "dbsDataProvider";
+    public static final String LIBRARY_DBS = "dbsDataProvider";
     public static final String DEPENDENCY_MANAGEMENT = "dependenciesAs";
     public static final String DEPENDENCY_MANAGEMENT_PODFILE = "Podfile";
     protected static final String DEPENDENCY_MANAGEMENT_CARTFILE = "Cartfile";

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -2,10 +2,9 @@ package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
-import org.openapitools.codegen.CodegenConfig;
-import org.openapitools.codegen.CodegenModel;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.SupportingFile;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.model.ModelsMap;
@@ -13,9 +12,13 @@ import org.openapitools.codegen.utils.ModelUtils;
 
 import java.util.*;
 
-
 public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenConfig {
     private static final String LIBRARY_DBS = "dbsDataProvider";
+    public static final String DEPENDENCY_MANAGEMENT = "dependenciesAs";
+    public static final String DEPENDENCY_MANAGEMENT_PODFILE = "Podfile";
+    protected static final String DEPENDENCY_MANAGEMENT_CARTFILE = "Cartfile";
+    protected static final String[] DEPENDENCY_MANAGEMENT_OPTIONS = {DEPENDENCY_MANAGEMENT_CARTFILE, DEPENDENCY_MANAGEMENT_PODFILE};
+    protected String[] dependenciesAs = new String[0];
 
     /**
      * Constructor for the BoatSwift5Codegen codegen module.
@@ -38,6 +41,11 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         this.typeMapping.remove("AnyType");
         this.typeMapping.put("object", "Any");
         this.typeMapping.put("AnyType", "Any");
+
+        cliOptions.add(new CliOption(DEPENDENCY_MANAGEMENT,
+                "Available dependency managers "
+                        + StringUtils.join(DEPENDENCY_MANAGEMENT_OPTIONS, ", ")
+                        + " are available."));
     }
 
     @Override
@@ -55,7 +63,20 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         super.processOpts();
         additionalProperties.put("useDBSDataProvider", getLibrary().equals(LIBRARY_DBS));
         supportingFiles.add(new SupportingFile("AnyCodable.swift.mustache", sourceFolder, "AnyCodable.swift"));
-        this.supportingFiles.add(new SupportingFile("AnyCodable.swift.mustache", this.sourceFolder, "AnyCodable.swift"));
+
+        if (additionalProperties.containsKey(DEPENDENCY_MANAGEMENT)) {
+            Object dependenciesAsObject = additionalProperties.get(DEPENDENCY_MANAGEMENT);
+            if (dependenciesAsObject instanceof String) {
+                setDependenciesAs(((String) dependenciesAsObject).split(","));
+            }
+        }
+
+        additionalProperties.put(DEPENDENCY_MANAGEMENT, dependenciesAs);
+        if (ArrayUtils.contains(dependenciesAs, DEPENDENCY_MANAGEMENT_PODFILE)) {
+            supportingFiles.add(new SupportingFile("Podfile.mustache",
+                    "",
+                    "Podfile"));
+        }
     }
 
     // Fix issues with generating arrays with Set.
@@ -71,7 +92,6 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
 
     @Override
     public CodegenModel fromModel(String name, Schema model) {
-        Map<String, Schema> allDefinitions = ModelUtils.getSchemas(this.openAPI);
         CodegenModel codegenModel = super.fromModel(name, model);
         if (codegenModel.description != null) {
             codegenModel.imports.add("ApiModel");
@@ -81,6 +101,11 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
 
         return codegenModel;
     }
+
+    public void setDependenciesAs(String[] dependenciesAs) {
+        this.dependenciesAs = dependenciesAs;
+    }
+
 
     /*
     This is added as a compatibility requirement for API specs containing free form objects

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -76,7 +76,7 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         if (ArrayUtils.contains(dependenciesAs, DEPENDENCY_MANAGEMENT_PODFILE)) {
             supportingFiles.add(new SupportingFile("Podfile.mustache",
                     "",
-                    "Podfile"));
+                    DEPENDENCY_MANAGEMENT_PODFILE));
         }
     }
 

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.WordUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
@@ -67,7 +68,7 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         if (additionalProperties.containsKey(DEPENDENCY_MANAGEMENT)) {
             Object dependenciesAsObject = additionalProperties.get(DEPENDENCY_MANAGEMENT);
             if (dependenciesAsObject instanceof String) {
-                setDependenciesAs(((String) dependenciesAsObject).split(","));
+                setDependenciesAs((WordUtils.capitalizeFully((String) dependenciesAsObject).split(",")));
             }
         }
 

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -30,129 +30,129 @@ public class BoatSwift5CodegenTests {
     BoatSwift5Codegen boatSwift5CodeGen = new BoatSwift5Codegen();
 
     @Test
-    public void testGeneratorName() {
+    void testGeneratorName() {
         assertEquals(boatSwift5CodeGen.getName(), "boat-swift5");
     }
     @Test
-    public void testGetHelpMessage() {
+    void testGetHelpMessage() {
         assertEquals(boatSwift5CodeGen.getHelp(), "Generates a BOAT Swift 5.x client library.");
     }
 
     @Test
-    public void testProcessOptsSetDBSDataProvider() {
+    void testProcessOptsSetDBSDataProvider() {
         boatSwift5CodeGen.setLibrary("dbsDataProvider");
         boatSwift5CodeGen.processOpts();
         boatSwift5CodeGen.postProcess();
     }
 
     @Test
-    public void testSetDependenciesAsToPodfile() {
+    void testSetDependenciesAsToPodfile() {
         boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
         boatSwift5CodeGen.processOpts();
 
         final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
-        assertEquals(dependenciesAs[0], BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
+        assertEquals(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE, dependenciesAs[0]);
     }
 
     @Test
-    public void testSetDependenciesAsToPodfileUpperCase() {
+    void testSetDependenciesAsToPodfileUpperCase() {
         boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, "PODFILE");
         boatSwift5CodeGen.processOpts();
 
         final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
-        assertEquals(dependenciesAs[0], BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
+        assertEquals(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE, dependenciesAs[0]);
     }
     @Test
-    public void testSetDependenciesAsToPodfileLowerCase() {
+    void testSetDependenciesAsToPodfileLowerCase() {
         boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, "podfile");
         boatSwift5CodeGen.processOpts();
 
         final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
-        assertEquals(dependenciesAs[0], BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
+        assertEquals(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE, dependenciesAs[0]);
     }
 
     @Test
-    public void testSetDependenciesAsToPodfileCamelCase() {
+    void testSetDependenciesAsToPodfileCamelCase() {
         boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, "podFile");
         boatSwift5CodeGen.processOpts();
 
         final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
-        assertEquals(dependenciesAs[0], BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
+        assertEquals(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE, dependenciesAs[0]);
     }
 
     @Test
-    public void testWhenDependenciesAsIsNotSetShouldBeEmpty() {
+    void testWhenDependenciesAsIsNotSetShouldBeEmpty() {
         boatSwift5CodeGen.processOpts();
         final String[] dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
-        assertEquals(0, dependenciesAs.length);
+        assertEquals(dependenciesAs.length, 0);
     }
 
     @Test
-    public void testGetTypeDeclaration() {
+    void testGetTypeDeclaration() {
 
         final ArraySchema childSchema = new ArraySchema().items(new StringSchema());
 
         assertEquals(boatSwift5CodeGen.getTypeDeclaration(childSchema),"[String]");
     }
     @Test
-    public void testCapitalizedReservedWord() throws Exception {
+    void testCapitalizedReservedWord() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("AS", null), "_as");
     }
 
     @Test
-    public void testReservedWord() throws Exception {
+    void testReservedWord() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("Public", null), "_public");
     }
 
     @Test
-    public void shouldNotBreakNonReservedWord() throws Exception {
+    void shouldNotBreakNonReservedWord() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("Error", null), "error");
     }
 
     @Test
-    public void shouldNotBreakCorrectName() throws Exception {
+    void shouldNotBreakCorrectName() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("EntryName", null), "entryName");
     }
 
     @Test
-    public void testSingleWordAllCaps() throws Exception {
+    void testSingleWordAllCaps() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("VALUE", null), "value");
     }
 
     @Test
-    public void testSingleWordLowercase() throws Exception {
+    void testSingleWordLowercase() throws Exception {
        assertEquals(boatSwift5CodeGen.toEnumVarName("value", null), "value");
     }
 
     @Test
-    public void testCapitalsWithUnderscore() throws Exception {
+    void testCapitalsWithUnderscore() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("ENTRY_NAME", null), "entryName");
     }
 
     @Test
-    public void testCapitalsWithDash() throws Exception {
+    void testCapitalsWithDash() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("ENTRY-NAME", null), "entryName");
     }
 
     @Test
-    public void testCapitalsWithSpace() throws Exception {
+    void testCapitalsWithSpace() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("ENTRY NAME", null), "entryName");
     }
 
     @Test
-    public void testLowercaseWithUnderscore() throws Exception {
+    void testLowercaseWithUnderscore() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("entry_name", null), "entryName");
     }
 
     @Test
-    public void testStartingWithNumber() throws Exception {
+    void testStartingWithNumber() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("123EntryName", null), "_123entryName");
         assertEquals(boatSwift5CodeGen.toEnumVarName("123Entry_name", null), "_123entryName");
         assertEquals(boatSwift5CodeGen.toEnumVarName("123EntryName123", null), "_123entryName123");
     }
 
     @Test
-    public void testSpecialCharacters() throws Exception {
+    void testSpecialCharacters() throws Exception {
         assertEquals(boatSwift5CodeGen.toEnumVarName("1:1", null), "_1Colon1");
         assertEquals(boatSwift5CodeGen.toEnumVarName("1:One", null), "_1ColonOne");
         assertEquals(boatSwift5CodeGen.toEnumVarName("Apple&Swift", null), "appleAmpersandSwift");
@@ -162,7 +162,7 @@ public class BoatSwift5CodegenTests {
     }
 
     @Test
-    public void prefixExceptionTest() {
+    void prefixExceptionTest() {
 
         boatSwift5CodeGen.setModelNamePrefix("API");
 
@@ -171,7 +171,7 @@ public class BoatSwift5CodegenTests {
     }
 
     @Test
-    public void suffixExceptionTest() {
+    void suffixExceptionTest() {
 
         boatSwift5CodeGen.setModelNameSuffix("API");
 
@@ -180,21 +180,21 @@ public class BoatSwift5CodegenTests {
     }
 
     @Test
-    public void prefixTest() {
+    void prefixTest() {
         boatSwift5CodeGen.setModelNamePrefix("API");
         final String result = boatSwift5CodeGen.toModelName("MyType");
         assertEquals(result, "APIMyType");
     }
 
     @Test
-    public void suffixTest() {
+    void suffixTest() {
         boatSwift5CodeGen.setModelNameSuffix("API");
         final String result = boatSwift5CodeGen.toModelName("MyType");
         assertEquals(result, "MyTypeAPI");
     }
 
     @Test
-    public void testDefaultPodAuthors() throws Exception {
+    void testDefaultPodAuthors() throws Exception {
         // Given
         // When
         boatSwift5CodeGen.processOpts();
@@ -204,7 +204,7 @@ public class BoatSwift5CodegenTests {
     }
 
     @Test
-    public void testPodAuthors() throws Exception {
+    void testPodAuthors() throws Exception {
         // Given
         final String openAPIDevs = "OpenAPI Devs";
         boatSwift5CodeGen.additionalProperties().put(Swift5ClientCodegen.POD_AUTHORS, openAPIDevs);
@@ -218,7 +218,7 @@ public class BoatSwift5CodegenTests {
     }
 
     @Test
-    public void testFromModel() {
+    void testFromModel() {
 
         final ObjectSchema objectSchema = new ObjectSchema();
         objectSchema.setDescription("Sample ObjectSchema");
@@ -323,7 +323,7 @@ public class BoatSwift5CodegenTests {
     }
 
     @Test
-    public  void testPostProcessAllModels() {
+    void testPostProcessAllModels() {
         final CodegenModel parent = new CodegenModel();
         Map<String, ModelsMap> models = new HashMap<>();
 

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -55,6 +55,32 @@ public class BoatSwift5CodegenTests {
     }
 
     @Test
+    public void testSetDependenciesAsToPodfileUpperCase() {
+        boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, "PODFILE");
+        boatSwift5CodeGen.processOpts();
+
+        final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
+        assertEquals(dependenciesAs[0], BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
+    }
+    @Test
+    public void testSetDependenciesAsToPodfileLowerCase() {
+        boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, "podfile");
+        boatSwift5CodeGen.processOpts();
+
+        final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
+        assertEquals(dependenciesAs[0], BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
+    }
+
+    @Test
+    public void testSetDependenciesAsToPodfileCamelCase() {
+        boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, "podFile");
+        boatSwift5CodeGen.processOpts();
+
+        final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
+        assertEquals(dependenciesAs[0], BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
+    }
+
+    @Test
     public void testWhenDependenciesAsIsNotSetShouldBeEmpty() {
         boatSwift5CodeGen.processOpts();
         final String[] dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -62,7 +62,7 @@ public class BoatSwift5CodegenTests {
     void testWhenDependenciesAsIsNotSetShouldBeEmpty() {
         boatSwift5CodeGen.processOpts();
         final String[] dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
-        assertEquals(dependenciesAs.length, 0);
+        assertEquals(0,dependenciesAs.length);
     }
 
     @Test

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -43,9 +43,10 @@ public class BoatSwift5CodegenTests {
 
     @Test
     void testProcessOptsSetDBSDataProvider() {
-        boatSwift5CodeGen.setLibrary("dbsDataProvider");
+        boatSwift5CodeGen.setLibrary(BoatSwift5Codegen.LIBRARY_DBS);
         boatSwift5CodeGen.processOpts();
         boatSwift5CodeGen.postProcess();
+        assertEquals(boatSwift5CodeGen.getLibrary(), BoatSwift5Codegen.LIBRARY_DBS);
     }
 
     @ParameterizedTest

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -13,6 +13,9 @@ import io.swagger.v3.parser.core.models.ParseOptions;
 
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.InlineModelResolver;
@@ -45,35 +48,10 @@ public class BoatSwift5CodegenTests {
         boatSwift5CodeGen.postProcess();
     }
 
-    @Test
-    void testSetDependenciesAsToPodfile() {
-        boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
-        boatSwift5CodeGen.processOpts();
-
-        final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
-        assertEquals(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE, dependenciesAs[0]);
-    }
-
-    @Test
-    void testSetDependenciesAsToPodfileUpperCase() {
-        boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, "PODFILE");
-        boatSwift5CodeGen.processOpts();
-
-        final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
-        assertEquals(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE, dependenciesAs[0]);
-    }
-    @Test
-    void testSetDependenciesAsToPodfileLowerCase() {
-        boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, "podfile");
-        boatSwift5CodeGen.processOpts();
-
-        final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
-        assertEquals(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE, dependenciesAs[0]);
-    }
-
-    @Test
-    void testSetDependenciesAsToPodfileCamelCase() {
-        boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, "podFile");
+    @ParameterizedTest
+    @ValueSource(strings = {BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE, "PODFILE", "podFile", "podfile", "podfilE"})
+    void testSetDependenciesDoesNotConsiderCase(String arg) {
+        boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, arg);
         boatSwift5CodeGen.processOpts();
 
         final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -44,6 +44,23 @@ public class BoatSwift5CodegenTests {
         boatSwift5CodeGen.processOpts();
         boatSwift5CodeGen.postProcess();
     }
+
+    @Test
+    public void testSetDependenciesAsToPodfile() {
+        boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
+        boatSwift5CodeGen.processOpts();
+
+        final String[]  dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
+        assertEquals(dependenciesAs[0], BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE);
+    }
+
+    @Test
+    public void testWhenDependenciesAsIsNotSetShouldBeEmpty() {
+        boatSwift5CodeGen.processOpts();
+        final String[] dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
+        assertEquals(0, dependenciesAs.length);
+    }
+
     @Test
     public void testGetTypeDeclaration() {
 

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -1,6 +1,5 @@
 package org.openapitools.codegen.languages;
 
-import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Paths;
@@ -9,21 +8,16 @@ import io.swagger.v3.oas.models.media.*;
 
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
-import io.swagger.v3.parser.core.models.ParseOptions;
 
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.InlineModelResolver;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
-import org.openapitools.codegen.utils.ModelUtils;
 
-import java.lang.reflect.Array;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -46,7 +40,7 @@ public class BoatSwift5CodegenTests {
         boatSwift5CodeGen.setLibrary(BoatSwift5Codegen.LIBRARY_DBS);
         boatSwift5CodeGen.processOpts();
         boatSwift5CodeGen.postProcess();
-        assertEquals(boatSwift5CodeGen.getLibrary(), BoatSwift5Codegen.LIBRARY_DBS);
+        assertEquals(BoatSwift5Codegen.LIBRARY_DBS, boatSwift5CodeGen.getLibrary());
     }
 
     @ParameterizedTest

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -196,42 +196,20 @@ public class BoatSwift5CodegenTests {
     }
 
     @Test
-    void testFromModel() {
+    void testFromModelCodegenModel() {
 
-        final ObjectSchema objectSchema = new ObjectSchema();
-        objectSchema.setDescription("Sample ObjectSchema");
-
-        final ArraySchema nestedArraySchema = new ArraySchema().items(new ObjectSchema());
-
-        final MapSchema mapSchema = new MapSchema();
-        mapSchema.additionalProperties(objectSchema);
-
-        final MapSchema mapSchema1 = new MapSchema();
-        mapSchema1.setDescription("Sample ObjectSchema");
-        mapSchema1.additionalProperties(new StringSchema());
-
-        final Schema schema = new Schema()
-                .description("a sample model")
-                .addProperty("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
-                .addProperty("name", new StringSchema())
-                .addProperty("content", objectSchema)
-                .addProperty("nested", nestedArraySchema)
-                .addProperty("map", mapSchema)
-                .addProperty("secondMap", mapSchema1)
-                .addRequiredItem("id")
-                .addRequiredItem("name")
-                .name("sample")
-                .discriminator(new Discriminator().propertyName("test"));
-
-        OpenAPI openAPI = createOpenAPIWithOneSchema("sample", schema);
-        boatSwift5CodeGen.setOpenAPI(openAPI);
-        final CodegenModel cm = boatSwift5CodeGen.fromModel("sample", schema);
+        final CodegenModel cm = prepareForModelTests();
 
         assertEquals(cm.name, "sample");
         assertEquals(cm.classname, "Sample");
         assertEquals(cm.description, "a sample model");
         assertEquals(cm.vars.size(), 6);
-        assertEquals(cm.getDiscriminatorName(),"test");
+        assertEquals(cm.getDiscriminatorName(), "test");
+    }
+
+    @Test
+    void testFromModelProperty1() {
+        final CodegenModel cm = prepareForModelTests();
 
         final CodegenProperty property1 = cm.vars.get(0);
         assertEquals(property1.baseName, "id");
@@ -242,6 +220,10 @@ public class BoatSwift5CodegenTests {
         assertTrue(property1.required);
         assertTrue(property1.isPrimitiveType);
         assertFalse(property1.isContainer);
+    }
+    @Test
+    void testFromModelProperty2() {
+        final CodegenModel cm = prepareForModelTests();
 
         final CodegenProperty property2 = cm.vars.get(1);
         assertEquals(property2.baseName, "name");
@@ -252,6 +234,10 @@ public class BoatSwift5CodegenTests {
         assertTrue(property2.required);
         assertTrue(property2.isPrimitiveType);
         assertFalse(property2.isContainer);
+    }
+    @Test
+    void testFromModelProperty3() {
+        final CodegenModel cm = prepareForModelTests();
 
         final CodegenProperty property3 = cm.vars.get(2);
         assertEquals(property3.baseName, "content");
@@ -262,6 +248,10 @@ public class BoatSwift5CodegenTests {
         assertFalse(property3.required);
         assertFalse(property3.isContainer);
         assertTrue(property3.isFreeFormObject);
+    }
+    @Test
+    void testFromModelProperty4() {
+        final CodegenModel cm = prepareForModelTests();
 
         final CodegenProperty property4 = cm.vars.get(3);
         assertEquals(property4.baseName, "nested");
@@ -273,6 +263,10 @@ public class BoatSwift5CodegenTests {
         assertTrue(property4.isContainer);
         assertTrue(property4.isFreeFormObject);
         assertTrue(property4.items.isFreeFormObject);
+    }
+    @Test
+    void testFromModelProperty5() {
+        final CodegenModel cm = prepareForModelTests();
 
         final CodegenProperty property5 = cm.vars.get(4);
         assertEquals(property5.baseName, "map");
@@ -285,6 +279,11 @@ public class BoatSwift5CodegenTests {
         assertTrue(property5.isFreeFormObject);
         assertTrue(property5.isMap);
         assertTrue(property5.items.isFreeFormObject);
+
+    }
+    @Test
+    void testFromModelProperty6() {
+        final CodegenModel cm = prepareForModelTests();
 
         final CodegenProperty property6 = cm.vars.get(5);
         assertEquals(property6.baseName, "secondMap");
@@ -328,6 +327,38 @@ public class BoatSwift5CodegenTests {
         models.put("ActionRecipeItemParent", createCodegenModelWrapper(actionRecipeItemParentModel));
 
         assertEquals(boatSwift5CodeGen.postProcessAllModels(models), models);
+    }
+
+    private CodegenModel prepareForModelTests() {
+
+        final ObjectSchema objectSchema = new ObjectSchema();
+        objectSchema.setDescription("Sample ObjectSchema");
+
+        final ArraySchema nestedArraySchema = new ArraySchema().items(new ObjectSchema());
+
+        final MapSchema mapSchema = new MapSchema();
+        mapSchema.additionalProperties(objectSchema);
+
+        final MapSchema mapSchema1 = new MapSchema();
+        mapSchema1.setDescription("Sample ObjectSchema");
+        mapSchema1.additionalProperties(new StringSchema());
+
+        final Schema schema = new Schema()
+                .description("a sample model")
+                .addProperty("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
+                .addProperty("name", new StringSchema())
+                .addProperty("content", objectSchema)
+                .addProperty("nested", nestedArraySchema)
+                .addProperty("map", mapSchema)
+                .addProperty("secondMap", mapSchema1)
+                .addRequiredItem("id")
+                .addRequiredItem("name")
+                .name("sample")
+                .discriminator(new Discriminator().propertyName("test"));
+
+        OpenAPI openAPI = createOpenAPIWithOneSchema("sample", schema);
+        boatSwift5CodeGen.setOpenAPI(openAPI);
+        return boatSwift5CodeGen.fromModel("sample", schema);
     }
 
     static ModelsMap createCodegenModelWrapper(CodegenModel cm) {


### PR DESCRIPTION
To ensure that Podfile is also generated, as extra flag `dependenciesAs` can be passed with comma delimited string. But for now we'll only consider the value `Podfile` to ensure that a `Podfile` is generated.