### PR TITLE
feat: support type-level validation for collections via x-not-null extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ It currently consists of
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.17.76
+* In Spring generator added support for type-level validation in collections via the `x-not-null` vendor extension to allow `@NotNull` annotations on generic type arguments.
+
 ## 0.17.75
 * Fixed duplicate serialization of the discriminator property in Jackson-based Java models by removing allowGetters = true from the @JsonIgnoreProperties annotation.
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,9 @@ It currently consists of
 # Release Notes
 BOAT is still under development and subject to change.
 
-## 0.17.76
-* In Spring generator added support for type-level validation in collections via the `x-not-null` vendor extension to allow `@NotNull` annotations on generic type arguments.
-
 ## 0.17.75
 * Fixed duplicate serialization of the discriminator property in Jackson-based Java models by removing allowGetters = true from the @JsonIgnoreProperties annotation.
+* In Spring generator added support for type-level validation in collections via the `x-not-null` vendor extension to allow `@NotNull` annotations on generic type arguments.
 
 ## 0.17.74
 * Swift5: Removed deprecated initializer from model objects. The initializer is now internal and only accessible through the Builder pattern, preventing breaking code from deprecation warnings.

--- a/boat-scaffold/src/main/templates/boat-spring/beanValidationCore.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/beanValidationCore.mustache
@@ -1,4 +1,4 @@
-{{#vendorExtensions.x-not-null}}@jakarta.validation.constraints.NotNull{{/vendorExtensions.x-not-null}}
+{{#vendorExtensions.x-not-null}}@NotNull{{/vendorExtensions.x-not-null}}
 {{#pattern}}{{^isByteArray}}@Pattern(regexp = "{{{pattern}}}") {{/isByteArray}}{{/pattern}}{{!
 minLength && maxLength set
 }}{{#minLength}}{{#maxLength}}@Size(min = {{minLength}}, max = {{maxLength}}) {{/maxLength}}{{/minLength}}{{!

--- a/boat-scaffold/src/main/templates/boat-spring/beanValidationCore.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/beanValidationCore.mustache
@@ -1,3 +1,4 @@
+{{#vendorExtensions.x-not-null}}@jakarta.validation.constraints.NotNull{{/vendorExtensions.x-not-null}}
 {{#pattern}}{{^isByteArray}}@Pattern(regexp = "{{{pattern}}}") {{/isByteArray}}{{/pattern}}{{!
 minLength && maxLength set
 }}{{#minLength}}{{#maxLength}}@Size(min = {{minLength}}, max = {{maxLength}}) {{/maxLength}}{{/minLength}}{{!

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringTemplatesTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringTemplatesTests.java
@@ -192,13 +192,25 @@ class BoatSpringTemplatesTests {
     @Check
     void useBeanValidation() {
         assertThat(findPattern("/api/.+\\.java$", "@Valid"),
-            equalTo(this.param.useBeanValidation||this.param.addBindingResult));
+            equalTo(this.param.useBeanValidation || this.param.addBindingResult));
         assertThat(findPattern("/model/.+\\.java$", "@Valid"),
-            equalTo(this.param.useBeanValidation||this.param.addBindingResult));
+            equalTo(this.param.useBeanValidation || this.param.addBindingResult));
         assertThat(findPattern("/model/MultiLinePaymentRequest.*\\.java$", "List<@Pattern\\(regexp"),
-            equalTo(this.param.useBeanValidation||this.param.addBindingResult));
+            equalTo(this.param.useBeanValidation || this.param.addBindingResult));
         assertThat(findPattern("/model/MultiLinePaymentRequest.*\\.java$", "Map<String, @Size\\(min = 7, max = 10\\)"),
-            equalTo(this.param.useBeanValidation||this.param.addBindingResult));
+            equalTo(this.param.useBeanValidation || this.param.addBindingResult));
+    }
+
+    @Check
+    void queryParamsCustomNotNullValidation() {
+        assertThat(findPattern("/api/ArrayTypesApi\\.java$", "List<@NotNull.*>\\s+qParamsNotNull"),
+            equalTo(this.param.useBeanValidation || this.param.addBindingResult));
+        assertThat(findPattern("/api/SetTypesApi\\.java$", "Set\\s*<@NotNull.*>\\s+qParamsNotNull"),
+            equalTo(this.param.useBeanValidation || this.param.addBindingResult));
+        assertThat(findPattern("/api/SimpleTypesApi\\.java$", "Set\\s*<@NotNull.*>\\s+qParamsNotNull"),
+            equalTo(this.param.useBeanValidation || this.param.addBindingResult));
+        assertThat(findPattern("/api/MapTypesApi\\.java$", "List<@NotNull.*>\\s+qParamsNotNull"),
+            equalTo(this.param.useBeanValidation || this.param.addBindingResult));
     }
 
     @Check

--- a/boat-scaffold/src/test/resources/boat-spring/paths/array-types.yaml
+++ b/boat-scaffold/src/test/resources/boat-spring/paths/array-types.yaml
@@ -86,6 +86,15 @@ get:
           minLength: 1
           maxLength: 36
           pattern: '^[A-Z]+$'
+    - name: q-params-not-null
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          x-not-null: true
+          pattern: '^[A-Z]+$'
     - name: q-params-set
       in: query
       required: false

--- a/boat-scaffold/src/test/resources/boat-spring/paths/map-types.yaml
+++ b/boat-scaffold/src/test/resources/boat-spring/paths/map-types.yaml
@@ -86,6 +86,15 @@ get:
           minLength: 1
           maxLength: 36
           pattern: '^[A-Z]+$'
+    - name: q-params-not-null
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          x-not-null: true
+          pattern: '^[A-Z]+$'
     - name: q-params-set
       in: query
       required: false

--- a/boat-scaffold/src/test/resources/boat-spring/paths/set-types.yaml
+++ b/boat-scaffold/src/test/resources/boat-spring/paths/set-types.yaml
@@ -97,6 +97,16 @@ get:
           minLength: 1
           maxLength: 36
           pattern: '^[A-Z]+$'
+    - name: q-params-not-null
+      in: query
+      required: false
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          x-not-null: true
+          pattern: '^[A-Z]+$'
     - name: q-params-set-req
       in: query
       required: true

--- a/boat-scaffold/src/test/resources/boat-spring/paths/simple-types.yaml
+++ b/boat-scaffold/src/test/resources/boat-spring/paths/simple-types.yaml
@@ -86,6 +86,16 @@ get:
           minLength: 1
           maxLength: 36
           pattern: '^[A-Z]+$'
+    - name: q-params-not-null
+      in: query
+      required: false
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          x-not-null: true
+          pattern: '^[A-Z]+$'
     - name: q-params-set
       in: query
       required: false


### PR DESCRIPTION
## Problem Statement
Currently, the Java/Spring generators primarily apply `@NotNull ` annotations to the container itself (the List or Set) rather than the elements inside the container.

We would like to validate the contents of a collection using "Type Use" annotations, for example:
`java.util.List<@NotNull @Pattern(...) String>` approvalPolicyIds

The current `beanValidationCore.mustache` does not provide a mechanism to inject these annotations into the generic type arguments without manually overriding large portions of the `pojo.mustache` or `queryParams.mustache` templates. This makes it difficult to enforce non-null constraints on individual items within an array.

### Why _required_ and _nullable_ are insufficient
In the OpenAPI specification, the required and nullable keywords have specific behaviors that do not map 1:1 to Java Type Argument validation:

1. **required** (Parent level): When an array is marked as required in a schema, it means the List itself must be present in the JSON. It does not dictate whether the elements inside that list can be null.

2. **nullable** (Item level): In many Java generators, nullable: false is the default assumption. If the generator automatically added `@NotNull `to every non-nullable type argument, it would produce `List<@NotNull String>` for every single array in the project. This would be a massive breaking change and often causes compilation errors with older Java versions or specific serialization frameworks.

## Proposed Solution
I am proposing the addition of a new vendor extension, **x-not-null**, within the **beanValidationCore.mustache** template.

By adding this check to the core validation partial, users can explicitly trigger a @jakarta.validation.constraints.NotNull annotation at the element level by defining it in their OpenAPI specification.

Changes in beanValidationCore.mustache:

Handlebars
`{{#vendorExtensions.x-not-null}}@jakarta.validation.constraints.NotNull {{/vendorExtensions.x-not-null}}`

###  Usage Example
With this change, a user can define their schema as follows to achieve type-level validation:

```
customIds:
  type: array
  items:
    type: string
    x-not-null: true
    pattern: "^[0-9a-fA-F]{32}$"
```

Generated Output:
Assuming the parent template is configured to iterate over items, this allows the generation of:
`List<@NotNull @Pattern(...) String> customIds`

## Benefits

- Non-Breaking: It uses a vendorExtension, meaning existing users who do not use `x-not-null` will see zero change in their generated code.

- Precision: Allows developers to distinguish between a "Required List" and "Required items within a List."

- Standardization: Follows the existing pattern of using vendor extensions to fill gaps in the standard OpenAPI-to-Java mapping.