### PR TITLE
Feature - Multiple Access Control Permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ It currently consists of
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.17.33
+BOAT now supports multiple access control permissions within the tag `x-BbAccessControls` in the OpenAPI spec. 
+It contains two parameters `description` which describes the relationship between the permissions and `permissions` 
+which is an array of permissions with tags `resource`, `function` and `privilege`. 
 ## 0.17.30
 * Angular 17
 ## 0.17.29

--- a/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRule.kt
+++ b/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRule.kt
@@ -29,25 +29,48 @@ class EndpointAccessControlDefinedRule(config: Config) {
                         violations.add(
                                 context.violation("Access Control not defined: ${it.operationId}", it))
                     } else {
-                        val acEnabledSet: Boolean = notEmpty(it.extensions["x-BbAccessControl"])
+                        val acExplicitlyDisabled: Boolean = "false" == it.extensions["x-BbAccessControl"].toString()
+                        val isMultipleAcs: Boolean = notEmpty(it.extensions["x-BbAccessControls"])
                         val acResourceSet: Boolean = notEmpty(it.extensions["x-BbAccessControl-resource"])
                         val acFunctionSet: Boolean = notEmpty(it.extensions["x-BbAccessControl-function"])
                         val acPrivilegeSet: Boolean = notEmpty(it.extensions["x-BbAccessControl-privilege"])
-                        val acExplicitlyDisabled: Boolean = "false" == it.extensions["x-BbAccessControl"].toString()
-                        if (acExplicitlyDisabled) {
-                            if (acResourceSet || acFunctionSet || acPrivilegeSet) {
-                                violations.add(
-                                        context.violation("AC both disabled and defined: ${it.operationId}", it))
+
+                        if (!acExplicitlyDisabled && isMultipleAcs) {
+                            val entries: List<*> = it.extensions["x-BbAccessControls"] as List<*>;
+                            val numberOfEntries = entries.size;
+
+                            if (numberOfEntries == 0) {
+                                violations.add(context.violation("No permissions defined despite presence of x-BbAccessControls", it))
                             }
-                        } else if (!acEnabledSet) {
-                            if (!acResourceSet || !acFunctionSet || !acPrivilegeSet) {
-                                violations.add(
-                                        context.violation("AC info not complete: ${it.extensions}", it))
+
+                            entries.forEach {
+                                val entry: Map<String, String> = it as Map<String, String>;
+
+                                if (!notEmpty(entry["resource"]) || !notEmpty(entry["function"]) || !notEmpty(entry["privilege"])) {
+                                    violations.add(context.violation("AC Permission must contain resource, function and privilege parameters", it))
+                                }
+
+                                if (entry.size > 3) {
+                                    violations.add(context.violation("AC Permission contains invalid parameter", it))
+                                }
                             }
+
+                        } else if (!acExplicitlyDisabled && (acResourceSet || acFunctionSet || acPrivilegeSet)) {
+                            violations.add(
+                                    context.violation("AC both disabled and defined: ${it.operationId}", it))
+
+                        } else if (acResourceSet || !acFunctionSet || !acPrivilegeSet) {
+                            violations.add(
+                                    context.violation("AC info not complete: ${it.extensions}", it))
                         }
                     }
                 }
         return violations
     }
 
+    /*class Permission {
+        val resource;
+        val
+    }*/
 }
+

