### PR TITLE
Make APIClient open to allow for overriding

### DIFF
--- a/boat-scaffold/src/main/templates/boat-swift5/api.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/api.mustache
@@ -22,7 +22,7 @@ extension {{moduleName}}Client {
 {{/swiftUseApiNamespace}}
 
 /// {{classname}} protocol defines a blueprint of methods, properties, and other requirements for {{classname}} functionality. 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol {{classname}}Protocol {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} protocol {{classname}}Protocol {
 {{#operation}}
     
     /**
@@ -53,7 +53,7 @@ extension {{moduleName}}Client {
 
 {{#description}}
 /** {{description}} */{{/description}}
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} class {{classname}}: NSObject, DBSClient, {{classname}}Protocol {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class {{classname}}: NSObject, DBSClient, {{classname}}Protocol {
     {{#useMsdkSwift}}
     public var dataProvider: BackbaseSDK.DBSDataProvider?
     {{/useMsdkSwift}}


### PR DESCRIPTION
Replace `public` with `open` to allow for inheritance and overriding outside the client. 