### PR TITLE
Lint rule BO14 no longer produces null exception with string array

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ It currently consists of
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.17.36
+* Lint rule `B014` doesn't throw a null exception when parsing a string array property in a schema.  
 ## 0.17.35
 * ISSUE: #776 add new lint rule `B014` - to validate if examples contain all defined properties in the schema
 * BOAT now supports multiple access control permissions within the tag `x-BbAccessControls` in the OpenAPI spec. 

--- a/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/RequestResponseExampleRule.kt
+++ b/boat-quay/boat-quay-rules/src/main/kotlin/com/backbase/oss/boat/quay/ruleset/RequestResponseExampleRule.kt
@@ -124,7 +124,14 @@ class RequestResponseExampleRule {
         val fieldValue = jsonObject.findValue(propertyName) ?: return listOf(missedProperty(parentName, propertyName))
         return when {
             "array" == property?.type && fieldValue.isArray -> {
-                property.items?.properties?.map { prop -> arrayTypeCheck(propertyName, prop, fieldValue) }!!.flatten()
+                when {
+                    property.items.type == "object" -> {
+                        property.items?.properties?.map { prop -> arrayTypeCheck(propertyName, prop, fieldValue) }!!.flatten()
+                    }
+                    else -> {
+                        emptyList()
+                    }
+                }
             }
 
             "object" == property?.type && fieldValue.isObject -> {

--- a/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/RequestResponseExampleRuleTest.kt
+++ b/boat-quay/boat-quay-rules/src/test/kotlin/com/backbase/oss/boat/quay/ruleset/RequestResponseExampleRuleTest.kt
@@ -298,6 +298,18 @@ class RequestResponseExampleRuleTest {
                 .isEmpty()
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = [EXAMPLE_STRING_ARRAY])
+    fun `Array of Strings`(value: String) {
+
+        val violations = cut.checkResponseExampleFulfill(DefaultContextFactory()
+            .getOpenApiContext(value.trimIndent()))
+
+        ZallyAssertions
+            .assertThat(violations)
+            .isEmpty()
+    }
+
     companion object {
 
         @Language("YAML")
@@ -480,6 +492,38 @@ class RequestResponseExampleRuleTest {
                                         incorrectObject:
                                           a: 1
                 """
-    }
+        @Language("YAML")
+        const val EXAMPLE_STRING_ARRAY: String = """
+            openapi: 3.0.3
+            info:
+              title: Thing API
+              version: 1.0.0
+            paths:
+              /foo:
+                get:
+                  description: Lorem Ipsum
+                  operationId: foo
+                  responses:
+                    200:
+                      description: Lorem Ipsum
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties: 
+                              names:
+                                type: array
+                                items:
+                                  type: string
+                          examples:
+                            example1:
+                              value:
+                                names: 
+                                  - aaa
+                                  - bbb
+                                  - ccc 
+                                  
+                """
 
+    }
 }


### PR DESCRIPTION
The lint rule BO14 (example validator) throws a null exception when it encounters an array of strings. This PR fixes that issue.  