### PR TITLE
chore: bump to 0.18.1-SNAPSHOT and fix spring example escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ It currently consists of
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.18.1
+* Spring generator: fixed `@ExampleObject` rendering in `api.mustache` by unwrapping escaped quotes in example payloads.
+* Added `unwrapEscapedQuotes` lambda to `boat-spring` generator templates to prevent malformed annotation values (for example `value = "\"{...}"`).
+* Added a regression test to verify generated Spring API interfaces include valid `@ExampleObject` annotation values and remain parseable Java code.
+
 ## 0.18.0
 * openapi-generator `7.20.0` baseline (Spring Boot 4, Jackson 3)
 * moved Java and JavaSpring templates to `7.20.0` adding remaing custom features

--- a/boat-engine/pom.xml
+++ b/boat-engine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.1-SNAPSHOT</version>
+        <version>0.18.2-SNAPSHOT</version>
     </parent>
     <artifactId>boat-engine</artifactId>
     <packaging>jar</packaging>

--- a/boat-engine/pom.xml
+++ b/boat-engine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
     <artifactId>boat-engine</artifactId>
     <packaging>jar</packaging>

--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
     <artifactId>boat-maven-plugin</artifactId>
 

--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.1-SNAPSHOT</version>
+        <version>0.18.2-SNAPSHOT</version>
     </parent>
     <artifactId>boat-maven-plugin</artifactId>
 

--- a/boat-quay/boat-quay-lint/pom.xml
+++ b/boat-quay/boat-quay-lint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>boat-quay</artifactId>
-        <version>0.18.1-SNAPSHOT</version>
+        <version>0.18.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>boat-quay-lint</artifactId>

--- a/boat-quay/boat-quay-lint/pom.xml
+++ b/boat-quay/boat-quay-lint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>boat-quay</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>boat-quay-lint</artifactId>

--- a/boat-quay/boat-quay-rules/pom.xml
+++ b/boat-quay/boat-quay-rules/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>boat-quay</artifactId>
-        <version>0.18.1-SNAPSHOT</version>
+        <version>0.18.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>boat-quay-rules</artifactId>

--- a/boat-quay/boat-quay-rules/pom.xml
+++ b/boat-quay/boat-quay-rules/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>boat-quay</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>boat-quay-rules</artifactId>

--- a/boat-quay/pom.xml
+++ b/boat-quay/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.1-SNAPSHOT</version>
+        <version>0.18.2-SNAPSHOT</version>
     </parent>
 
 

--- a/boat-quay/pom.xml
+++ b/boat-quay/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
 
 

--- a/boat-scaffold/pom.xml
+++ b/boat-scaffold/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.1-SNAPSHOT</version>
+        <version>0.18.2-SNAPSHOT</version>
     </parent>
   
     <artifactId>boat-scaffold</artifactId>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.backbase.oss</groupId>
             <artifactId>boat-trail-resources</artifactId>
-            <version>0.18.1-SNAPSHOT</version>
+            <version>0.18.2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/boat-scaffold/pom.xml
+++ b/boat-scaffold/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
   
     <artifactId>boat-scaffold</artifactId>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.backbase.oss</groupId>
             <artifactId>boat-trail-resources</artifactId>
