### PR TITLE
Remove derepcated for no-args constructor

### DIFF
--- a/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/pojo.mustache
@@ -139,11 +139,6 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
 {{#generatedConstructorWithRequiredArgs}}
   {{#hasRequired}}
 
-    /**
-    * Default constructor
-    * @deprecated Use {@link {{classname}}#{{classname}}({{#requiredVars}}{{{datatypeWithEnum}}}{{^-last}}, {{/-last}}{{/requiredVars}})}
-    */
-    @Deprecated
     public {{classname}}() {
     super();
     }


### PR DESCRIPTION
`openapi-generator` added a change in version `6.5.0` to mark default / no-arg constructor as Deprecated. This change was since then removed from the `openapi-generator` project as of `7.x.x` via FIX https://github.com/OpenAPITools/openapi-generator/pull/15512

This project templates for `boat-spring` seems to have been synced last for version `6.6.0` of `openapi-generator`.

The impact of this deprecation is that no-arg constructor usages are marked as violations in SONAR reports, lowering the code quality number.