### PR TITLE
NOJIRA: Add additional openapi-generator parameter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     needs: correct_repository
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     needs: correct_repository
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@b1476f6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
           git commit -m "[version bump] new dev version" -a
 
       - name: Push Development Version to Branch
-        uses: ad-m/github-push-action@77c5b41
+        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{github.event.release.target_commitish || 'main'}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
           git commit -m "[version bump] new dev version" -a
 
       - name: Push Development Version to Branch
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@77c5b41
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{github.event.release.target_commitish || 'main'}}

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: wget
-      uses: wei/wget@c15e476
+      uses: wei/wget@c15e476d1463f4936cb54f882170d9d631f1aba5
       with:
         args: -O .rules.toml https://raw.githubusercontent.com/fnxpt/gitleaks-action/rules/.rules.toml
     - name: gitleaks-action
-      uses: gitleaks/gitleaks-action@bf2dc8e
+      uses: gitleaks/gitleaks-action@bf2dc8e55639c1e091e9b45970152e4313705814
       with:
         config-path: .rules.toml

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: wget
-      uses: wei/wget@v1
+      uses: wei/wget@c15e476
       with:
         args: -O .rules.toml https://raw.githubusercontent.com/fnxpt/gitleaks-action/rules/.rules.toml
     - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@master
+      uses: gitleaks/gitleaks-action@bf2dc8e
       with:
         config-path: .rules.toml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ It currently consists of
 
 # Release Notes
 BOAT is still under development and subject to change.
+
+## 0.17.63
+Add support params of openapi-generator `name-mappings` and `enum-name-mappings`.
+Check `Property & Enum Name Mappings (new)` in [boat-maven-plugin](boat-maven-plugin/README.md)
+
 ## 0.17.62
 * Fixed reactive generation of code to not include extra Flux<> to return parameter
 ## 0.17.61

--- a/boat-maven-plugin/README.md
+++ b/boat-maven-plugin/README.md
@@ -96,6 +96,60 @@ Same with `generate` but with opinionated defaults for Rest Template Client
         </additionalProperties>
     </configuration>
 
