### PR TITLE
MF-2445: Removal of deprecated initialiser in the swift templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ It currently consists of
 
 # Release Notes
 BOAT is still under development and subject to change.
+## 0.17.74
+* Swift5: Removed deprecated initializer from model objects. The initializer is now internal and only accessible through the Builder pattern, preventing breaking code from deprecation warnings.
+
 ## 0.17.73
 Added code related to generate webhook endpoints with different goal
 To add prehook and posthook request mappings for all the requests in spec yaml using webhooks.

--- a/boat-scaffold/src/main/templates/boat-swift5/modelObject.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/modelObject.mustache
@@ -26,7 +26,6 @@
 
 {{#hasVars}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init() {
-        // All properties initialized with their default values
     }
 {{/hasVars}}
 

--- a/boat-scaffold/src/main/templates/boat-swift5/modelObject.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/modelObject.mustache
@@ -25,11 +25,8 @@
 {{/allVars}}
 
 {{#hasVars}}
-    @available(*, deprecated, message: "This initializer is deprecated, use the initializer and the setters of {{classname}}.Builder class.")
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init({{#allVars}}{{name}}: {{{datatypeWithEnum}}}{{#required}}{{#isNullable}}? = nil{{/isNullable}}{{/required}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allVars}}) {
-        {{#allVars}}
-        self.{{name}} = {{name}}
-        {{/allVars}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init() {
+        // All properties initialized with their default values
     }
 {{/hasVars}}
 
@@ -70,8 +67,11 @@
 
         /// Builder initializer method for {{classname}} DTO.
         {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func build() -> {{classname}} {
-            return {{classname}}({{#allVars}}{{name}}: {{name}}{{^-last}}, 
-                    {{/-last}}{{/allVars}})
+            var result = {{classname}}()
+            {{#allVars}}
+            result.{{name}} = {{name}}
+            {{/allVars}}
+            return result
         }
 
         public static func ==(lhs: Builder, rhs: Builder) -> Bool {

--- a/boat-scaffold/src/main/templates/boat-swift5/modelObject.mustache
+++ b/boat-scaffold/src/main/templates/boat-swift5/modelObject.mustache
@@ -25,7 +25,10 @@
 {{/allVars}}
 
 {{#hasVars}}
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init() {
+    internal init({{#allVars}}{{name}}: {{{datatypeWithEnum}}}{{#required}}{{#isNullable}}? = nil{{/isNullable}}{{/required}}{{^required}}? = nil{{/required}}{{^-last}}, {{/-last}}{{/allVars}}) {
+        {{#allVars}}
+        self.{{name}} = {{name}}
+        {{/allVars}}
     }
 {{/hasVars}}
 
@@ -66,11 +69,8 @@
 
         /// Builder initializer method for {{classname}} DTO.
         {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func build() -> {{classname}} {
-            var result = {{classname}}()
-            {{#allVars}}
-            result.{{name}} = {{name}}
-            {{/allVars}}
-            return result
+            return {{classname}}({{#allVars}}{{name}}: {{name}}{{^-last}}, 
+                    {{/-last}}{{/allVars}})
         }
 
         public static func ==(lhs: Builder, rhs: Builder) -> Bool {


### PR DESCRIPTION
The company has moved away from using this initialiser for a long time, but it's still being generated. The problem is that the Open API generator cannot properly handle default value sometimes and the removed method is generated with breaking changes. 

Added a new internal initialiser for generated classes otherwise the build function wouldn't work as is.