### PR TITLE
[RestTemplate Java] Use UriTemplate instead of URI object

### DIFF
--- a/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/ApiClient.mustache
+++ b/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/ApiClient.mustache
@@ -697,7 +697,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
             throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
         }
 
-        final BodyBuilder requestBuilder = RequestEntity.method(method, uri);
+        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromHttpUrl(basePath).toUriString() + finalUri, uriParams);
         if (accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }


### PR DESCRIPTION
original PR https://github.com/Backbase/backbase-openapi-tools/pull/1184 moved from fork to repo

**Problem statement**

When using BOAT to generate Rest Template in Java it generates ApiClient class which uses URI object when creating RequestEntity which is then used in rest template itself. The problem is that RestTemplate when URI object is used has access to ONLY full URL of the request with all url/query params already filled out with exact values.

This creates a problem for observability and monitoring using OOTB metrics for rest template from spring which is http.client.requests. How it works in spring-boot 3 is that they are taking the URI TEMPLATE and putting that into uri tag for http.client.requests metric. Full URL is not used in that metric due to high cardinality.

URI Template is available only using specific approaches while using RestTemplate, so not all constructors/method will use that. The current code uses constructor with URI object which does not provide any uri template but a final URL only and we ends up getting the value "none" in uri tag in the metrics all the time (because thats the default value if there is no uri template).

**Solution**

The solution to a problem is the code added. It is not passing URI object to the RequestEntity and instead it uses a constructor with uri template and a list of variables which is then populated to http.client.requests metric which properly construct uri tag with URI template. The final URI is actually constructed inside a rest template class using the UriTemplateHandler class as a helper method, so to the the final "doExecute" method in RestTemplate we are passing both - final uri with pre-filled variables and the uri template.

The code was tested locally and actually comes from newest version of open api generator templates for Rest Template.