--- a/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRule.kt
+++ b/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRule.kt
@@ -34,7 +34,16 @@ class EndpointAccessControlDefinedRule(config: Config) {
                         val acPrivilegeSet: Boolean = notEmpty(it.extensions["x-BbAccessControl-privilege"])
 
                         if (!acExplicitlyDisabled && isMultipleAcs) {
-                            val entries: List<*> = it.extensions["x-BbAccessControls"] as List<*>;
+
+                            val multiAccessControls = it.extensions["x-BbAccessControls"] as Map<*, *>;
+
+                            val description = multiAccessControls["description"];
+
+                            if (!notEmpty(description)) {
+                                violations.add(context.violation("No description defined for x-BbAccessControls", it))
+                            }
+
+                            val entries: List<*> = multiAccessControls["permissions"] as List<*>;
                             val numberOfEntries = entries.size;
 
                             if (numberOfEntries == 0) {

--- a/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRuleTest.kt
+++ b/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRuleTest.kt
@@ -216,6 +216,9 @@ class EndpointAccessControlDefinedRuleTest {
                     - resource: Users
                       function: Manage Users
                       privilege: view
+                    - resource: Payment
+                      function: Manage Payments
+                      privilege: view
                     """.trimIndent()
         )
         val violations = rule.validate(context)
@@ -223,6 +226,117 @@ class EndpointAccessControlDefinedRuleTest {
         ZallyAssertions
                 .assertThat(violations)
                 .isEmpty()
+    }
+
+    @Test
+    fun `Endpoint with multiple ACs but no permissions defined`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BbAccessControls:
+                    """.trimIndent()
+        )
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
+    }
+
+    @Test
+    fun `Endpoint with multiple ACs but missing parameter in permission`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BbAccessControls:
+                    - resource: Users
+                      function: Manage Users
+                    """.trimIndent()
+        )
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
+    }
+
+    @Test
+    fun `Endpoint with multiple ACs but missing parameter in second permission`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BbAccessControls:
+                    - resource: Users
+                      function: Manage Users
+                      privilege: view
+                    - resource: Payment
+                      privilege: view
+                    """.trimIndent()
+        )
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
+    }
+
+    @Test
+    fun `Endpoint with multiple ACs but too many parameters in permission`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BbAccessControls:
+                    - resource: Users
+                      function: Manage Users
+                      privilege: view
+                      something: else
+                    """.trimIndent()
+        )
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
+    }
+
+    @Test
+    fun `Endpoint has multiple ACs defined and explicitly set false `() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BbAccessControl: false
+                  x-BbAccessControls:
+                    - resource: Users
+                      function: Manage Users
+                      privilege: view
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isNotEmpty
     }
 
 }

--- a/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRuleTest.kt
+++ b/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRuleTest.kt
@@ -213,12 +213,14 @@ class EndpointAccessControlDefinedRuleTest {
               /client-api/foo:
                 get:
                   x-BbAccessControls:
-                    - resource: Users
-                      function: Manage Users
-                      privilege: view
-                    - resource: Payment
-                      function: Manage Payments
-                      privilege: view
+                    description: This endpoint requires the following permissions
+                    permissions:
+                        - resource: Users
+                          function: Manage Users
+                          privilege: view
+                        - resource: Payment
+                          function: Manage Payments
+                          privilege: view
                     """.trimIndent()
         )
         val violations = rule.validate(context)
@@ -257,8 +259,10 @@ class EndpointAccessControlDefinedRuleTest {
               /client-api/foo:
                 get:
                   x-BbAccessControls:
-                    - resource: Users
-                      function: Manage Users
+                    description: This endpoint requires the following permissions
+                    permissions: 
+                        - resource: Users
+                          function: Manage Users
                     """.trimIndent()
         )
         val violations = rule.validate(context)
@@ -278,11 +282,13 @@ class EndpointAccessControlDefinedRuleTest {
               /client-api/foo:
                 get:
                   x-BbAccessControls:
-                    - resource: Users
-                      function: Manage Users
-                      privilege: view
-                    - resource: Payment
-                      privilege: view
+                    description: This endpoint requires the following permissions
+                    permissions: 
+                        - resource: Users
+                          function: Manage Users
+                          privilege: view
+                        - resource: Payment
+                          privilege: view
                     """.trimIndent()
         )
         val violations = rule.validate(context)
