### PR TITLE
revert conflicting dependency update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
             <dependency>
                 <groupId>org.apache.maven.shared</groupId>
                 <artifactId>maven-common-artifact-filters</artifactId>
-                <version>3.4.0</version>
+                <version>3.3.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Examples of failures in services builds:
https://jenkins.backbase.eu/job/Entitlements/job/AG/job/accessgroup-integration-service/job/SEGM-558-migrate-to-boat/2/
https://jenkins.backbase.eu/blue/organizations/jenkins/F5%2FFX%2Fforex-test-client/detail/main/28/pipeline/
https://jenkins.backbase.eu/job/Entitlements/job/LE/job/legalentity-integration-service/job/SEGM-558-migrate-to-boat/1/

These builds pass locally, but fail on Jenkins, I was able to reproduce the issue locally only with clean maven local repo.