### PR TITLE
Add 'flattenOutput' parameter for 'bundle' execution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It currently consists of
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.17.56
+* Added new `flattenOutput` parameter into `bundle` execution to generate the bundled APIs directly into `output` directory, even though the respective `input` files are located within a subdirectory in the `input`.
 ## 0.17.55
 * Enhanced `boat-swift5` generator to cater for nested freeformObjects. This issue was identified in `ContentServicesApi`
 ## 0.17.54 and later

--- a/boat-maven-plugin/README.md
+++ b/boat-maven-plugin/README.md
@@ -202,6 +202,36 @@ Bundles a spec by resolving external references.
 Configuration can point to a single in- and output file, or to in- and output directories. When directories are
 specified, all files specified by the `includes` parameter are bundled.
 
+Available parameters:
+
+    input (Default: ${project.basedir}/src/main/resources)
+        Required: true
+        Path to a directory or a file to indicate the input Open API files to bundle.
+
+    includes (Default: **/openapi.yaml, **/*api*.yaml)
+        Required: false
+        List of file patterns to include to bundle.
+
+    output (Default: ${project.build.directory}/openapi)
+        Required: true
+        Output directory for the bundled OpenAPI specs.
+
+    flattenOutput (Default: false)
+        Required: false
+        Flatten the output directory structure, i.e. the bundle API specs are directly put into the output folder, even if the respective `input` files are located within a subdirectory in the `input`.
+
+    version
+        Required: false
+        Optional parameter, to override the bundled spec version.
+
+    versionFileName (Default: false)
+        Required: false
+        Optional parameter to include the version in the bundled spec file name.
+        
+    removeExtensions (Default: "")
+        Required: false
+        Optional parameter to remove extensions from the bundled spec.
+
 Examples in `json` files are parsed to objects.
 
     <configuration>


### PR DESCRIPTION
**Problem Statement:**
As moving towards mono-repo structure to include the OpenAPI specs into the same repo, and even into `/src/main/openapi` directory to include all the APIs defined by the respective service, such as `client-api`, `service-api, the source directory might contain a structure such that the OpenAPI specs to be bundled might be located in a subdirectory.

While bundling those such specs, the output also contains the same directory structure, i.e. the bundled specs are generated into the same path.

As an example;
```
Input file: /src/main/openapi/client/v1/my-service-client-api-v1.yaml
Output parameter: /target/openapi/my-service

Output file: /target/openapi/my-service/client/v1/my-service-client-api-v1.yaml
```

This creates some extra pressure on the executions that relies on these outputs, such as generation of the controllers, which leads to verbose configurations and cognitive overhead to require the knowledge of the source directory structure, instead of simply pointing to a file name.

**Solution:**
The proposed solution here is to introduce a parameter, namely `flattenOutput`, into the `bundle` execution, i.e. regardless of the input file structure, the output is directly put into the `output` folder, without the file hierarchy.

Then the same above example;
```
Input file: /src/main/openapi/client/v1/my-service-client-api-v1.yaml
Output parameter: /target/openapi/my-service

Output file: /target/openapi/my-service/my-service-client-api-v1.yaml
```