### PR TITLE
Fix: Nested freeform objects generating broken models

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It currently consists of
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.17.55
+* Enhanced `boat-swift5` generator to cater for nested freeformObjects. This issue was identified in `ContentServicesApi`
 ## 0.17.54 and later
 Starting from 0.17.54 the release notes are available at https://github.com/Backbase/backbase-openapi-tools/releases
 ## 0.17.53

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -146,7 +146,7 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
                 }
             }
 
-            if ( hasNestedStringAnyDictionary(codegenProperty)) {
+            if (hasNestedStringAnyDictionary(codegenProperty)) {
                 codegenProperty.isFreeFormObject = true;
                 codegenProperty.setDataType(STRING_ANY_DICTIONARY);
                 codegenProperty.setDatatypeWithEnum(STRING_ANY_DICTIONARY);

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -146,10 +146,14 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
 
             if ( codegenProperty.isMap && codegenProperty.additionalProperties != null ) {
 
-                if (codegenProperty.getAdditionalProperties().isContainer) {
+                if (codegenProperty.getAdditionalProperties().isContainer && !codegenProperty.getAdditionalProperties().isArray) {
+                    System.out.println("********************** START *********************");
+                    System.out.println("CodegenProperty" + codegenProperty.toString());
+                    System.out.println("Additional Properties" + codegenProperty.getAdditionalProperties().toString());
+                    System.out.println("*********************** END **********************");
                     codegenProperty.isFreeFormObject = true;
-                    codegenProperty.dataType = "[String: Any]";
-                    codegenProperty.datatypeWithEnum = "[String: Any]";
+                    codegenProperty.setDataType("[String: Any]");
+                    codegenProperty.setDatatypeWithEnum("[String: Any]");
                 }
             }
         }

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -21,6 +21,8 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
     protected static final String DEPENDENCY_MANAGEMENT_CARTFILE = "Cartfile";
     protected static final String[] DEPENDENCY_MANAGEMENT_OPTIONS = {DEPENDENCY_MANAGEMENT_CARTFILE, DEPENDENCY_MANAGEMENT_PODFILE};
     protected static final String MODULE_NAME = "moduleName";
+    protected static final String NESTED_STRING_ANY_DICTIONARY = "[String: [String: Any]]";
+    protected static final String STRING_ANY_DICTIONARY = "[String: Any]";
     protected String[] dependenciesAs = new String[0];
 
     /**
@@ -145,15 +147,12 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
             }
 
             if ( codegenProperty.isMap && codegenProperty.additionalProperties != null ) {
-
                 if (codegenProperty.getAdditionalProperties().isContainer && !codegenProperty.getAdditionalProperties().isArray) {
-                    System.out.println("********************** START *********************");
-                    System.out.println("CodegenProperty" + codegenProperty.toString());
-                    System.out.println("Additional Properties" + codegenProperty.getAdditionalProperties().toString());
-                    System.out.println("*********************** END **********************");
-                    codegenProperty.isFreeFormObject = true;
-                    codegenProperty.setDataType("[String: Any]");
-                    codegenProperty.setDatatypeWithEnum("[String: Any]");
+                    if (codegenProperty.getDataType().equals(NESTED_STRING_ANY_DICTIONARY)){
+                        codegenProperty.isFreeFormObject = true;
+                        codegenProperty.setDataType(STRING_ANY_DICTIONARY);
+                        codegenProperty.setDatatypeWithEnum(STRING_ANY_DICTIONARY);
+                    }
                 }
             }
         }

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -143,6 +143,15 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
                     codegenProperty.isMap = false;
                 }
             }
+
+            if ( codegenProperty.isMap && codegenProperty.additionalProperties != null ) {
+
+                if (codegenProperty.getAdditionalProperties().isContainer) {
+                    codegenProperty.isFreeFormObject = true;
+                    codegenProperty.dataType = "[String: Any]";
+                    codegenProperty.datatypeWithEnum = "[String: Any]";
+                }
+            }
         }
     }
 

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -146,13 +146,11 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
                 }
             }
 
-            if ( codegenProperty.isMap && codegenProperty.additionalProperties != null ) {
-                if (codegenProperty.getAdditionalProperties().isContainer && !codegenProperty.getAdditionalProperties().isArray) {
-                    if (codegenProperty.getDataType().equals(NESTED_STRING_ANY_DICTIONARY)){
-                        codegenProperty.isFreeFormObject = true;
-                        codegenProperty.setDataType(STRING_ANY_DICTIONARY);
-                        codegenProperty.setDatatypeWithEnum(STRING_ANY_DICTIONARY);
-                    }
+            if ( hasNestedAdditionalProperties(codegenProperty)) {
+                if (codegenProperty.getDataType().equals(NESTED_STRING_ANY_DICTIONARY)) {
+                    codegenProperty.isFreeFormObject = true;
+                    codegenProperty.setDataType(STRING_ANY_DICTIONARY);
+                    codegenProperty.setDatatypeWithEnum(STRING_ANY_DICTIONARY);
                 }
             }
         }
@@ -221,6 +219,16 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
             projName = projectName;
         }
         return projName;
+    }
+
+    /*
+    Helper method to check whether a codegenProperty has nested additional properties
+     */
+    private boolean hasNestedAdditionalProperties(CodegenProperty codegenProperty) {
+        return codegenProperty.isMap
+                && codegenProperty.additionalProperties != null
+                && codegenProperty.getAdditionalProperties().isContainer
+                && !codegenProperty.getAdditionalProperties().isArray;
     }
 
     @Override

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -146,12 +146,10 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
                 }
             }
 
