### PR TITLE
Improve generated client Class Name

### DIFF
--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -200,7 +200,7 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
     Check if it's ending with API, if yes, strip the API / Api and set moduleName to the stripped string
     Check if it's ending with Client, if yes, stop, fail the whole generation.
      */
-    String sanitize(String projectName) {
+    private String sanitize(String projectName) {
         String projName = "";
         if (Pattern.matches("\\w.*(API|Api)$", projectName)) {
             projName = Pattern.compile("(API|Api)$").matcher(projectName).replaceAll("");

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -200,12 +200,12 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
     Check if it's ending with API, if yes, strip the API / Api and set moduleName to the stripped string
     Check if it's ending with Client, if yes, stop, fail the whole generation.
      */
-    private String sanitize(String projectName) {
+    String sanitize(String projectName) {
         String projName = "";
         if (Pattern.matches("\\w.*(API|Api)$", projectName)) {
             projName = Pattern.compile("(API|Api)$").matcher(projectName).replaceAll("");
         } else if (Pattern.matches("\\w.*(CLIENT|client|Client)$", projectName)) {
-            throw new RuntimeException(projectName + " is not valid. projectName should end with `API or `Api` ");
+            throw new RuntimeException(projectName + " is not valid. projectName should end with `API or `Api`");
         } else {
             projName = projectName;
         }

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -205,7 +205,7 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         if (Pattern.matches("\\w.*(API|Api)$", projectName)) {
             projName = Pattern.compile("(API|Api)$").matcher(projectName).replaceAll("");
         } else if (Pattern.matches("\\w.*(CLIENT|client|Client)$", projectName)) {
-            throw new RuntimeException(projectName + " is not valid. projectName should end with `API or `Api`");
+            throw new IllegalArgumentException(projectName + " is not valid. projectName should end with `API or `Api`");
         } else {
             projName = projectName;
         }

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -12,6 +12,7 @@ import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.utils.ModelUtils;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenConfig {
     public static final String LIBRARY_DBS = "dbsDataProvider";
@@ -19,6 +20,7 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
     public static final String DEPENDENCY_MANAGEMENT_PODFILE = "Podfile";
     protected static final String DEPENDENCY_MANAGEMENT_CARTFILE = "Cartfile";
     protected static final String[] DEPENDENCY_MANAGEMENT_OPTIONS = {DEPENDENCY_MANAGEMENT_CARTFILE, DEPENDENCY_MANAGEMENT_PODFILE};
+    protected static final String MODULE_NAME = "moduleName";
     protected String[] dependenciesAs = new String[0];
 
     /**
@@ -77,6 +79,9 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
             supportingFiles.add(new SupportingFile("Podfile.mustache",
                     "",
                     DEPENDENCY_MANAGEMENT_PODFILE));
+        }
+        if (!additionalProperties.containsKey(MODULE_NAME)) {
+            additionalProperties.put(MODULE_NAME, sanitize((String) additionalProperties.get(PROJECT_NAME)));
         }
     }
 
@@ -190,10 +195,27 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         codegenModel.removeAllDuplicatedProperty();
     }
 
+    /*
+    Get the projectName,
+    Check if it's ending with API, if yes, strip the API / Api and set moduleName to the stripped string
+    Check if it's ending with Client, if yes, stop, fail the whole generation.
+     */
+    private String sanitize(String projectName) {
+        String projName = "";
+        if (Pattern.matches("\\w.*(API|Api)$", projectName)) {
+            projName = Pattern.compile("(API|Api)$").matcher(projectName).replaceAll("");
+        } else if (Pattern.matches("\\w.*(CLIENT|client|Client)$", projectName)) {
+            throw new RuntimeException(projectName + " is not valid. projectName should end with `API or `Api` ");
+        } else {
+            projName = projectName;
+        }
+        return projName;
+    }
+
     @Override
     public void postProcess() {
         System.out.println("################################################################################");
-        System.out.println("# Thanks for using BOAT Swift 5 OpenAPI Generator.                                          #");
+        System.out.println("#            Thanks for using BOAT Swift 5 OpenAPI Generator.                   #");
         System.out.println("################################################################################");
     }
 

--- a/boat-scaffold/src/main/templates/boat-swift5/APIs.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/APIs.mustache
@@ -8,7 +8,7 @@ import Foundation
 import Backbase
 import ClientCommonGen2
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class {{projectName}}API: NSObject, DBSClient {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class {{#strippedProjectName}}{{strippedProjectName}}Client{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API{{/strippedProjectName}}: NSObject, DBSClient {
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var dataProvider: DBSDataProvider?
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var baseURL: URL{{#useAlamofire}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory(){{/useAlamofire}}{{#useURLSession}}
@@ -41,7 +41,7 @@ import ClientCommonGen2
         self.isBody = isBody
         self.headers = headers
 
-        addHeaders({{projectName}}API.customHeaders)
+        addHeaders({{#strippedProjectName}}{{strippedProjectName}}Client.customHeaders{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.customHeaders{{/strippedProjectName}})
         addHeaders(Backbase.authClient().tokens())
     }
 
@@ -51,7 +51,7 @@ import ClientCommonGen2
         }
     }
 
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{projectName}}API.apiResponseQueue, _ completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) { }
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}, _ completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) { }
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func addHeader(name: String, value: String) -> Self {
         if !value.isEmpty {

--- a/boat-scaffold/src/main/templates/boat-swift5/APIs.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/APIs.mustache
@@ -8,7 +8,7 @@ import Foundation
 import Backbase
 import ClientCommonGen2
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class {{#strippedProjectName}}{{strippedProjectName}}Client{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API{{/strippedProjectName}}: NSObject, DBSClient {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class {{#hasStrippedProjectName}}{{strippedProjectName}}Client{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API{{/hasStrippedProjectName}}: NSObject, DBSClient {
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var dataProvider: DBSDataProvider?
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var baseURL: URL{{#useAlamofire}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory(){{/useAlamofire}}{{#useURLSession}}
@@ -41,7 +41,7 @@ import ClientCommonGen2
         self.isBody = isBody
         self.headers = headers
 
-        addHeaders({{#strippedProjectName}}{{strippedProjectName}}Client.customHeaders{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.customHeaders{{/strippedProjectName}})
+        addHeaders({{#hasStrippedProjectName}}{{strippedProjectName}}Client.customHeaders{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.customHeaders{{/hasStrippedProjectName}})
         addHeaders(Backbase.authClient().tokens())
     }
 
@@ -51,7 +51,7 @@ import ClientCommonGen2
         }
     }
 
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}, _ completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) { }
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}, _ completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) { }
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func addHeader(name: String, value: String) -> Self {
         if !value.isEmpty {

--- a/boat-scaffold/src/main/templates/boat-swift5/APIs.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/APIs.mustache
@@ -8,7 +8,7 @@ import Foundation
 import Backbase
 import ClientCommonGen2
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class {{#hasStrippedProjectName}}{{strippedProjectName}}Client{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API{{/hasStrippedProjectName}}: NSObject, DBSClient {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class {{moduleName}}Client: NSObject, DBSClient {
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var dataProvider: DBSDataProvider?
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var baseURL: URL{{#useAlamofire}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory(){{/useAlamofire}}{{#useURLSession}}
@@ -41,7 +41,7 @@ import ClientCommonGen2
         self.isBody = isBody
         self.headers = headers
 
-        addHeaders({{#hasStrippedProjectName}}{{strippedProjectName}}Client.customHeaders{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.customHeaders{{/hasStrippedProjectName}})
+        addHeaders({{moduleName}}Client.customHeaders)
         addHeaders(Backbase.authClient().tokens())
     }
 
@@ -51,7 +51,7 @@ import ClientCommonGen2
         }
     }
 
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}, _ completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) { }
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{moduleName}}Client.apiResponseQueue, _ completion: @escaping (_ result: Result<Response<T>, Error>) -> Void) { }
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func addHeader(name: String, value: String) -> Self {
         if !value.isEmpty {

--- a/boat-scaffold/src/main/templates/boat-swift5/Podspec.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/Podspec.mustache
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   {{/podDocumentationURL}}
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.source = { :git => 'https://github.com/backbase-rnd/backbase-generated-clients-ios/ios-clients/{{projectName}}'}
+  s.source = { :git => 'https://github.com/backbase-rnd/backbase-generated-clients-ios/tree/main/ios-clients/{{projectName}}'}
   s.source_files = '{{projectName}}/Classes/**/*.swift'
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/boat-scaffold/src/main/templates/boat-swift5/api.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/api.mustache
@@ -12,7 +12,7 @@ import PromiseKit{{/usePromiseKit}}{{#useRxSwift}}
 import RxSwift{{/useRxSwift}}{{#useCombine}}
 import Combine{{/useCombine}}
 {{#swiftUseApiNamespace}}
-extension {{#hasStrippedProjectName}}{{strippedProjectName}}Client{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API{{/hasStrippedProjectName}} {
+extension {{moduleName}}Client {
 {{/swiftUseApiNamespace}}
 
 /// {{classname}} protocol defines a blueprint of methods, properties, and other requirements for {{classname}} functionality. 
@@ -114,7 +114,7 @@ extension {{#hasStrippedProjectName}}{{strippedProjectName}}Client{{/hasStripped
      - parameter apiResponseQueue: The queue on which api response is dispatched.
      - returns: Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}} {{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}} {{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{moduleName}}Client.apiResponseQueue) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         let deferred = Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.pending()
         {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
             switch result {
@@ -142,7 +142,7 @@ extension {{#hasStrippedProjectName}}{{strippedProjectName}}Client{{/hasStripped
      - parameter apiResponseQueue: The queue on which api response is dispatched.
      - returns: Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}) -> Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{moduleName}}Client.apiResponseQueue) -> Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         return Observable.create { observer -> Disposable in
             {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
                 switch result {
@@ -173,7 +173,7 @@ extension {{#hasStrippedProjectName}}{{strippedProjectName}}Client{{/hasStripped
      - returns: AnyPublisher<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>
      */
     @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}) -> AnyPublisher<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error> {    
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{moduleName}}Client.apiResponseQueue) -> AnyPublisher<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error> {    
         return Future<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>.init { promisse in
             {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
                 switch result {
@@ -201,7 +201,7 @@ extension {{#hasStrippedProjectName}}{{strippedProjectName}}Client{{/hasStripped
      - parameter apiResponseQueue: The queue on which api response is dispatched.
      - parameter completion: completion handler to receive the result
      */
-    open func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}, completion: @escaping ((_ result: Result<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>) -> Void)) {    
+    open func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{moduleName}}Client.apiResponseQueue, completion: @escaping ((_ result: Result<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>) -> Void)) {    
         {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
             switch result {
             {{#returnType}}

--- a/boat-scaffold/src/main/templates/boat-swift5/api.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/api.mustache
@@ -12,7 +12,7 @@ import PromiseKit{{/usePromiseKit}}{{#useRxSwift}}
 import RxSwift{{/useRxSwift}}{{#useCombine}}
 import Combine{{/useCombine}}
 {{#swiftUseApiNamespace}}
-extension {{#strippedProjectName}}{{strippedProjectName}}Client{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API{{/strippedProjectName}} {
+extension {{#hasStrippedProjectName}}{{strippedProjectName}}Client{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API{{/hasStrippedProjectName}} {
 {{/swiftUseApiNamespace}}
 
 /// {{classname}} protocol defines a blueprint of methods, properties, and other requirements for {{classname}} functionality. 
@@ -114,7 +114,7 @@ extension {{#strippedProjectName}}{{strippedProjectName}}Client{{/strippedProjec
      - parameter apiResponseQueue: The queue on which api response is dispatched.
      - returns: Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}} {{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}} {{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         let deferred = Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.pending()
         {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
             switch result {
@@ -142,7 +142,7 @@ extension {{#strippedProjectName}}{{strippedProjectName}}Client{{/strippedProjec
      - parameter apiResponseQueue: The queue on which api response is dispatched.
      - returns: Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}) -> Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}) -> Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         return Observable.create { observer -> Disposable in
             {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
                 switch result {
@@ -173,7 +173,7 @@ extension {{#strippedProjectName}}{{strippedProjectName}}Client{{/strippedProjec
      - returns: AnyPublisher<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>
      */
     @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}) -> AnyPublisher<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error> {    
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}) -> AnyPublisher<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error> {    
         return Future<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>.init { promisse in
             {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
                 switch result {
@@ -201,7 +201,7 @@ extension {{#strippedProjectName}}{{strippedProjectName}}Client{{/strippedProjec
      - parameter apiResponseQueue: The queue on which api response is dispatched.
      - parameter completion: completion handler to receive the result
      */
-    open func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}, completion: @escaping ((_ result: Result<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>) -> Void)) {    
+    open func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}, completion: @escaping ((_ result: Result<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>) -> Void)) {    
         {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
             switch result {
             {{#returnType}}

--- a/boat-scaffold/src/main/templates/boat-swift5/api.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/api.mustache
@@ -12,7 +12,7 @@ import PromiseKit{{/usePromiseKit}}{{#useRxSwift}}
 import RxSwift{{/useRxSwift}}{{#useCombine}}
 import Combine{{/useCombine}}
 {{#swiftUseApiNamespace}}
-extension {{projectName}}API {
+extension {{#strippedProjectName}}{{strippedProjectName}}Client{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API{{/strippedProjectName}} {
 {{/swiftUseApiNamespace}}
 
 /// {{classname}} protocol defines a blueprint of methods, properties, and other requirements for {{classname}} functionality. 
@@ -114,7 +114,7 @@ extension {{projectName}}API {
      - parameter apiResponseQueue: The queue on which api response is dispatched.
      - returns: Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}} {{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{projectName}}API.apiResponseQueue) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}} {{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         let deferred = Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.pending()
         {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
             switch result {
@@ -142,7 +142,7 @@ extension {{projectName}}API {
      - parameter apiResponseQueue: The queue on which api response is dispatched.
      - returns: Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{projectName}}API.apiResponseQueue) -> Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}) -> Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         return Observable.create { observer -> Disposable in
             {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
                 switch result {
@@ -173,7 +173,7 @@ extension {{projectName}}API {
      - returns: AnyPublisher<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>
      */
     @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{projectName}}API.apiResponseQueue) -> AnyPublisher<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error> {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}) -> AnyPublisher<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error> {    
         return Future<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>.init { promisse in
             {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
                 switch result {
@@ -201,7 +201,7 @@ extension {{projectName}}API {
      - parameter apiResponseQueue: The queue on which api response is dispatched.
      - parameter completion: completion handler to receive the result
      */
-    open func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{projectName}}API.apiResponseQueue, completion: @escaping ((_ result: Result<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>) -> Void)) {
+    open func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}, completion: @escaping ((_ result: Result<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>) -> Void)) {    
         {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(apiResponseQueue) { result -> Void in
             switch result {
             {{#returnType}}

--- a/boat-scaffold/src/main/templates/boat-swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -25,7 +25,7 @@ class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} typealias {{#hasStrippedProjectName}}{{strippedProjectName}}ClientChallengeHandler{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}APIChallengeHandler{{/hasStrippedProjectName}} = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} typealias {{moduleName}}ClientChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
 
 // Store the URLSession's delegate to retain its reference
 private let sessionDelegate = SessionDelegate()
@@ -34,7 +34,7 @@ private let sessionDelegate = SessionDelegate()
 private let defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
 
 // Store current taskDidReceiveChallenge for every URLSessionTask
-private var challengeHandlerStore = SynchronizedDictionary<Int, {{#hasStrippedProjectName}}{{strippedProjectName}}ClientChallengeHandler{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}APIChallengeHandler{{/hasStrippedProjectName}}>()
+private var challengeHandlerStore = SynchronizedDictionary<Int, {{moduleName}}ClientChallengeHandler>()
 
 // Store current URLCredential for every URLSessionTask
 private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
@@ -44,7 +44,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
     /**
      May be assigned if you want to control the authentication challenges.
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var taskDidReceiveChallenge: {{#hasStrippedProjectName}}{{strippedProjectName}}ClientChallengeHandler?{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}APIChallengeHandler?{{/hasStrippedProjectName}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var taskDidReceiveChallenge: {{moduleName}}ClientChallengeHandler?
 
     /**
      May be assigned if you want to do any of those things:
@@ -102,7 +102,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
     }
 
     @discardableResult
-    override {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}, _ completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) -> RequestTask {
+    override {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{moduleName}}Client.apiResponseQueue, _ completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) -> RequestTask {
         let urlSession = createURLSession()
 
         guard let xMethod = HTTPMethod(rawValue: method) else {
@@ -197,7 +197,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func buildHeaders() -> [String: String] {
         var httpHeaders: [String: String] = [:]
-        for (key, value) in {{#hasStrippedProjectName}}{{strippedProjectName}}Client.customHeaders{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.customHeaders{{/hasStrippedProjectName}}
+        for (key, value) in {{moduleName}}Client.customHeaders
             httpHeaders[key] = value
         }
         for (key, value) in headers {

--- a/boat-scaffold/src/main/templates/boat-swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -25,7 +25,7 @@ class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} typealias {{projectName}}APIChallengeHandler = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} typealias {{#strippedProjectName}}{{strippedProjectName}}ClientChallengeHandler{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}APIChallengeHandler{{/strippedProjectName}} = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
 
 // Store the URLSession's delegate to retain its reference
 private let sessionDelegate = SessionDelegate()
@@ -34,7 +34,7 @@ private let sessionDelegate = SessionDelegate()
 private let defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
 
 // Store current taskDidReceiveChallenge for every URLSessionTask
-private var challengeHandlerStore = SynchronizedDictionary<Int, {{projectName}}APIChallengeHandler>()
+private var challengeHandlerStore = SynchronizedDictionary<Int, {{#strippedProjectName}}{{strippedProjectName}}ClientChallengeHandler{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}APIChallengeHandler{{/strippedProjectName}}>()
 
 // Store current URLCredential for every URLSessionTask
 private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
@@ -44,7 +44,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
     /**
      May be assigned if you want to control the authentication challenges.
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var taskDidReceiveChallenge: {{projectName}}APIChallengeHandler?
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var taskDidReceiveChallenge: {{#strippedProjectName}}{{strippedProjectName}}ClientChallengeHandler?{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}APIChallengeHandler?{{/strippedProjectName}}
 
     /**
      May be assigned if you want to do any of those things:
@@ -102,7 +102,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
     }
 
     @discardableResult
-    override {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{projectName}}API.apiResponseQueue, _ completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) -> RequestTask {
+    override {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}, _ completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) -> RequestTask {
         let urlSession = createURLSession()
 
         guard let xMethod = HTTPMethod(rawValue: method) else {
@@ -197,7 +197,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func buildHeaders() -> [String: String] {
         var httpHeaders: [String: String] = [:]
-        for (key, value) in {{projectName}}API.customHeaders {
+        for (key, value) in {{#strippedProjectName}}{{strippedProjectName}}Client.customHeaders{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.customHeaders{{/strippedProjectName}}
             httpHeaders[key] = value
         }
         for (key, value) in headers {

--- a/boat-scaffold/src/main/templates/boat-swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -25,7 +25,7 @@ class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} typealias {{#strippedProjectName}}{{strippedProjectName}}ClientChallengeHandler{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}APIChallengeHandler{{/strippedProjectName}} = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} typealias {{#hasStrippedProjectName}}{{strippedProjectName}}ClientChallengeHandler{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}APIChallengeHandler{{/hasStrippedProjectName}} = ((URLSession, URLSessionTask, URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))
 
 // Store the URLSession's delegate to retain its reference
 private let sessionDelegate = SessionDelegate()
@@ -34,7 +34,7 @@ private let sessionDelegate = SessionDelegate()
 private let defaultURLSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
 
 // Store current taskDidReceiveChallenge for every URLSessionTask
-private var challengeHandlerStore = SynchronizedDictionary<Int, {{#strippedProjectName}}{{strippedProjectName}}ClientChallengeHandler{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}APIChallengeHandler{{/strippedProjectName}}>()
+private var challengeHandlerStore = SynchronizedDictionary<Int, {{#hasStrippedProjectName}}{{strippedProjectName}}ClientChallengeHandler{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}APIChallengeHandler{{/hasStrippedProjectName}}>()
 
 // Store current URLCredential for every URLSessionTask
 private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
@@ -44,7 +44,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
     /**
      May be assigned if you want to control the authentication challenges.
      */
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var taskDidReceiveChallenge: {{#strippedProjectName}}{{strippedProjectName}}ClientChallengeHandler?{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}APIChallengeHandler?{{/strippedProjectName}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var taskDidReceiveChallenge: {{#hasStrippedProjectName}}{{strippedProjectName}}ClientChallengeHandler?{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}APIChallengeHandler?{{/hasStrippedProjectName}}
 
     /**
      May be assigned if you want to do any of those things:
@@ -102,7 +102,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
     }
 
     @discardableResult
-    override {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{#strippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.apiResponseQueue{{/strippedProjectName}}, _ completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) -> RequestTask {
+    override {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func execute(_ apiResponseQueue: DispatchQueue = {{#hasStrippedProjectName}}{{strippedProjectName}}Client.apiResponseQueue{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.apiResponseQueue{{/hasStrippedProjectName}}, _ completion: @escaping (_ result: Swift.Result<Response<T>, ErrorResponse>) -> Void) -> RequestTask {
         let urlSession = createURLSession()
 
         guard let xMethod = HTTPMethod(rawValue: method) else {
@@ -197,7 +197,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func buildHeaders() -> [String: String] {
         var httpHeaders: [String: String] = [:]
-        for (key, value) in {{#strippedProjectName}}{{strippedProjectName}}Client.customHeaders{{/strippedProjectName}}{{^strippedProjectName}}{{projectName}}API.customHeaders{{/strippedProjectName}}
+        for (key, value) in {{#hasStrippedProjectName}}{{strippedProjectName}}Client.customHeaders{{/hasStrippedProjectName}}{{^hasStrippedProjectName}}{{projectName}}API.customHeaders{{/hasStrippedProjectName}}
             httpHeaders[key] = value
         }
         for (key, value) in headers {

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -331,17 +331,26 @@ public class BoatSwift5CodegenTests {
     }
 
     @Test
-    void testSanitizeThrowsWhenProjectNameIsInvalid() {
+    void test_processOptsThrowsWhenProjectNameIsInvalid() {
         boatSwift5CodeGen.additionalProperties().put("projectName","SomethingClient");
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> boatSwift5CodeGen.sanitize((String) boatSwift5CodeGen.additionalProperties().get("projectName")));
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> boatSwift5CodeGen.processOpts());
         assertEquals("SomethingClient is not valid. projectName should end with `API or `Api`", exception.getMessage());
     }
 
     @Test
-    void testSanitizeReturnsStrippedModuleNameIsAProjectNameEndingWithAPIIsProvided() {
+    void test_processOptsSetsStrippedModuleNameIsAProjectNameEndingWithAPIIsProvided() {
         boatSwift5CodeGen.additionalProperties().put("projectName","SomethingAPI");
         String expectedModuleName = "Something";
-        assertEquals(boatSwift5CodeGen.sanitize((String) boatSwift5CodeGen.additionalProperties().get("projectName")), expectedModuleName);
+        boatSwift5CodeGen.processOpts();
+        assertEquals(boatSwift5CodeGen.additionalProperties().get("moduleName"), expectedModuleName);
+    }
+
+    @Test
+    void test_processOptsSetsOriginalProjectNameAsModuleNameIfNameDoesNotEndWithAPIOrClient() {
+        String expectedModuleName = "Something";
+        boatSwift5CodeGen.additionalProperties().put("projectName",expectedModuleName);
+        boatSwift5CodeGen.processOpts();
+        assertEquals(boatSwift5CodeGen.additionalProperties().get("moduleName"), expectedModuleName);
     }
 
     private CodegenModel prepareForModelTests() {

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -333,7 +333,7 @@ public class BoatSwift5CodegenTests {
     @Test
     void test_processOptsThrowsWhenProjectNameIsInvalid() {
         boatSwift5CodeGen.additionalProperties().put("projectName","SomethingClient");
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> boatSwift5CodeGen.processOpts());
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> boatSwift5CodeGen.processOpts());
         assertEquals("SomethingClient is not valid. projectName should end with `API or `Api`", exception.getMessage());
     }
 

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -330,6 +330,20 @@ public class BoatSwift5CodegenTests {
         assertEquals(boatSwift5CodeGen.postProcessAllModels(models), models);
     }
 
+    @Test
+    void testSanitizeThrowsWhenProjectNameIsInvalid() {
+        boatSwift5CodeGen.additionalProperties().put("projectName","SomethingClient");
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> boatSwift5CodeGen.sanitize((String) boatSwift5CodeGen.additionalProperties().get("projectName")));
+        assertEquals("SomethingClient is not valid. projectName should end with `API or `Api`", exception.getMessage());
+    }
+
+    @Test
+    void testSanitizeReturnsStrippedModuleNameIsAProjectNameEndingWithAPIIsProvided() {
+        boatSwift5CodeGen.additionalProperties().put("projectName","SomethingAPI");
+        String expectedModuleName = "Something";
+        assertEquals(boatSwift5CodeGen.sanitize((String) boatSwift5CodeGen.additionalProperties().get("projectName")), expectedModuleName);
+    }
+
     private CodegenModel prepareForModelTests() {
 
         final ObjectSchema objectSchema = new ObjectSchema();

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class BoatSwift5CodegenTests {
     BoatSwift5Codegen boatSwift5CodeGen = new BoatSwift5Codegen();
 
+
     @Test
     void testGeneratorName() {
         assertEquals(boatSwift5CodeGen.getName(), "boat-swift5");
@@ -37,6 +38,7 @@ public class BoatSwift5CodegenTests {
 
     @Test
     void testProcessOptsSetDBSDataProvider() {
+        boatSwift5CodeGen.additionalProperties().put("projectName","SomethingAPI");
         boatSwift5CodeGen.setLibrary(BoatSwift5Codegen.LIBRARY_DBS);
         boatSwift5CodeGen.processOpts();
         boatSwift5CodeGen.postProcess();
@@ -46,6 +48,7 @@ public class BoatSwift5CodegenTests {
     @ParameterizedTest
     @ValueSource(strings = {BoatSwift5Codegen.DEPENDENCY_MANAGEMENT_PODFILE, "PODFILE", "podFile", "podfile", "podfilE"})
     void testSetDependenciesDoesNotConsiderCase(String arg) {
+        boatSwift5CodeGen.additionalProperties().put("projectName","SomethingAPI");
         boatSwift5CodeGen.additionalProperties().put(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT, arg);
         boatSwift5CodeGen.processOpts();
 
@@ -55,6 +58,7 @@ public class BoatSwift5CodegenTests {
 
     @Test
     void testWhenDependenciesAsIsNotSetShouldBeEmpty() {
+        boatSwift5CodeGen.additionalProperties().put("projectName","SomethingAPI");
         boatSwift5CodeGen.processOpts();
         final String[] dependenciesAs = (String[]) boatSwift5CodeGen.additionalProperties().get(BoatSwift5Codegen.DEPENDENCY_MANAGEMENT);
         assertEquals(0,dependenciesAs.length);
@@ -168,6 +172,7 @@ public class BoatSwift5CodegenTests {
 
     @Test
     void testDefaultPodAuthors() throws Exception {
+        boatSwift5CodeGen.additionalProperties().put("projectName","SomethingAPI");
         // Given
         // When
         boatSwift5CodeGen.processOpts();
@@ -178,6 +183,7 @@ public class BoatSwift5CodegenTests {
 
     @Test
     void testPodAuthors() throws Exception {
+        boatSwift5CodeGen.additionalProperties().put("projectName","SomethingAPI");
         // Given
         final String openAPIDevs = "OpenAPI Devs";
         boatSwift5CodeGen.additionalProperties().put(Swift5ClientCodegen.POD_AUTHORS, openAPIDevs);

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -353,6 +353,19 @@ public class BoatSwift5CodegenTests {
         assertEquals(boatSwift5CodeGen.additionalProperties().get("moduleName"), expectedModuleName);
     }
 
+    /*
+    Test that when a moduleName is provided sanitize is not called
+     */
+    @Test
+    void test_processOptsDoesNotSetModuleNameIfAlreadySet() {
+        String projectName = "CustomerAPI";
+        String moduleName = "CustomerAPIModified";
+        boatSwift5CodeGen.additionalProperties().put("projectName",projectName);
+        boatSwift5CodeGen.additionalProperties().put("moduleName",moduleName);
+        boatSwift5CodeGen.processOpts();
+        assertEquals(boatSwift5CodeGen.additionalProperties().get("moduleName"), moduleName);
+    }
+
     private CodegenModel prepareForModelTests() {
 
         final ObjectSchema objectSchema = new ObjectSchema();


### PR DESCRIPTION
In order to make it easier for the migration from "[Capability]Api" from "[Capability]Client" this change is necessary 