### PR TITLE
Fix jackson3 imports in BigDecimalCustomSerializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ It currently consists of
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.18.1
+* Use Jackson3 imports in `BigDecimalCustomSerializer.class` when using `useJackson3` set to `true`
+
 ## 0.18.0
 * openapi-generator `7.20.0` baseline (Spring Boot 4, Jackson 3)
 * moved Java and JavaSpring templates to `7.20.0` adding remaing custom features

--- a/boat-engine/pom.xml
+++ b/boat-engine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
     <artifactId>boat-engine</artifactId>
     <packaging>jar</packaging>

--- a/boat-maven-plugin/pom.xml
+++ b/boat-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
     <artifactId>boat-maven-plugin</artifactId>
 

--- a/boat-quay/boat-quay-lint/pom.xml
+++ b/boat-quay/boat-quay-lint/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>boat-quay</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>boat-quay-lint</artifactId>

--- a/boat-quay/boat-quay-rules/pom.xml
+++ b/boat-quay/boat-quay-rules/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>boat-quay</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>boat-quay-rules</artifactId>

--- a/boat-quay/pom.xml
+++ b/boat-quay/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
 
 

--- a/boat-scaffold/pom.xml
+++ b/boat-scaffold/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
   
     <artifactId>boat-scaffold</artifactId>

--- a/boat-scaffold/pom.xml
+++ b/boat-scaffold/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.backbase.oss</groupId>
             <artifactId>boat-trail-resources</artifactId>
-            <version>0.18.0-SNAPSHOT</version>
+            <version>0.18.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatSpringCodeGen.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatSpringCodeGen.java
@@ -206,8 +206,8 @@ public class BoatSpringCodeGen extends SpringCodegen {
     }
 
     /**
-     * "overridden" to fix invalid code when the data type is a collection of a fully qualified classname.
-     * eg. <code>Set<@Valid com.backbase.dbs.arrangement.commons.model.TranslationItemDto></code>
+     * "overridden" to fix invalid code when the data type is a collection of a fully qualified classname. eg. <code>Set<@Valid
+     * com.backbase.dbs.arrangement.commons.model.TranslationItemDto></code>
      *
      * @param itemsProperty
      * @param dataType
@@ -314,7 +314,12 @@ public class BoatSpringCodeGen extends SpringCodegen {
             serializerTemplate + ".java"
         ));
         this.importMapping.put(serializerTemplate, modelPackage + "." + serializerTemplate);
-        this.importMapping.put("JsonSerialize", "com.fasterxml.jackson.databind.annotation.JsonSerialize");
+
+        if (this.additionalProperties.containsKey(USE_JACKSON_3)) {
+            this.importMapping.put("JsonSerialize", "tools.jackson.databind.annotation.JsonSerialize");
+        } else {
+            this.importMapping.put("JsonSerialize", "com.fasterxml.jackson.databind.annotation.JsonSerialize");
+        }
 
         if (this.additionalProperties.containsKey(ADD_SERVLET_REQUEST)) {
             this.addServletRequest = convertPropertyToBoolean(ADD_SERVLET_REQUEST);

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatSpringCodeGen.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/java/BoatSpringCodeGen.java
@@ -50,6 +50,7 @@ public class BoatSpringCodeGen extends SpringCodegen {
     public static final String ADD_BINDING_RESULT = "addBindingResult";
 
     private static final String VENDOR_EXTENSION_NOT_NULL = "x-not-null";
+    private static final String JSON_SERIALIZE = "JsonSerialize";
 
     static class NewLineIndent implements Mustache.Lambda {
 
@@ -316,9 +317,9 @@ public class BoatSpringCodeGen extends SpringCodegen {
         this.importMapping.put(serializerTemplate, modelPackage + "." + serializerTemplate);
 
         if (this.additionalProperties.containsKey(USE_JACKSON_3)) {
-            this.importMapping.put("JsonSerialize", "tools.jackson.databind.annotation.JsonSerialize");
+            this.importMapping.put(JSON_SERIALIZE, "tools.jackson.databind.annotation.JsonSerialize");
         } else {
-            this.importMapping.put("JsonSerialize", "com.fasterxml.jackson.databind.annotation.JsonSerialize");
+            this.importMapping.put(JSON_SERIALIZE, "com.fasterxml.jackson.databind.annotation.JsonSerialize");
         }
 
         if (this.additionalProperties.containsKey(ADD_SERVLET_REQUEST)) {
@@ -391,7 +392,7 @@ public class BoatSpringCodeGen extends SpringCodegen {
         if (shouldSerializeBigDecimalAsString(property)) {
             property.vendorExtensions.put("x-extra-annotation", "@JsonSerialize(using = BigDecimalCustomSerializer.class)");
             model.imports.add("BigDecimalCustomSerializer");
-            model.imports.add("JsonSerialize");
+            model.imports.add(JSON_SERIALIZE);
         }
     }
 

--- a/boat-scaffold/src/main/templates/boat-spring/BigDecimalCustomSerializer.mustache
+++ b/boat-scaffold/src/main/templates/boat-spring/BigDecimalCustomSerializer.mustache
@@ -1,6 +1,11 @@
 package {{modelPackage}};
 
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializerBase;
+{{#useJackson3}}
+  import tools.jackson.databind.ser.std.ToStringSerializerBase;
+{{/useJackson3}}
+{{^useJackson3}}
+  import com.fasterxml.jackson.databind.ser.std.ToStringSerializerBase;
+{{/useJackson3}}
 import java.math.BigDecimal;
 
 public class BigDecimalCustomSerializer extends ToStringSerializerBase {

--- a/boat-trail-resources/pom.xml
+++ b/boat-trail-resources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
   
     <artifactId>boat-trail-resources</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.backbase.oss</groupId>
     <artifactId>backbase-openapi-tools</artifactId>
-    <version>0.18.0-SNAPSHOT</version>
+    <version>0.18.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <description>Backbase Open Api Tools is a collection of tools to work with Open API</description>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.backbase.oss</groupId>
         <artifactId>backbase-openapi-tools</artifactId>
-        <version>0.18.0-SNAPSHOT</version>
+        <version>0.18.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>tests</artifactId>


### PR DESCRIPTION
With Spring Boot 4 and Jackson 3 during the runtime Jackson 2 annotations for BigDecimalCustomSerializer are not used. 