-            if ( hasNestedAdditionalProperties(codegenProperty)) {
-                if (codegenProperty.getDataType().equals(NESTED_STRING_ANY_DICTIONARY)) {
-                    codegenProperty.isFreeFormObject = true;
-                    codegenProperty.setDataType(STRING_ANY_DICTIONARY);
-                    codegenProperty.setDatatypeWithEnum(STRING_ANY_DICTIONARY);
-                }
+            if ( hasNestedStringAnyDictionaryDataTypeFromNestedAdditionalProperties(codegenProperty)) {
+                codegenProperty.isFreeFormObject = true;
+                codegenProperty.setDataType(STRING_ANY_DICTIONARY);
+                codegenProperty.setDatatypeWithEnum(STRING_ANY_DICTIONARY);
             }
         }
     }
@@ -229,6 +227,10 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
                 && codegenProperty.additionalProperties != null
                 && codegenProperty.getAdditionalProperties().isContainer
                 && !codegenProperty.getAdditionalProperties().isArray;
+    }
+
+    private boolean hasNestedStringAnyDictionaryDataTypeFromNestedAdditionalProperties(CodegenProperty codegenProperty) {
+        return hasNestedAdditionalProperties(codegenProperty) && codegenProperty.getDataType().equals(NESTED_STRING_ANY_DICTIONARY);
     }
 
     @Override

--- a/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
+++ b/boat-scaffold/src/main/java/org/openapitools/codegen/languages/BoatSwift5Codegen.java
@@ -146,7 +146,7 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
                 }
             }
 
-            if ( hasNestedStringAnyDictionaryDataTypeFromNestedAdditionalProperties(codegenProperty)) {
+            if ( hasNestedStringAnyDictionary(codegenProperty)) {
                 codegenProperty.isFreeFormObject = true;
                 codegenProperty.setDataType(STRING_ANY_DICTIONARY);
                 codegenProperty.setDatatypeWithEnum(STRING_ANY_DICTIONARY);
@@ -229,7 +229,7 @@ public class BoatSwift5Codegen extends Swift5ClientCodegen implements CodegenCon
                 && !codegenProperty.getAdditionalProperties().isArray;
     }
 
-    private boolean hasNestedStringAnyDictionaryDataTypeFromNestedAdditionalProperties(CodegenProperty codegenProperty) {
+    private boolean hasNestedStringAnyDictionary(CodegenProperty codegenProperty) {
         return hasNestedAdditionalProperties(codegenProperty) && codegenProperty.getDataType().equals(NESTED_STRING_ANY_DICTIONARY);
     }
 

--- a/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
+++ b/boat-scaffold/src/test/java/org/openapitools/codegen/languages/BoatSwift5CodegenTests.java
@@ -204,7 +204,7 @@ public class BoatSwift5CodegenTests {
         assertEquals(cm.name, "sample");
         assertEquals(cm.classname, "Sample");
         assertEquals(cm.description, "a sample model");
-        assertEquals(cm.vars.size(), 6);
+        assertEquals(cm.vars.size(), 7);
         assertEquals(cm.getDiscriminatorName(), "test");
     }
 
@@ -380,6 +380,12 @@ public class BoatSwift5CodegenTests {
         mapSchema1.setDescription("Sample ObjectSchema");
         mapSchema1.additionalProperties(new StringSchema());
 
+        final ObjectSchema oneLevelNestedObjectSchema = new ObjectSchema();
+        final ObjectSchema nestedObjectSchema = new ObjectSchema();
+        nestedObjectSchema.additionalProperties(oneLevelNestedObjectSchema);
+        final ObjectSchema objectSchema1 = new ObjectSchema();
+        objectSchema1.additionalProperties(nestedObjectSchema);
+
         final Schema schema = new Schema()
                 .description("a sample model")
                 .addProperty("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
@@ -388,6 +394,7 @@ public class BoatSwift5CodegenTests {
                 .addProperty("nested", nestedArraySchema)
                 .addProperty("map", mapSchema)
                 .addProperty("secondMap", mapSchema1)
+                .addProperty("link", objectSchema1)
                 .addRequiredItem("id")
                 .addRequiredItem("name")
                 .name("sample")


### PR DESCRIPTION
Affects: Properties of type of object with doubly nested additionalProperties of freeformObjects.

Example 

```yaml
links:
  title: Links
  type: object
  additionalProperties:
    type: object
    additionalProperties:
      type: object
```

Will result to `let links: [String: [String: Any]]` which doesn't give you much information about the property. 

Solution: Flatten generated types for Schema with properties of type object with doubly nested additionalProperties
i.e `let links: [String: Any]`