-            <version>0.18.0-SNAPSHOT</version>
+            <version>0.18.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatSpringCodeGen.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatSpringCodeGen.java
@@ -48,6 +48,7 @@ public class BoatSpringCodeGen extends SpringCodegen {
 
     public static final String ADD_SERVLET_REQUEST = "addServletRequest";
     public static final String ADD_BINDING_RESULT = "addBindingResult";
+    public static final String UNWRAP_ESCAPED_QUOTES = "unwrapEscapedQuotes";
 
     private static final String VENDOR_EXTENSION_NOT_NULL = "x-not-null";
 
@@ -144,6 +145,23 @@ public class BoatSpringCodeGen extends SpringCodegen {
         @Override
         protected String postProcessLine(String line) {
             return line.trim();
+        }
+    }
+
+    static class UnwrapEscapedQuotes implements Mustache.Lambda {
+
+        @Override
+        public void execute(Fragment frag, Writer out) throws IOException {
+            String text = frag.execute();
+            if (text == null) {
+                return;
+            }
+            String normalized = text.replace("\\\\\"", "\\\"");
+            if (normalized.length() >= 4 && normalized.startsWith("\\\"") && normalized.endsWith("\\\"")) {
+                out.write(normalized.substring(2, normalized.length() - 2));
+                return;
+            }
+            out.write(normalized);
         }
     }
 
@@ -332,6 +350,7 @@ public class BoatSpringCodeGen extends SpringCodegen {
         this.additionalProperties.put("newLine8", new NewLineIndent(8, " "));
         this.additionalProperties.put("toOneLine", new FormatToOneLine());
         this.additionalProperties.put("trimAndIndent4", new TrimAndIndent(4, " "));
+        this.additionalProperties.put(UNWRAP_ESCAPED_QUOTES, new UnwrapEscapedQuotes());
     }
 
     @Override

--- a/boat-scaffold/src/main/templates/boat-spring/api.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/api.mustache
@@ -187,7 +187,7 @@ public interface {{classname}} {
                 {{#examples}}
                     @ExampleObject(
                         name = "{{{exampleName}}}",
-                        value = "{{{exampleValue}}}"
+                        value = "{{#unwrapEscapedQuotes}}{{{exampleValue}}}{{/unwrapEscapedQuotes}}"
                     ){{^-last}},{{/-last}}
                 {{/examples}}
                 {{#-last}}

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -137,6 +138,45 @@ class BoatSpringCodeGenTests {
         assertTrue(contentParam.getAnnotationByName("RequestPart").isPresent());
         assertThat(contentParam.getTypeAsString(), equalTo("TestObjectPart"));
         assertThat(filesParam.getTypeAsString(), equalTo("List<MultipartFile>"));
+    }
+
+    @Test
+    void shouldGenerateValidExampleObjectAnnotation() throws IOException {
+        var codegen = new BoatSpringCodeGen();
+        var input = new File("src/test/resources/openapi-with-examples/openapi-with-multiple-permissions.yaml");
+        codegen.setLibrary("spring-boot");
+        codegen.setInterfaceOnly(true);
+        codegen.setSkipDefaultInterface(true);
+        codegen.setOutputDir(TEST_OUTPUT + "/example-object");
+        codegen.setInputSpec(input.getAbsolutePath());
+        codegen.additionalProperties().put(SpringCodegen.USE_SPRING_BOOT3, Boolean.TRUE.toString());
+
+        var openApiInput = new OpenAPIParser().readLocation(input.getAbsolutePath(), null, new ParseOptions())
+                .getOpenAPI();
+        var clientOptInput = new ClientOptInput();
+        clientOptInput.config(codegen);
+        clientOptInput.openAPI(openApiInput);
+
+        List<File> files = new DefaultGenerator().opts(clientOptInput).generate();
+
+        File apiFile = files.stream()
+                .filter(file -> file.getName().endsWith("Api.java"))
+                .filter(file -> {
+                    try {
+                        return Files.readString(file.toPath()).contains("@ExampleObject(");
+                    } catch (IOException e) {
+                        throw new UnhandledException(e);
+                    }
+                })
+                .findFirst()
+                .orElseThrow();
+
+        String apiContent = Files.readString(apiFile.toPath());
+        assertTrue(apiContent.contains("@ExampleObject("));
+        assertTrue(apiContent.contains("Value Exceeded. Must be between {min} and {max}."));
+        assertTrue(apiContent.contains("Bad Request"));
+        assertFalse(apiContent.contains("value = \"\\\"{"));
+        StaticJavaParser.parse(apiFile);
     }
 
     @Test

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
@@ -99,6 +99,58 @@ class BoatSpringCodeGenTests {
     }
 
     @Test
+    void unwrapEscapedQuotes_withNullInput_shouldWriteNothing() throws IOException {
+        final BoatSpringCodeGen.UnwrapEscapedQuotes lambda = new BoatSpringCodeGen.UnwrapEscapedQuotes();
+        final StringWriter output = new StringWriter();
+        final Fragment frag = mock(Fragment.class);
+
+        when(frag.execute()).thenReturn(null);
+
+        lambda.execute(frag, output);
+
+        assertThat(output.toString(), equalTo(""));
+    }
+
+    @Test
+    void unwrapEscapedQuotes_withWrappedEscapedQuotes_shouldRemoveOuterEscapedQuotes() throws IOException {
+        final BoatSpringCodeGen.UnwrapEscapedQuotes lambda = new BoatSpringCodeGen.UnwrapEscapedQuotes();
+        final StringWriter output = new StringWriter();
+        final Fragment frag = mock(Fragment.class);
+
+        when(frag.execute()).thenReturn("\\\"{\\\"message\\\":\\\"Bad Request\\\"}\\\"");
+
+        lambda.execute(frag, output);
+
+        assertThat(output.toString(), equalTo("{\\\"message\\\":\\\"Bad Request\\\"}"));
+    }
+
+    @Test
+    void unwrapEscapedQuotes_withDoubleEscapedQuotesAndNoWrapper_shouldOnlyNormalize() throws IOException {
+        final BoatSpringCodeGen.UnwrapEscapedQuotes lambda = new BoatSpringCodeGen.UnwrapEscapedQuotes();
+        final StringWriter output = new StringWriter();
+        final Fragment frag = mock(Fragment.class);
+
+        when(frag.execute()).thenReturn("prefix\\\\\"quoted\\\\\"suffix");
+
+        lambda.execute(frag, output);
+
+        assertThat(output.toString(), equalTo("prefix\\\"quoted\\\"suffix"));
+    }
+
+    @Test
+    void unwrapEscapedQuotes_withShortEscapedQuoteToken_shouldNotUnwrap() throws IOException {
+        final BoatSpringCodeGen.UnwrapEscapedQuotes lambda = new BoatSpringCodeGen.UnwrapEscapedQuotes();
+        final StringWriter output = new StringWriter();
+        final Fragment frag = mock(Fragment.class);
+
+        when(frag.execute()).thenReturn("\\\"");
+
+        lambda.execute(frag, output);
+
+        assertThat(output.toString(), equalTo("\\\""));
+    }
+
+    @Test
     void addServletRequestTestFromOperation(){
         final BoatSpringCodeGen gen = new BoatSpringCodeGen();
         gen.addServletRequest = true;

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatSpringCodeGenTests.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.UnhandledException;
 import org.hamcrest.Matchers;
@@ -56,7 +57,9 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenOperation;
@@ -98,56 +101,18 @@ class BoatSpringCodeGenTests {
         assertThat(output.toString(), equalTo(String.format("__%n__Good%n__  morning,%n__ Dave%n")));
     }
 
-    @Test
-    void unwrapEscapedQuotes_withNullInput_shouldWriteNothing() throws IOException {
+    @ParameterizedTest
+    @MethodSource("unwrapEscapedQuotesCases")
+    void unwrapEscapedQuotes_execute_shouldHandleAllScenarios(String input, String expectedOutput) throws IOException {
         final BoatSpringCodeGen.UnwrapEscapedQuotes lambda = new BoatSpringCodeGen.UnwrapEscapedQuotes();
         final StringWriter output = new StringWriter();
         final Fragment frag = mock(Fragment.class);
 
-        when(frag.execute()).thenReturn(null);
+        when(frag.execute()).thenReturn(input);
 
         lambda.execute(frag, output);
 
-        assertThat(output.toString(), equalTo(""));
-    }
-
-    @Test
-    void unwrapEscapedQuotes_withWrappedEscapedQuotes_shouldRemoveOuterEscapedQuotes() throws IOException {
-        final BoatSpringCodeGen.UnwrapEscapedQuotes lambda = new BoatSpringCodeGen.UnwrapEscapedQuotes();
-        final StringWriter output = new StringWriter();
-        final Fragment frag = mock(Fragment.class);
-
-        when(frag.execute()).thenReturn("\\\"{\\\"message\\\":\\\"Bad Request\\\"}\\\"");
-
-        lambda.execute(frag, output);
-
-        assertThat(output.toString(), equalTo("{\\\"message\\\":\\\"Bad Request\\\"}"));
-    }
-
-    @Test
-    void unwrapEscapedQuotes_withDoubleEscapedQuotesAndNoWrapper_shouldOnlyNormalize() throws IOException {
-        final BoatSpringCodeGen.UnwrapEscapedQuotes lambda = new BoatSpringCodeGen.UnwrapEscapedQuotes();
-        final StringWriter output = new StringWriter();
-        final Fragment frag = mock(Fragment.class);
-
-        when(frag.execute()).thenReturn("prefix\\\\\"quoted\\\\\"suffix");
-
-        lambda.execute(frag, output);
-
-        assertThat(output.toString(), equalTo("prefix\\\"quoted\\\"suffix"));
-    }
-
-    @Test
-    void unwrapEscapedQuotes_withShortEscapedQuoteToken_shouldNotUnwrap() throws IOException {
-        final BoatSpringCodeGen.UnwrapEscapedQuotes lambda = new BoatSpringCodeGen.UnwrapEscapedQuotes();
-        final StringWriter output = new StringWriter();
-        final Fragment frag = mock(Fragment.class);
-
-        when(frag.execute()).thenReturn("\\\"");
-
-        lambda.execute(frag, output);
-
-        assertThat(output.toString(), equalTo("\\\""));
+        assertThat(output.toString(), equalTo(expectedOutput));
     }
 
     @Test
@@ -643,5 +608,13 @@ class BoatSpringCodeGenTests {
         ClassOrInterfaceType collectionItemType = (ClassOrInterfaceType) ((ClassOrInterfaceType) method.getType())
             .getTypeArguments().get().getFirst().get();
         assertEquals(itemType, collectionItemType.getName().toString());
+    }
+
+    static Stream<Arguments> unwrapEscapedQuotesCases() {
+        return Stream.of(
+                Arguments.of((String) null, ""),
+                Arguments.of("\\\"{\\\"message\\\":\\\"Bad Request\\\"}\\\"", "{\\\"message\\\":\\\"Bad Request\\\"}"),
+                Arguments.of("prefix\\\\\"quoted\\\\\"suffix", "prefix\\\"quoted\\\"suffix"),
+                Arguments.of("\\\"", "\\\""));
     }
 }

--- a/boat-trail-resources/pom.xml
+++ b/boat-trail-resources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.1-SNAPSHOT</version>
+        <version>0.18.2-SNAPSHOT</version>
     </parent>
   
     <artifactId>boat-trail-resources</artifactId>

--- a/boat-trail-resources/pom.xml
+++ b/boat-trail-resources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
   
     <artifactId>boat-trail-resources</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.backbase.oss</groupId>
     <artifactId>backbase-openapi-tools</artifactId>
-    <version>0.18.1-SNAPSHOT</version>
+    <version>0.18.2-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <description>Backbase Open Api Tools is a collection of tools to work with Open API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.backbase.oss</groupId>
     <artifactId>backbase-openapi-tools</artifactId>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <description>Backbase Open Api Tools is a collection of tools to work with Open API</description>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.1-SNAPSHOT</version>
+        <version>0.18.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>tests</artifactId>


### PR DESCRIPTION
Update project versions to 0.18.1-SNAPSHOT, add 0.18.1 release notes, and fix boat-spring ExampleObject value rendering by unwrapping escaped quotes with regression coverage.

Made-with: Cursor