+### Property & Enum Name Mappings (new)
+
+Two new optional parameters are supported by the BOAT plugin (mirroring OpenAPI Generator capabilities) to rename generated members without post-processing:
+
+    nameMappings        A map of property names to their new names.
+    enumNameMappings    A map of enum (symbol) names to their new names.
+
+You can configure them directly as top-level plugin parameters OR via `configOptions` using the underlying generator keys `name-mappings` and `enum-name-mappings`.
+
+Supported input formats:
+1. Top-level list form (preferred for clarity):
+
+    <configuration>
+        ...
+        <nameMappings>
+            <nameMapping>old_property_name=NewPropertyName</nameMapping>
+            <nameMapping>id=identifier</nameMapping>
+        </nameMappings>
+        <enumNameMappings>
+            <enumNameMapping>old_enum_name=NewEnumName</enumNameMapping>
+            <enumNameMapping>Status=ApiStatus</enumNameMapping>
+        </enumNameMappings>
+    </configuration>
+
+2. Via system properties / CLI (helpful for experimentation):
+
+    mvn clean compile \
+      -Dopenapi.generator.maven.plugin.nameMappings=old_property_name=NewPropertyName,id=identifier \
+      -Dopenapi.generator.maven.plugin.enumNameMappings=old_enum_name=NewEnumName,Status=ApiStatus
+
+Rules & notes:
+- Key/value pairs use '='. Whitespace around keys/values is trimmed.
+- For multiple entries in system property form, separate by comma.
+- Duplicate keys: last one wins.
+- These mappings apply after any model / type renames from other mapping options.
+- `nameMappings` affects property (field) identifiers in generated models & parameter names (where supported by the underlying generator).
+- `enumNameMappings` affects enum constant identifiers (not their serialized wire values). To change wire values, adjust the OpenAPI schema itself.
+
+Example combining with other options:
+
+    <plugin>
+      <groupId>com.backbase.oss</groupId>
+      <artifactId>boat-maven-plugin</artifactId>
+      <configuration>
+        <nameMappings>
+          <nameMapping>created_at=createdAt</nameMapping>
+          <nameMapping>updated_at=updatedAt</nameMapping>
+        </nameMappings>
+        <enumNameMappings>
+          <enumNameMapping>status=ResourceStatus</enumNameMapping>
+        </enumNameMappings>
+      </configuration>
+    </plugin>
+
 ## boat:generate-webclient-embedded
 
 Same with `generate` but with opinionated defaults for Web Client

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
@@ -7,12 +7,14 @@ import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyAdditionalPropertiesKvp;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyAdditionalPropertiesKvpList;
+import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyEnumNameMappingsKvpList;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyImportMappingsKvp;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyImportMappingsKvpList;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyInstantiationTypesKvp;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyInstantiationTypesKvpList;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyLanguageSpecificPrimitivesCsv;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyLanguageSpecificPrimitivesCsvList;
+import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyNameMappingsKvpList;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyOpenAPINormalizerKvpList;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyReservedWordsMappingsKvp;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyReservedWordsMappingsKvpList;
@@ -492,10 +494,23 @@ public class GenerateMojo extends InputMavenArtifactMojo {
     private List<String> openapiNormalizer;
 
     /**
-     * A map of scheme and the new one
+     * A map of scheme and the new one.
      */
     @Parameter(name = "schemaMappings", property = "openapi.generator.maven.plugin.schemaMappings")
     private List<String> schemaMappings;
+
+    /**
+     * A map of property names and the new names.
+     */
+    @Parameter(name = "nameMappings", property = "openapi.generator.maven.plugin.nameMappings")
+    private List<String> nameMappings;
+
+    /**
+     * A map of enum names and the new names.
+     */
+    @Parameter(name = "enumNameMappings", property = "openapi.generator.maven.plugin.enumNameMappings")
+    private List<String> enumNameMappings;
+
 
     public void setBuildContext(BuildContext buildContext) {
         this.buildContext = buildContext;
@@ -863,6 +878,16 @@ public class GenerateMojo extends InputMavenArtifactMojo {
             // Apply Schema Mappings
             if (schemaMappings != null && (configOptions == null || !configOptions.containsKey(SCHEMA_MAPPING))) {
                 applySchemaMappingsKvpList(schemaMappings, configurator);
+            }
+
+            // Apply Name Mappings
+            if (nameMappings != null && (configOptions == null || !configOptions.containsKey("name-mappings"))) {
+                applyNameMappingsKvpList(nameMappings, configurator);
+            }
+
+            // Apply Enum Name Mappings
+            if (enumNameMappings != null && (configOptions == null || !configOptions.containsKey("enum-name-mappings"))) {
+                applyEnumNameMappingsKvpList(enumNameMappings, configurator);
             }
 
             if (environmentVariables != null) {

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
@@ -516,6 +516,14 @@ public class GenerateMojo extends InputMavenArtifactMojo {
         this.buildContext = buildContext;
     }
 
+    public void setNameMappings(List<String> nameMappings) {
+        this.nameMappings = nameMappings;
+    }
+
+    public void setEnumNameMappings(List<String> enumNameMappings) {
+        this.enumNameMappings = enumNameMappings;
+    }
+
     @Override
     @SuppressWarnings({"java:S3776", "java:S1874"})
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/boat-maven-plugin/src/test/resources/oas-examples/petstore.yaml
+++ b/boat-maven-plugin/src/test/resources/oas-examples/petstore.yaml
@@ -114,10 +114,19 @@ components:
           type: string
         tag:
           type: string
+        size:
+          $ref: '#/components/schemas/Size'
     Pets:
       type: array
       items:
         $ref: "#/components/schemas/Pet"
+    Size:
+      type: string
+      description: Size of the pet
+      enum:
+        - SMALL
+        - MEDIUM
+        - LARGE
     Error:
       type: object
       required:

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/MavenProjectCompiler.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/MavenProjectCompiler.java
@@ -53,12 +53,11 @@ class MavenProjectCompiler {
         log.debug("Compiling mvn project in: {}", projectDir);
         var mavenCli = new MavenCli(new ClassWorld("myRealm", contextClassLoader));
         final String initialDir = System.getProperty(MavenCli.MULTIMODULE_PROJECT_DIRECTORY);
-        try {
+        try(PrintStream out = new PrintStream(new File(projectDir, "mvn.log"))) {
             System.setProperty(MavenCli.MULTIMODULE_PROJECT_DIRECTORY, projectDir.getAbsolutePath());
             String[] args = generateMavenCliArgs();
             log.debug("mvn cli args: {}", Arrays.toString(args));
             log.info("Building: {}", projectDir.getName());
-            PrintStream out = new PrintStream(new File(projectDir, "mvn.log"));
             int compilationStatus = mavenCli.doMain(args, projectDir.getAbsolutePath(), out, out);
             log.debug("compilation status={}", compilationStatus);
             return compilationStatus;


### PR DESCRIPTION
Allow to use `nameMappings` & `enumNameMappings` in BOAT maven plugin. "openapi.generator.maven.plugin.nameMappings";
"openapi.generator.maven.plugin.enumNameMappings"