### PR TITLE
Fix - missing parameter for class generator

### DIFF
--- a/boat-scaffold/src/main/templates/boat-swift5/modelObject.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/modelObject.mustache
@@ -1,4 +1,4 @@
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} struct {{classname}}: Codable, Equatable {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#useClasses}}final class{{/useClasses}}{{^useClasses}}struct{{/useClasses}}  {{classname}}: Codable, Equatable {
 {{#allVars}}
 {{#isEnum}}
 {{> modelInlineEnumDeclaration}}


### PR DESCRIPTION
Currently the Swift generator doesn't support recursiveness. While in the swift generator's code there is a parameter to create final classes instead of structs our template did not support this parameter.