@@ -302,10 +308,12 @@ class EndpointAccessControlDefinedRuleTest {
               /client-api/foo:
                 get:
                   x-BbAccessControls:
-                    - resource: Users
-                      function: Manage Users
-                      privilege: view
-                      something: else
+                    description: This endpoint requires the following permissions
+                    permissions:
+                        - resource: Users
+                          function: Manage Users
+                          privilege: view
+                          something: else
                     """.trimIndent()
         )
         val violations = rule.validate(context)
@@ -326,9 +334,11 @@ class EndpointAccessControlDefinedRuleTest {
                 get:
                   x-BbAccessControl: false
                   x-BbAccessControls:
-                    - resource: Users
-                      function: Manage Users
-                      privilege: view
+                    description: This endpoint requires the following permissions
+                    permissions:   
+                        - resource: Users
+                          function: Manage Users
+                          privilege: view
             """.trimIndent()
         )
 
@@ -337,6 +347,30 @@ class EndpointAccessControlDefinedRuleTest {
         ZallyAssertions
                 .assertThat(violations)
                 .isNotEmpty
+    }
+
+    @Test
+    fun `Endpoint has multiple ACs defined but no description `() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+            """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BbAccessControls:
+                    permissions:   
+                        - resource: Users
+                          function: Manage Users
+                          privilege: view
+            """.trimIndent()
+        )
+
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+            .assertThat(violations)
+            .isNotEmpty
     }
 
 }

--- a/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRuleTest.kt
+++ b/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/EndpointAccessControlDefinedRuleTest.kt
@@ -203,4 +203,26 @@ class EndpointAccessControlDefinedRuleTest {
                 .isNotEmpty
     }
 
+    @Test
+    fun `Endpoint with multiple ACs`() {
+        @Language("YAML")
+        val context = DefaultContextFactory().getOpenApiContext(
+                """
+            openapi: 3.0.3
+            paths: 
+              /client-api/foo:
+                get:
+                  x-BbAccessControls:
+                    - resource: Users
+                      function: Manage Users
+                      privilege: view
+                    """.trimIndent()
+        )
+        val violations = rule.validate(context)
+
+        ZallyAssertions
+                .assertThat(violations)
+                .isEmpty()
+    }
+
 }

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatDocsGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatDocsGenerator.java
@@ -1,10 +1,14 @@
 package com.backbase.oss.codegen.doc;
 
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
 
 import java.util.HashMap;
+import org.openapitools.codegen.CodegenOperation;
 
 @Slf4j
 public class BoatDocsGenerator extends com.backbase.oss.codegen.BoatStaticDocsGenerator {
@@ -25,6 +29,14 @@ public class BoatDocsGenerator extends com.backbase.oss.codegen.BoatStaticDocsGe
         typeAliases = new HashMap<>();
     }
 
