### PR TITLE
Make boat-maven-plugin goal `doc` to run in Java 17. 

### DIFF
--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatDocsGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/doc/BoatDocsGenerator.java
@@ -20,7 +20,7 @@ public class BoatDocsGenerator extends com.backbase.oss.codegen.BoatStaticDocsGe
         super();
         embeddedTemplateDir = templateDir = NAME;
         cliOptions.add(new CliOption(CodegenConstants.GENERATE_ALIAS_AS_MODEL, CodegenConstants.GENERATE_ALIAS_AS_MODEL));
-        additionalProperties.put(CodegenConstants.GENERATE_ALIAS_AS_MODEL, false);
+        additionalProperties.put(CodegenConstants.GENERATE_ALIAS_AS_MODEL, true);
         additionalProperties.put("appName", "OpenAPI Sample");
         additionalProperties.put("appDescription", "A sample OpenAPI server");
         additionalProperties.put("infoUrl", "https://backbase.github.io/backbase-openapi-tools/");

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/marina/BoatMarinaGenerator.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/marina/BoatMarinaGenerator.java
@@ -21,7 +21,7 @@ public class BoatMarinaGenerator extends BoatStaticDocsGenerator {
 
         embeddedTemplateDir = templateDir = NAME;
         cliOptions.add(new CliOption(CodegenConstants.GENERATE_ALIAS_AS_MODEL, CodegenConstants.GENERATE_ALIAS_AS_MODEL));
-        additionalProperties.put(CodegenConstants.GENERATE_ALIAS_AS_MODEL, false);
+        additionalProperties.put(CodegenConstants.GENERATE_ALIAS_AS_MODEL, true);
         additionalProperties.put("appName", "BOAT Marina Documentation");
         additionalProperties.put("appDescription", "For a collection of doc(k)s");
         additionalProperties.put("infoUrl", "https://backbase.github.io/backbase-openapi-tools/");
@@ -31,6 +31,7 @@ public class BoatMarinaGenerator extends BoatStaticDocsGenerator {
         typeAliases = new HashMap<>();
         HandlebarsEngineAdapter templatingEngine = new BoatHandlebarsEngineAdapter();
         setTemplatingEngine(templatingEngine);
+
     }
 
 

--- a/boat-scaffold/src/main/resources/META-INF/services/org.openapitools.codegen.api.TemplatingEngineAdapter
+++ b/boat-scaffold/src/main/resources/META-INF/services/org.openapitools.codegen.api.TemplatingEngineAdapter
@@ -1,0 +1,1 @@
+com.backbase.oss.codegen.marina.BoatHandlebarsEngineAdapter


### PR DESCRIPTION
When running `boat-maven-plugin` goal `doc`.  With parameters:

```xml
<engine>handlebars</engine>
<generatorName>boat-marina</generatorName>
```

New version of the plugin requires `Java 17` and this goal does not work in `Java 17`

Additionally, model doc generated ignores `Array` type fields. Those are not shown in Portal Api and those produce inconsistencies in the documentation.

For that, BoatMarinaGenerator was changed with property `generateAliasAsModel` as `true` 




