### PR TITLE
fix(marina): serialize Java 8 date/time in api.js Handlebars json helper

### DIFF
--- a/boat-scaffold/pom.xml
+++ b/boat-scaffold/pom.xml
@@ -54,6 +54,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.backbase.oss</groupId>
             <artifactId>boat-engine</artifactId>
             <version>${project.version}</version>

--- a/boat-scaffold/src/main/java/com/backbase/oss/codegen/marina/BoatHandlebarsEngineAdapter.java
+++ b/boat-scaffold/src/main/java/com/backbase/oss/codegen/marina/BoatHandlebarsEngineAdapter.java
@@ -3,6 +3,7 @@ package com.backbase.oss.codegen.marina;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
@@ -78,6 +79,8 @@ public class BoatHandlebarsEngineAdapter extends HandlebarsEngineAdapter {
             return "";
         });
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         Helper<Object> instance = new Jackson2Helper(objectMapper);

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/marina/BoatMarinaTest.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/marina/BoatMarinaTest.java
@@ -31,6 +31,15 @@ class BoatMarinaTest {
     }
 
     @Test
+    void testGenerateDocsWithDateTimeExamples() throws IOException {
+        generateDocs(getFile("/openapi-with-examples/openapi-with-multiple-permissions.yaml"));
+
+        File index = new File("target/marina-docs/api.js");
+        String generated = String.join(" ", Files.readAllLines(Paths.get(index.getPath())));
+        assertTrue(generated.contains("2017-10-04T14:54:36Z"));
+    }
+
+    @Test
     void testGenerateDocs() throws IOException {
         generateDocs(getFile("/openapi-with-examples/openapi-with-json.yaml"));
 


### PR DESCRIPTION
## Summary

Fixes `boat-marina` failing to generate `api.js` when OpenAPI examples or parameters contain Java 8 date/time values (notably `java.time.OffsetDateTime`).

During Developer Hub BOM ingest (`boat-maven-plugin` 0.18.2, `generatorName=boat-marina`), several specs on `2026.03.5-LTS` failed at the Boat step with:

```
InvalidDefinitionException: Java 8 date/time type `java.time.OffsetDateTime` not supported by default:
add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling
```

The failure happens while rendering `api.js.handlebars`: each `{{json .}}` call uses `Jackson2Helper` with a plain `ObjectMapper` that did not register `JavaTimeModule`.

### Affected specs (verified on Developer Hub ingest)

| Spec | Version |
|------|---------|
| `cdp-profiles-client-api` | 1.3.0-beta |
| `cdp-profiles-service-api` | 1.3.0-beta |
| `remote-deposit-capturer-client-api` | 2.8.0 |
| `product-directory-service-api` | 1.3.0 |

The OpenAPI sources are valid; Boat's Handlebars JSON serialization could not serialize parsed date-time example values.

## Before / after proof

### 1. Boat `doc` goal — before (stock 0.18.2)

Reproduced locally with `boat-maven-plugin:0.18.2:doc` on `cdp-profiles-client-api-v1.3.0-beta.yaml`:

```
[ERROR] ... unexpected error in Open-API generation
Caused by: HandlebarsException: api.js.handlebars:21:35: InvalidDefinitionException:
  Java 8 date/time type `java.time.OffsetDateTime` not supported by default ...
  (through reference chain: ... Example["value"]->java.util.HashMap["lastUpdated"])
```

Line 21 is `data.operations.push({{json .}});` — Jackson blows up when serializing response examples that swagger-parser already parsed into `OffsetDateTime`.

**Result:** no `api.js` written → Developer Hub ingest marks the spec as failed.

### 2. Jackson serialization — what the fix changes

The `{{json}}` helper uses the same `ObjectMapper` configured in `BoatHandlebarsEngineAdapter`. Minimal reproduction with a `HashMap` containing `OffsetDateTime.parse("2020-07-24T12:00:00Z")`:

| Configuration | Output |
|---------------|--------|
| **Before** — plain `ObjectMapper` (current Boat) | `InvalidDefinitionException` (generation aborts) |
| JavaTimeModule only (`WRITE_DATES_AS_TIMESTAMPS` default **true**) | `{ "lastUpdated": 1595592000.000000000 }` |
| **After** — JavaTimeModule + `disable(WRITE_DATES_AS_TIMESTAMPS)` | `{ "lastUpdated": "2020-07-24T12:00:00Z" }` |

### Why disable `WRITE_DATES_AS_TIMESTAMPS`?

`JavaTimeModule` alone is **not enough** for documentation output:

- With timestamps enabled, Jackson writes date-times as **numeric epoch seconds** (e.g. `1595592000.000000000`).
- OpenAPI examples and the generated `api.js` are meant for humans and downstream markdown tooling — they use **ISO-8601 strings** (`2017-10-04T14:54:36Z`), matching the YAML source.
- Disabling `WRITE_DATES_AS_TIMESTAMPS` is the standard Jackson setting for “serialize dates as strings” and is what our test asserts.

### 3. Existing specs — output remains unchanged

`WRITE_DATES_AS_TIMESTAMPS` only affects Jackson serialization of **Java temporal types** (`OffsetDateTime`, etc.). For the ~265 specs that already build on `2026.03.5-LTS`, date-time values in examples reach `{{json}}` as **strings**, not `OffsetDateTime` objects — so this flag has no effect on their output.

Verified by regenerating several successful BOM specs with stock `boat-maven-plugin:0.18.2:doc` and scanning `api.js`:

| Spec | ISO date strings in `api.js` | Epoch-style floats |
|------|------------------------------|--------------------|
| `loan-client-api` 1.3.0 | 99 | 0 |
| `metric-client-api` 1.12.0 | 121 | 0 |
| `user-manager-client-api` 2.19.0 | 36 | 0 |
| `approval-flow-client-api` 1.1.0 | 21 | 0 |

Example from `loan-client-api` (current production shape):

```javascript
"currentMaturityDate" : "2020-07-24T00:00:00Z",
"paymentDate" : "2020-07-24T00:00:00Z",
```

**Regression expectation:** re-ingesting already-successful specs after this release should produce the same ISO-8601 date formatting. The fix only changes output for specs that currently fail generation entirely (4 on `2026.03.5-LTS`). Those newly-unblocked specs will match the existing string format — not introduce epoch numbers — because `WRITE_DATES_AS_TIMESTAMPS` is disabled.

### 4. Boat `doc` goal — after (this PR)

`BoatMarinaTest.testGenerateDocsWithDateTimeExamples` generates `api.js` from `openapi-with-multiple-permissions.yaml` (query param example `value: 2017-10-04T14:54:36Z`) and asserts the ISO string appears in output:

```java
assertTrue(generated.contains("2017-10-04T14:54:36Z"));
```

Without the fix, generation fails before this assertion can run. With only `JavaTimeModule` (timestamps on), the assertion would fail because the file would contain `1507131276` instead of the ISO string.

## Changes

- Register `JavaTimeModule` on the `ObjectMapper` in `BoatHandlebarsEngineAdapter`
- Disable `WRITE_DATES_AS_TIMESTAMPS` so examples render as ISO-8601 strings in `api.js`
- Add explicit `jackson-datatype-jsr310` dependency to `boat-scaffold` (version from parent `jackson-bom`)
- Add `BoatMarinaTest.testGenerateDocsWithDateTimeExamples` using `openapi-with-multiple-permissions.yaml`

## Test plan

- [ ] `mvn -pl boat-scaffold -Dtest=BoatMarinaTest test`
- [ ] Regenerate `api.js` for one previously failing spec (e.g. `cdp-profiles-client-api-v1.3.0-beta.yaml`) and confirm Boat completes
- [ ] After release, bump `boat-maven-plugin` in Developer Hub and re-ingest affected BOM calvers

Made with [Cursor](https://cursor.com)