### PR TITLE
FIX: the maven compiler plugin config in the generated pom

### DIFF
--- a/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/pom.mustache
+++ b/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/pom.mustache
@@ -143,14 +143,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
-              {{#useJakartaEe}}
-                <source>17</source>
-                <target>17</target>
-              {{/useJakartaEe}}
-              {{^useJakartaEe}}
-                <source>1.8</source>
-                <target>1.8</target>
-              {{/useJakartaEe}}
+                <configuration>
+                  {{#useJakartaEe}}
+                    <source>17</source>
+                    <target>17</target>
+                  {{/useJakartaEe}}
+                  {{^useJakartaEe}}
+                    <source>1.8</source>
+                    <target>1.8</target>
+                  {{/useJakartaEe}}
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fix "source and target need to be inside configuration tag"