+    @Override
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+        CodegenOperation codegenOperation = super.fromOperation(path, httpMethod, operation, servers);
+        boolean isMultipleAccessControlPermission = codegenOperation.vendorExtensions.containsKey("x-BbAccessControls");
+        codegenOperation.vendorExtensions.put("hasMultipleAccessControlPermissions", isMultipleAccessControlPermission);
+
+        return codegenOperation;
+    }
 
     @Override
     public String getName() {

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatDocsGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatDocsGenerator.java
@@ -3,6 +3,7 @@ package com.backbase.oss.codegen.doc;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
@@ -34,6 +35,21 @@ public class BoatDocsGenerator extends com.backbase.oss.codegen.BoatStaticDocsGe
         CodegenOperation codegenOperation = super.fromOperation(path, httpMethod, operation, servers);
         boolean isMultipleAccessControlPermission = codegenOperation.vendorExtensions.containsKey("x-BbAccessControls");
         codegenOperation.vendorExtensions.put("hasMultipleAccessControlPermissions", isMultipleAccessControlPermission);
+        if (isMultipleAccessControlPermission) {
+            try {
+                Map<String, Object> accessControlInfo = (Map<String, Object>)codegenOperation.vendorExtensions.get("x-BbAccessControls");
+
+                if (accessControlInfo.containsKey("permissions")) {
+                    List<Map<String, Object>> permissions = (List<Map<String, Object>>) accessControlInfo.get("permissions");
+
+                    for (int p = 0; p < permissions.size(); p++) {
+                        permissions.get(p).put("letter", (char)('a' + p));
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Unable to add index to access control BOAT docs", e);
+            }
+        }
 
         return codegenOperation;
     }

--- a/boat-scaffold/src/main/templates/boat-docs/index.mustache
+++ b/boat-scaffold/src/main/templates/boat-docs/index.mustache
@@ -48,14 +48,34 @@
                           {{#description}}<p>{{description}}</p>{{/description}}
                     <p class="marked">{{notes}}</p>
                       <br/>
-                      {{#vendorExtensions}}
-                          <div class="secured-by">
-                              <h2>Secured by Backbase Access Control</h2>
-                              {{#x-BbAccessControl-resource}}<pre><b>Resource:</b> {{.}}</pre>{{/x-BbAccessControl-resource}}
-                              {{#x-BbAccessControl-function}}<pre><b>Function:</b> {{.}}</pre>{{/x-BbAccessControl-function}}
-                              {{#x-BbAccessControl-privilege}}<pre><b>Privilege:</b> {{.}}</pre>{{/x-BbAccessControl-privilege}}
-                          </div>
-                      {{/vendorExtensions}}
+                {{#vendorExtensions}}
+                  {{#hasMultipleAccessControlPermissions}}
+                  <div class="secured-by">
+                    <h2>Secured by Backbase Access Control</h2>
+                    <table>
+                      <tr>
+                    {{#x-BbAccessControls}}
+                      <td>
+                        <div class="secured-by-multiple">
+                          {{#resource}}<pre><b>Resource:</b> {{.}}</pre>{{/resource}}
+                          {{#function}}<pre><b>Function:</b> {{.}}</pre>{{/function}}
+                          {{#privilege}}<pre><b>Privilege:</b> {{.}}</pre>{{/privilege}}
+                        </div>
+                      </td>
+                    {{/x-BbAccessControls}}
+                      </tr>
+                    </table>
+                  </div>
+                  {{/hasMultipleAccessControlPermissions}}
+                  {{^hasMultipleAccessControlPermissions}}
+                    <div class="secured-by">
+                      <h2>Secured by Backbase Access Control</h2>
+                      {{#x-BbAccessControl-resource}}<pre><b>Resource:</b> {{.}}</pre>{{/x-BbAccessControl-resource}}
+                      {{#x-BbAccessControl-function}}<pre><b>Function:</b> {{.}}</pre>{{/x-BbAccessControl-function}}
+                      {{#x-BbAccessControl-privilege}}<pre><b>Privilege:</b> {{.}}</pre>{{/x-BbAccessControl-privilege}}
+                    </div>
+                  {{/hasMultipleAccessControlPermissions}}
+                {{/vendorExtensions}}
                       <pre class="prettyprint language-html prettyprinted"><code><span class="pln"><span  class="http-method" data-type="{{httpMethod}}">{{httpMethod}}</span>{{path}}</span></code></pre>
 
                       {{#hasAuthMethods}}

--- a/boat-scaffold/src/main/templates/boat-docs/index.mustache
+++ b/boat-scaffold/src/main/templates/boat-docs/index.mustache
@@ -55,13 +55,17 @@
                     <table>
                       <tr>
                     {{#x-BbAccessControls}}
-                      <td>
-                        <div class="secured-by-multiple">
-                          {{#resource}}<pre><b>Resource:</b> {{.}}</pre>{{/resource}}
-                          {{#function}}<pre><b>Function:</b> {{.}}</pre>{{/function}}
-                          {{#privilege}}<pre><b>Privilege:</b> {{.}}</pre>{{/privilege}}
-                        </div>
-                      </td>
+                      {{#description}}<pre><b>Description:</b> {{.}}</pre>{{/description}}
+                      {{#permissions}}
+                          <td>
+                            <div class="secured-by-multiple">
+                              {{#letter}}<pre><b>({{.}})</b></pre>{{/letter}}
+                              {{#resource}}<pre><b>Resource:</b> {{.}}</pre>{{/resource}}
+                              {{#function}}<pre><b>Function:</b> {{.}}</pre>{{/function}}
+                              {{#privilege}}<pre><b>Privilege:</b> {{.}}</pre>{{/privilege}}
+                            </div>
+                          </td>
+                      {{/permissions}}
                     {{/x-BbAccessControls}}
                       </tr>
                     </table>

--- a/boat-scaffold/src/main/templates/boat-docs/styles.mustache
+++ b/boat-scaffold/src/main/templates/boat-docs/styles.mustache
@@ -119,10 +119,19 @@ h2 {
   margin-bottom: 32px;
 }
 
-div.secured-by {
+div.in-row {
+  display: inline-block;
+}
+
+div.secured-by.secured-by-multiple {
   margin-bottom: 16px;
   display: flex;
   flex-direction: column;
+}
+
+div.secured-by-multiple {
+  margin-bottom: 8px;
+  margin-top: 8px;
 }
 
 div.secured-by > h2 {
@@ -136,7 +145,13 @@ div.secured-by > h2:only-child {
   display: none !important;
 }
 
-div.secured-by > pre {
+div.secured-by-multiple > pre:nth-child(1) {
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  padding-top: 8px;
+}
+
+div.secured-by,div.secured-by-multiple > pre {
   margin: 0;
   border: none;
   border-radius: 0;
@@ -150,7 +165,7 @@ div.secured-by > pre:nth-child(2) {
   padding-top: 8px;
 }
 
-div.secured-by > pre:last-child {
+div.secured-by,div.secured-by-multiple > pre:last-child {
   border-bottom-left-radius: 6px;
   border-bottom-right-radius: 6px;
   padding-bottom: 8px;

--- a/boat-scaffold/src/main/templates/boat-docs/styles.mustache
+++ b/boat-scaffold/src/main/templates/boat-docs/styles.mustache
@@ -151,7 +151,7 @@ div.secured-by-multiple > pre:nth-child(1) {
   padding-top: 8px;
 }
 
-div.secured-by,div.secured-by-multiple > pre {
+div.secured-by > pre, div.secured-by-multiple > pre {
   margin: 0;
   border: none;
   border-radius: 0;
@@ -165,7 +165,7 @@ div.secured-by > pre:nth-child(2) {
   padding-top: 8px;
 }
 
-div.secured-by,div.secured-by-multiple > pre:last-child {
+div.secured-by > pre:last-child, div.secured-by-multiple > pre:last-child {
   border-bottom-left-radius: 6px;
   border-bottom-right-radius: 6px;
   padding-bottom: 8px;

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/doc/BoatDocsTest.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/doc/BoatDocsTest.java
@@ -71,11 +71,9 @@ class BoatDocsTest {
     @Test
     void testGenerateDocs_MultiplePermissions() throws IOException {
         generateDocs(getFile("/openapi-with-examples/openapi-with-multiple-permissions.yaml"));
-
-        File output = new File("target/docs/");
-        String[] actualDirectorySorted = output.list();
         File index = new File("target/docs/index.html");
         String generated = String.join(" ", Files.readAllLines(Paths.get(index.getPath())));
+        assertTrue(generated.startsWith("<!DOCTYPE html>"));
     }
 
     @Test

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/doc/BoatDocsTest.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/doc/BoatDocsTest.java
@@ -47,8 +47,6 @@ class BoatDocsTest {
         File output = new File("target/docs/");
         String[] actualDirectorySorted = output.list();
         Arrays.sort(actualDirectorySorted);
-        String[] expectedDirectory = {".openapi-generator", ".openapi-generator-ignore", "index.html"};
-//        assertArrayEquals(expectedDirectory, actualDirectorySorted);
         File index = new File("target/docs/index.html");
         String generated = String.join(" ", Files.readAllLines(Paths.get(index.getPath())));
         assertTrue(generated.startsWith("<!DOCTYPE html>"));

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/doc/BoatDocsTest.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/doc/BoatDocsTest.java
@@ -25,7 +25,7 @@ class BoatDocsTest {
         } else {
             generateDocs(getFile("/psd2/psd2-api-1.3.5-20191216v1.yaml"));
         }
-//        String generated = String.join( " ", Files.readAllLines(Paths.get("target/docs/index.html")));
+//       String generated = String.join( " ", Files.readAllLines(Paths.get("target/docs/index.html")));
 //        assertTrue(generated.contains("<title>NextGenPSD2 XS2A Framework</title>"));
     }
 
@@ -37,6 +37,21 @@ class BoatDocsTest {
     @Test
     public void testGenerateDocsExampleRefs() {
         assertDoesNotThrow(() -> generateDocs(getFile("/oas-examples/petstore-example-refs.yaml")));
+    }
+
+
+    @Test
+    void testGenerateDocs_Multiple_Permissions() throws IOException {
+        generateDocs(getFile("/openapi-with-examples/openapi-with-multiple-permissions.yaml"));
+
+        File output = new File("target/docs/");
+        String[] actualDirectorySorted = output.list();
+        Arrays.sort(actualDirectorySorted);
+        String[] expectedDirectory = {".openapi-generator", ".openapi-generator-ignore", "index.html"};
+//        assertArrayEquals(expectedDirectory, actualDirectorySorted);
+        File index = new File("target/docs/index.html");
+        String generated = String.join(" ", Files.readAllLines(Paths.get(index.getPath())));
+        assertTrue(generated.startsWith("<!DOCTYPE html>"));
     }
 
     @Test
@@ -51,6 +66,16 @@ class BoatDocsTest {
         File index = new File("target/docs/index.html");
         String generated = String.join(" ", Files.readAllLines(Paths.get(index.getPath())));
         assertTrue(generated.startsWith("<!DOCTYPE html>"));
+    }
+
+    @Test
+    void testGenerateDocs_MultiplePermissions() throws IOException {
+        generateDocs(getFile("/openapi-with-examples/openapi-with-multiple-permissions.yaml"));
+
+        File output = new File("target/docs/");
+        String[] actualDirectorySorted = output.list();
+        File index = new File("target/docs/index.html");
+        String generated = String.join(" ", Files.readAllLines(Paths.get(index.getPath())));
     }
 
     @Test

--- a/boat-scaffold/src/test/resources/openapi-with-examples/openapi-with-multiple-permissions.yaml
+++ b/boat-scaffold/src/test/resources/openapi-with-examples/openapi-with-multiple-permissions.yaml
@@ -1,0 +1,290 @@
+openapi: 3.0.1
+info:
+  title: Wallet Test Client API
+  description: No description available
+  version: v1
+servers:
+  - url: /serviceName/client-api/v1
+    description: The server
+tags:
+  - name: wallet test client api
+paths:
+  /wallet/paymentcards:
+    summary: Payment Cards
+    description: No description available
+    get:
+      tags:
+        - wallet
+      summary: Returns available payment card details for user, optionally filtered
+        by nameOnCard.
+      description: Returns available payment card details for user, optionally filtered
+        by nameOnCard
+      operationId: getPaymentcards
+      parameters:
+        - name: nameOnCard
+          in: query
+          description: Filter by the cardholder's name (case-insensitive), can be the
+            first one or more characters of one of the words/names
+          required: false
+          schema:
+            type: string
+          examples:
+            example:
+              summary: example
+              value: Smi
+        - name: dateTimeOnly
+          in: query
+          description: Creation date in datetime-only format
+          required: false
+          schema:
+            type: string
+            format: date-time
+          examples:
+            example:
+              summary: example
+              value: 2017-10-04T14:54:36
+        - name: dateTime
+          in: query
+          description: Creation date in Zoned RFC3339 Date-time format
+          required: false
+          schema:
+            type: string
+            format: date-time
+          examples:
+            example:
+              summary: example
+              value: 2017-10-04T14:54:36Z
+        - name: dateTime2616
+          in: query
+          description: Zoned RFC2616 Date-time param example
+          required: false
+          schema:
+            type: string
+            format: date-time
+          examples:
+            example:
+              summary: example
+              value: Wed, 4 Jul 2001 12:08:56 PDT
+        - name: date
+          in: query
+          description: Date-only param example
+          required: false
+          schema:
+            type: string
+            format: date
+          examples:
+            example:
+              summary: example
+              value: 2017-10-04
+        - name: time
+          in: query
+          description: time-only param example
+          required: false
+          schema:
+            type: string
+            format: date-time
+          examples:
+            example:
+              summary: example
+              value: 14:54:36
+        - name: orderBy
+          in: query
+          description: |
+            Order by field: nameOnCard
+          required: false
+          schema:
+            type: string
+          examples:
+            example:
+              summary: example
+        - name: direction
+          in: query
+          description: Direction
+          required: false
+          schema:
+            type: string
+            enum:
+              - ASC
+              - DESC
+            default: DESC
+          examples:
+            example:
+              summary: example
+      responses:
+        "200":
+          description: No description available
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentCards'
+              examples:
+                example:
+                  value: |-
+                    [ {
+                      "id" : "a5b0fe7d-c4dd-40a7-bd80-dfc7869327e1",
+                      "pan" : "5434111122223333",
+                      "cvc" : "123",
+                      "startDate" : "0116",
+                      "expiryDate" : "1219",
+                      "nameOnCard" : "Mr Timmy Tester",
+                      "creationDate" : "2011-05-30T12:13:14+03:00",
+                      "balance" : {
+                        "amount" : "2001",
+                        "currencyCode" : "EUR"
+                      },
+                      "apr" : 12.75
+                    }, {
+                      "id" : "d593c212-70ad-41a6-a547-d5d9232414cb",
+                      "pan" : "5434111122224444",
+                      "cvc" : "101",
+                      "startDate" : "0216",
+                      "expiryDate" : "0120",
+                      "nameOnCard" : "Mr Timmothy Tester",
+                      "creationDate" : "2011-05-30T12:13:14+03:00",
+                      "balance" : {
+                        "amount" : "4.4399999999999995",
+                        "currencyCode" : "GBP"
+                      },
+                      "apr" : 12.75
+                    }, {
+                      "id" : "9635966b-28e9-4479-8121-bb7bc9beeb62",
+                      "pan" : "5434121212121212",
+                      "cvc" : "121",
+                      "startDate" : "0115",
+                      "expiryDate" : "1218",
+                      "nameOnCard" : "Mr Timmy Tester",
+                      "creationDate" : "2011-05-30T12:13:14+03:00",
+                      "balance" : {
+                        "amount" : "1981",
+                        "currencyCode" : "EUR"
+                      },
+                      "apr" : 12.75
+                    } ]
+        "400":
+          description: BadRequest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                example:
+                  value: |-
+                    {
+                      "message" : "Bad Request",
+                      "errors" : [ {
+                        "message" : "Value Exceeded. Must be between {min} and {max}.",
+                        "key" : "common.api.shoesize",
+                        "context" : {
+                          "max" : "50",
+                          "min" : "1"
+                        }
+                      } ]
+                    }
+        "406":
+          description: NotAcceptable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotAcceptableError'
+              examples:
+                example:
+                  value: |-
+                    {
+                      "message" : "Could not find acceptable representation",
+                      "supportedMediaTypes" : [ "application/json" ]
+                    }
+        "500":
+          description: InternalServerError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+              examples:
+                example:
+                  value: |-
+                    {
+                      "message" : "Description of error"
+                    }
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+              examples:
+                example:
+                  value: |-
+                    {
+                      "message" : "Access to requested resource denied.",
+                      "errors" : [ {
+                        "message" : "Resource access denied due to an insufficient user quota of {quota}.",
+                        "key" : "common.api.quota",
+                        "context" : {
+                          "quota" : "someQuota"
+                        }
+                      } ]
+                    }
+        "415":
+          description: UnsupportedMediaType
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnsupportedMediaTypeError'
+              examples:
+                example:
+                  value: |-
+                    {
+                      "message" : "Unsupported media type.",
+                      "errors" : [ {
+                        "message" : "The request entity has a media type {mediaType} which the resource does not support.",
+                        "key" : "common.api.mediaType",
+                        "context" : {
+                          "mediaType" : "application/javascript"
+                        }
+                      } ]
+                    }
+        "404":
+          description: NotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+              examples:
+                example:
+                  value: |-
+                    {
+                      "message" : "Resource not found.",
+                      "errors" : [ {
+                        "message" : "Unable to find the resource requested resource: {resource}.",
+                        "key" : "common.api.resource",
+                        "context" : {
+                          "resource" : "aResource"
+                        }
+                      } ]
+                    }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedAltError'
+              examples:
+                example:
+                  value: |-
+                    {
+                      "message" : "Access to requested resource denied.",
+                      "errors" : [ {
+                        "message" : "Resource access denied due to invalid credentials.",
+                        "key" : "common.api.token",
+                        "context" : {
+                          "accessToken" : "expired"
+                        }
+                      } ]
+                    }
+      x-BbAccessControls:
+        - resource: WALLET
+          function: MANAGE_PAYMENT_CARDS
+          privilege: READ_PAYMENT_CARD
+        - resource: CARDS
+          function: MANAGE
+          privilege: READ_CARD

--- a/boat-scaffold/src/test/resources/openapi-with-examples/openapi-with-multiple-permissions.yaml
+++ b/boat-scaffold/src/test/resources/openapi-with-examples/openapi-with-multiple-permissions.yaml
@@ -282,9 +282,11 @@ paths:
                       } ]
                     }
       x-BbAccessControls:
-        - resource: WALLET
-          function: MANAGE_PAYMENT_CARDS
-          privilege: READ_PAYMENT_CARD
-        - resource: CARDS
-          function: MANAGE
-          privilege: READ_CARD
+        description: (a) and (b) are required permissions.
+        permissions:
+          - resource: WALLET
+            function: MANAGE_PAYMENT_CARDS
+            privilege: READ_PAYMENT_CARD
+          - resource: CARDS
+            function: MANAGE
+            privilege: READ_CARD


### PR DESCRIPTION
Backbase Email: harry@backbase.com

Some of digital assists endpoints are protected with multiple function group permissions which we want to represent elegantly. This PR keeps the old properties for access control i.e.  x-BbAccessControl-resource, etc... but adds an optional x-BbAccessControls with the format below:
```
x-BbAccessControls:
  description: Description including references to the permissions (a), (b) etc...
  permissions:
    - resource: Permission_a_Resource
      function: Permission_a_Function
      privilege: Permission_a_Privilege
    - resource: Permission_b_Resource
       function: Permission_b_Function
       privilege: Permission_b_Privilege
```

Theses permissions appears in the generated docs side by side. 

Example: 
![Screenshot 2024-04-19 at 15 36 31](https://github.com/Backbase/backbase-openapi-tools/assets/7137398/9c535e24-3042-48dd-9e31-04807c72ce66)