### PR TITLE
NewGen iOS Mobile Clients: Update Templates to remove internal steps

### DIFF
--- a/boat-scaffold/src/main/templates/boat-swift5/Podfile.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/Podfile.mustache
@@ -1,6 +1,6 @@
 source 'https://cdn.cocoapods.org'
 
-platform :ios, '11.0'
+platform :ios, '15.0'
 
 plugin 'cocoapods-art', sources: %w[
   bbartifacts3
@@ -14,7 +14,7 @@ install! 'cocoapods', deterministic_uuids: false
 inhibit_all_warnings!
 
 def normal_pods
-  pod 'Backbase', '>= 6.11'{{#useRxSwift}}
+  pod 'Backbase', '>= 9'{{#useRxSwift}}
   pod 'RxSwift', '~> 5.0.0'{{/useRxSwift}}{{#useAlamofire}}
   pod 'Alamofire', '~> 4.9.1'{{/useAlamofire}}{{#usePromiseKit}}
   pod 'PromiseKit', '~> 6.12.0'{{/usePromiseKit}}

--- a/boat-scaffold/src/main/templates/boat-swift5/Podspec.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/Podspec.mustache
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary = '{{projectDescription}}'{{/projectDescription}}{{#podDescription}}
   s.description = '{{podDescription}}'{{/podDescription}}
   s.license = '{{#podLicense}}{{& podLicense}}{{/podLicense}}'{{^podLicense}}'Proprietary'{{/podLicense}}
-  s.homepage = '{{podHomepage}}{{^podHomepage}}https://github.com/OpenAPITools/openapi-generator{{/podHomepage}}'{{#podAuthors}}
+  s.homepage = '{{podHomepage}}{{^podHomepage}}https://github.com/Backbase/backbase-openapi-tools{{/podHomepage}}'{{#podAuthors}}
   s.author = '{{podAuthors}}'{{/podAuthors}}
 
   s.platform = :ios
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.source = { :git => 'https://github.com/backbase-rnd/backbase-generated-clients-ios/ios-clients/{{projectName}}'}
-  s.source_files = 'sources/**/*.swift'
+  s.source_files = '{{projectName}}/Classes/**/*.swift'
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.vendored_frameworks = '{{projectName}}.xcframework'

--- a/boat-scaffold/src/main/templates/boat-swift5/Podspec.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/Podspec.mustache
@@ -8,14 +8,14 @@ Pod::Spec.new do |s|
   s.author = '{{podAuthors}}'{{/podAuthors}}
 
   s.platform = :ios
-  s.ios.deployment_target = '14.0'
+  s.ios.deployment_target = '15.0'
   {{#podDocumentationURL}}
   s.documentation_url = '{{podDocumentationURL}}'
   {{/podDocumentationURL}}
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.source = { :git => "https://github.com/Backbase/backbase-openapi-tools", :tag => "{{{podVersion}}}" }
-  s.source_files = '{{projectName}}/Classes/**/*.swift'
+  s.source = { :git => 'https://github.com/backbase-rnd/backbase-generated-clients-ios/ios-clients/{{projectName}}'}
+  s.source_files = 'sources/**/*.swift'
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.vendored_frameworks = '{{projectName}}.xcframework'

--- a/boat-scaffold/src/main/templates/boat-swift5/XcodeGen.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/XcodeGen.mustache
@@ -10,6 +10,3 @@ targets:
     info:
       path: ./Info.plist
       version: {{#podVersion}}{{podVersion}}{{/podVersion}}{{^podVersion}}{{#apiInfo}}{{version}}{{/apiInfo}}{{^apiInfo}}}0.0.1{{/apiInfo}}{{/podVersion}}
-    scheme:
-      testTargets:
-        - {{projectName}}IntegrationTests

--- a/boat-scaffold/src/main/templates/boat-swift5/XcodeGen.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/XcodeGen.mustache
@@ -5,7 +5,7 @@ targets:
   {{projectName}}:
     type: framework
     platform: iOS
-    deploymentTarget: "14.0"
+    deploymentTarget: "15.0"
     sources: [{{projectName}}]
     info:
       path: ./Info.plist
@@ -13,6 +13,3 @@ targets:
     scheme:
       testTargets:
         - {{projectName}}IntegrationTests
-    postBuildScripts:
-      - path: ../../fix_swiftinterface.sh
-        name: Fix swiftinterface


### PR DESCRIPTION
To allow for a more clean approach of generating our clients, stop of the step / generated sections are not needed any more. This PR will facilitate this clean up. 