### PR TITLE
Update Podspec template file 

### DIFF
--- a/boat-scaffold/src/main/templates/boat-swift5/Podfile.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/Podfile.mustache
@@ -1,11 +1,7 @@
 source 'https://cdn.cocoapods.org'
+source 'https://repo.backbase.com/api/pods/pods'
 
 platform :ios, '15.0'
-
-plugin 'cocoapods-art', sources: %w[
-  bbartifacts3
-  bbartifacts-retail3
-]
 
 use_frameworks!
 install! 'cocoapods', deterministic_uuids: false
@@ -15,9 +11,9 @@ inhibit_all_warnings!
 
 def normal_pods
   pod 'Backbase', '>= 9'{{#useRxSwift}}
-  pod 'RxSwift', '~> 5.0.0'{{/useRxSwift}}{{#useAlamofire}}
-  pod 'Alamofire', '~> 4.9.1'{{/useAlamofire}}{{#usePromiseKit}}
-  pod 'PromiseKit', '~> 6.12.0'{{/usePromiseKit}}
+  pod 'RxSwift', '>= 5.0.0'{{/useRxSwift}}{{#useAlamofire}}
+  pod 'Alamofire', '>= 4.9.1'{{/useAlamofire}}{{#usePromiseKit}}
+  pod 'PromiseKit', '>= 6.12.0'{{/usePromiseKit}}
 end
 
 target 'Common' do

--- a/boat-scaffold/src/main/templates/boat-swift5/Podspec.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/Podspec.mustache
@@ -22,14 +22,14 @@ Pod::Spec.new do |s|
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.dependency 'Backbase', '>= 9.0'
-  s.dependency 'ClientCommonGen2', '~> 1.0'
+  s.dependency 'ClientCommonGen2', '>= 1.0'
   {{#usePromiseKit}}
-  s.dependency 'PromiseKit/CorePromise', '~> 6.12.0'
+  s.dependency 'PromiseKit/CorePromise', '>= 6.12.0'
   {{/usePromiseKit}}
   {{#useRxSwift}}
-  s.dependency 'RxSwift', '~> 5.0.0'
+  s.dependency 'RxSwift', '>= 5.0.0'
   {{/useRxSwift}}
   {{#useAlamofire}}
-  s.dependency 'Alamofire', '~> 4.9.1'
+  s.dependency 'Alamofire', '>= 4.9.1'
   {{/useAlamofire}}
 end


### PR DESCRIPTION
This will allow never versions of ClientCommonGen2 to be picked. Allows for the version to be specified on app level.