### PR TITLE
Fix for Map objects in the Swift generator

### DIFF
--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -112,7 +112,6 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
         this.dependenciesAs = dependenciesAs;
     }
 
-
     /*
     This is added as a compatibility requirement for API specs containing free form objects
     missing `additionalProperties` property
@@ -134,9 +133,9 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
     */
     private void fixFreeFormObject(List<CodegenProperty> codegenProperties) {
         for (CodegenProperty codegenProperty : codegenProperties) {
-            if (codegenProperty.isFreeFormObject && codegenProperty.isMap && !codegenProperty.items.isFreeFormObject) {
-                codegenProperty.isFreeFormObject = false;
-            }
+            //if (codegenProperty.isFreeFormObject && codegenProperty.isMap && !codegenProperty.items.isFreeFormObject) {
+            //    codegenProperty.isFreeFormObject = false;
+            //}
 
             if (codegenProperty.isArray && codegenProperty.items.isFreeFormObject) {
                 codegenProperty.isFreeFormObject = true;

--- a/boat-scaffold/src/main/templates/boat-swift5/modelObject.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/modelObject.mustache
@@ -1,4 +1,4 @@
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#useClasses}}final class{{/useClasses}}{{^useClasses}}struct{{/useClasses}}  {{classname}}: Codable, Equatable {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#useClasses}}final class{{/useClasses}}{{^useClasses}}struct{{/useClasses}} {{classname}}: Codable, Equatable {
 {{#allVars}}
 {{#isEnum}}
 {{> modelInlineEnumDeclaration}}


### PR DESCRIPTION
Fixes an issue when the spec had an object (map), and internally the generator handled it as a map instead of a freeform object. 