### PR TITLE
fix(boat-engine): deduplicate structurally identical components/schemas entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ It currently consists of
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.18.3
+* **Breaking change**: `boat:bundle` and `boat:generate` (when `bundleSpecs` is enabled) now de-duplicate
+  `components/schemas` entries that are structurally identical but were registered under different names
+  (e.g. because the same model file was reachable both via its canonical component name and via a direct
+  `$ref` to the file). Previously this produced two field-for-field identical models; now only one is kept
+  and every `$ref` to the discarded duplicate is rewritten to the surviving one.
+  * This can rename or remove generated types (Java, Angular/TypeScript, Swift, Android/Kotlin) for specs
+    that were affected by the duplication - consumers depending on the previously duplicated type name will
+    need to update their references.
+  * Added a new `deduplicateSchemas` plugin parameter (default `true`) on `boat:bundle` and `boat:generate`
+    to opt out and keep the previous (duplicated) behaviour while migrating.
+
 ## 0.18.2
 * Spring generator: fixed `@ExampleObject` rendering in `api.mustache` by unwrapping escaped quotes in example payloads.
 * Added `unwrapEscapedQuotes` lambda to `boat-spring` generator templates to prevent malformed annotation values (for example `value = "\"{...}"`).

--- a/boat-engine/src/main/java/com/backbase/oss/boat/transformers/DeduplicateSchemasTransformer.java
+++ b/boat-engine/src/main/java/com/backbase/oss/boat/transformers/DeduplicateSchemasTransformer.java
@@ -1,0 +1,136 @@
+package com.backbase.oss.boat.transformers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Merges {@code components/schemas} entries that are structurally identical but registered under different
+ * names.
+ *
+ * <p>This situation arises when the same external schema file is reachable through more than one {@code $ref}
+ * string (e.g. once via its canonical component name, once via a direct ref straight to the model file). The
+ * bundler resolver has no way of knowing both refs point at the same content, so it registers both, producing
+ * two field-for-field identical schemas that show up as duplicate models/classes/doc pages downstream.
+ *
+ * <p>Of every group of duplicates, this transformer keeps a single canonical entry and rewrites every
+ * {@code $ref} in {@code paths} and {@code components} that pointed at a discarded duplicate so it points at
+ * the canonical entry instead. The discarded duplicate(s) are then removed from {@code components/schemas}.
+ *
+ * <p>The canonical name is picked with a heuristic: a name starting with an uppercase letter is preferred
+ * (schema names are conventionally PascalCase, whereas a name synthesized from a {@code $ref} tends to keep
+ * the original file's casing, e.g. {@code arrangement} from {@code ./arrangement.yaml}); ties are then broken
+ * by shortest name, then alphabetically.
+ *
+ * <p><b>This is a breaking change for generated clients.</b> Whichever duplicate name is dropped disappears
+ * from the generated Java/TypeScript/Swift/Kotlin models, and any code referencing that type name will fail to
+ * compile. Consumers that need time to migrate can disable this behaviour (see the {@code deduplicateSchemas}
+ * plugin option on {@code boat:bundle}/{@code boat:generate}).
+ */
+@SuppressWarnings("rawtypes")
+@Slf4j
+public class DeduplicateSchemasTransformer implements Transformer {
+
+    private static final String SCHEMA_REF_PREFIX = "#/components/schemas/";
+
+    private static final Comparator<String> CANONICAL_NAME_ORDER = Comparator
+        .<String>comparingInt(name -> startsWithUpperCase(name) ? 0 : 1)
+        .thenComparingInt(String::length)
+        .thenComparing(Comparator.naturalOrder());
+
+    private static boolean startsWithUpperCase(String name) {
+        return !name.isEmpty() && Character.isUpperCase(name.charAt(0));
+    }
+
+    @Override
+    public OpenAPI transform(OpenAPI openAPI, Map<String, Object> options) {
+        if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+            return openAPI;
+        }
+
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        Map<String, String> renames = findDuplicateRenames(schemas);
+
+        if (renames.isEmpty()) {
+            log.debug("No duplicate schemas found.");
+            return openAPI;
+        }
+
+        renames.forEach((duplicate, canonical) ->
+            log.info("Merging duplicate schema '{}' into '{}'.", duplicate, canonical));
+
+        rewriteReferences(openAPI, renames);
+        // rewriteReferences() replaces components with a freshly deserialized instance, so the removal
+        // must happen against the new schemas map, not the one captured before the rewrite.
+        renames.keySet().forEach(openAPI.getComponents().getSchemas()::remove);
+
+        return openAPI;
+    }
+
+    /**
+     * Groups schemas by structural equality (their serialized JSON representation) and, for every group with
+     * more than one member, maps every non-canonical member's name onto the canonical one.
+     */
+    private Map<String, String> findDuplicateRenames(Map<String, Schema> schemas) {
+        Map<JsonNode, List<String>> byContent = new LinkedHashMap<>();
+
+        schemas.forEach((name, schema) -> {
+            JsonNode node = Json.mapper().valueToTree(schema);
+            byContent.computeIfAbsent(node, key -> new ArrayList<>()).add(name);
+        });
+
+        Map<String, String> renames = new LinkedHashMap<>();
+        for (List<String> names : byContent.values()) {
+            if (names.size() < 2) {
+                continue;
+            }
+            String canonical = names.stream()
+                .min(CANONICAL_NAME_ORDER)
+                .orElseThrow();
+            names.stream()
+                .filter(name -> !name.equals(canonical))
+                .forEach(name -> renames.put(name, canonical));
+        }
+        return renames;
+    }
+
+    private void rewriteReferences(OpenAPI openAPI, Map<String, String> renames) {
+        JsonNode pathsNode = Json.mapper().valueToTree(openAPI.getPaths());
+        rewriteRefs(pathsNode, renames);
+        openAPI.setPaths(Json.mapper().convertValue(pathsNode, Paths.class));
+
+        JsonNode componentsNode = Json.mapper().valueToTree(openAPI.getComponents());
+        rewriteRefs(componentsNode, renames);
+        openAPI.setComponents(Json.mapper().convertValue(componentsNode, Components.class));
+    }
+
+    private void rewriteRefs(JsonNode node, Map<String, String> renames) {
+        if (node instanceof ObjectNode) {
+            ObjectNode objectNode = (ObjectNode) node;
+            JsonNode ref = objectNode.get("$ref");
+            if (ref != null && ref.isTextual()) {
+                String refValue = ref.textValue();
+                if (refValue.startsWith(SCHEMA_REF_PREFIX)) {
+                    String canonical = renames.get(refValue.substring(SCHEMA_REF_PREFIX.length()));
+                    if (canonical != null) {
+                        objectNode.set("$ref", TextNode.valueOf(SCHEMA_REF_PREFIX + canonical));
+                    }
+                }
+            }
+            objectNode.elements().forEachRemaining(child -> rewriteRefs(child, renames));
+        } else if (node.isArray()) {
+            node.elements().forEachRemaining(child -> rewriteRefs(child, renames));
+        }
+    }
+}

--- a/boat-engine/src/test/java/com/backbase/oss/boat/transformers/DeduplicateSchemasTransformerTests.java
+++ b/boat-engine/src/test/java/com/backbase/oss/boat/transformers/DeduplicateSchemasTransformerTests.java
@@ -1,0 +1,83 @@
+package com.backbase.oss.boat.transformers;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.junit.jupiter.api.Test;
+
+class DeduplicateSchemasTransformerTests {
+
+    @Test
+    void mergesStructurallyIdenticalSchemasAndRewritesReferences() {
+        Schema<?> canonical = new Schema<>();
+        canonical.setType("object");
+        canonical.addProperty("id", new StringSchema());
+
+        Schema<?> duplicate = new Schema<>();
+        duplicate.setType("object");
+        duplicate.addProperty("id", new StringSchema());
+
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setComponents(new Components()
+            .addSchemas("CurrencyExchangeArrangement", canonical)
+            .addSchemas("CurrencyExchangeArrangementYaml", duplicate));
+
+        Operation getOperation = new Operation();
+        ApiResponse response = new ApiResponse();
+        response.setContent(new Content().addMediaType("application/json",
+            new MediaType().schema(new Schema<>().$ref("#/components/schemas/CurrencyExchangeArrangementYaml"))));
+        getOperation.setResponses(new ApiResponses().addApiResponse("200", response));
+
+        openAPI.setPaths(new Paths().addPathItem("/currency-exchange-arrangements",
+            new PathItem().get(getOperation)));
+
+        new DeduplicateSchemasTransformer().transform(openAPI, emptyMap());
+
+        assertEquals(1, openAPI.getComponents().getSchemas().size(), "The duplicate schema should be removed.");
+        assertTrue(openAPI.getComponents().getSchemas().containsKey("CurrencyExchangeArrangement"),
+            "The shorter (canonical) name should be kept.");
+        assertFalse(openAPI.getComponents().getSchemas().containsKey("CurrencyExchangeArrangementYaml"));
+
+        String rewrittenRef = openAPI.getPaths().get("/currency-exchange-arrangements").getGet()
+            .getResponses().get("200").getContent().get("application/json").getSchema().get$ref();
+        assertEquals("#/components/schemas/CurrencyExchangeArrangement", rewrittenRef,
+            "The response schema $ref should be rewritten to point at the canonical schema.");
+    }
+
+    @Test
+    void leavesDistinctSchemasAlone() {
+        Schema<?> first = new Schema<>();
+        first.setType("object");
+        first.addProperty("id", new StringSchema());
+
+        Schema<?> second = new Schema<>();
+        second.setType("object");
+        second.addProperty("name", new StringSchema());
+
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setComponents(new Components()
+            .addSchemas("First", first)
+            .addSchemas("Second", second));
+        openAPI.setPaths(new Paths());
+
+        OpenAPI result = new DeduplicateSchemasTransformer().transform(openAPI, emptyMap());
+
+        assertEquals(2, result.getComponents().getSchemas().size());
+        assertNull(result.getComponents().getSchemas().get("First").get$ref());
+        assertNull(result.getComponents().getSchemas().get("Second").get$ref());
+    }
+}

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/BundleMojo.java
@@ -9,6 +9,7 @@ import com.backbase.oss.boat.loader.OpenAPILoader;
 import com.backbase.oss.boat.loader.OpenAPILoaderException;
 import com.backbase.oss.boat.serializer.SerializerUtils;
 import com.backbase.oss.boat.transformers.Bundler;
+import com.backbase.oss.boat.transformers.DeduplicateSchemasTransformer;
 import com.backbase.oss.boat.transformers.SetVersion;
 import com.backbase.oss.boat.transformers.ExtensionFilter;
 
@@ -70,6 +71,16 @@ public class BundleMojo extends AbstractMojo {
     private List<String> removeExtensions;
 
     /**
+     * Merge components/schemas entries that are structurally identical but registered under different names
+     * (e.g. because the same model file is $ref'd both by its component name and directly). Disable this
+     * only if you rely on the current, duplicated output and are not ready for the breaking change to
+     * generated model names yet.
+     */
+    @Parameter(name = "deduplicateSchemas", property = "openapi.generator.maven.plugin.deduplicateSchemas",
+        defaultValue = "true")
+    private boolean deduplicateSchemas = true;
+
+    /**
      * Skip the execution.
      */
     @Parameter(name = "skip", property = "bundle.skip", defaultValue = "false", alias = "codegen.skip")
@@ -129,6 +140,11 @@ public class BundleMojo extends AbstractMojo {
 
             openAPI = new Bundler(inputFile)
                 .transform(openAPI);
+
+            if (deduplicateSchemas) {
+                openAPI = new DeduplicateSchemasTransformer()
+                    .transform(openAPI);
+            }
 
             if (isNotEmpty(removeExtensions)) {
                 openAPI = new ExtensionFilter()

--- a/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
+++ b/boat-maven-plugin/src/main/java/com/backbase/oss/boat/GenerateMojo.java
@@ -26,6 +26,7 @@ import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyType
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyTypeMappingsKvpList;
 
 import com.backbase.oss.boat.transformers.Bundler;
+import com.backbase.oss.boat.transformers.DeduplicateSchemasTransformer;
 import com.backbase.oss.boat.transformers.DereferenceComponentsPropertiesTransformer;
 import com.backbase.oss.boat.transformers.UnAliasTransformer;
 import com.google.common.hash.Hashing;
@@ -486,6 +487,15 @@ public class GenerateMojo extends InputMavenArtifactMojo {
      */
     @Parameter(property = "openapi.generator.maven.plugin.bundlesSpecs")
     protected boolean bundleSpecs;
+
+    /**
+     * Merge components/schemas entries that are structurally identical but registered under different names
+     * (e.g. because the same model file is $ref'd both by its component name and directly). Only takes effect
+     * when {@code bundleSpecs} is enabled. Disable this only if you rely on the current, duplicated output
+     * and are not ready for the breaking change to generated model names yet.
+     */
+    @Parameter(property = "openapi.generator.maven.plugin.deduplicateSchemas", defaultValue = "true")
+    protected boolean deduplicateSchemas = true;
 
     @Parameter(name = "writeDebugFiles")
     protected boolean writeDebugFiles = false;
@@ -950,6 +960,10 @@ public class GenerateMojo extends InputMavenArtifactMojo {
 
             if(bundleSpecs) {
                 new Bundler(inputSpecFile).transform(input.getOpenAPI(), Collections.emptyMap());
+
+                if (deduplicateSchemas) {
+                    new DeduplicateSchemasTransformer().transform(input.getOpenAPI(), Collections.emptyMap());
+                }
 
                 if(writeDebugFiles) {
                     java.nio.file.Files.write(new File(output, "openapi-bundled.yaml").toPath(), Yaml.pretty(input.getOpenAPI()).getBytes(StandardCharsets.UTF_8));

--- a/boat-maven-plugin/src/test/java/com/backbase/oss/boat/BundleMojoTest.java
+++ b/boat-maven-plugin/src/test/java/com/backbase/oss/boat/BundleMojoTest.java
@@ -1,5 +1,6 @@
 package com.backbase.oss.boat;
 
+import com.backbase.oss.boat.loader.OpenAPILoader;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import java.io.File;
@@ -7,6 +8,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Set;
 
 import lombok.SneakyThrows;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -168,6 +170,49 @@ class BundleMojoTest {
 
         String outputApi = String.join( " ", Files.readAllLines(Paths.get(output.getPath())));
         assertTrue(outputApi.contains("version: 3.0.0"));
+    }
+
+    @Test
+    @SneakyThrows
+    void testBundleFolder_deduplicatesSchemasByDefault() {
+        File output = new File("target/test-bundle-duplicate-schema-dedup.yaml");
+
+        BundleMojo mojo = new BundleMojo();
+        mojo.setInput(getFile("/bundler/duplicate-schema/api.yaml"));
+        mojo.setOutput(output);
+        // deduplicateSchemas is left unset, exercising the default (true).
+        mojo.execute();
+
+        OpenAPI bundled = OpenAPILoader.load(output);
+        Set<String> schemaNames = bundled.getComponents().getSchemas().keySet();
+
+        assertEquals(1, schemaNames.size(), "The duplicate schema should have been merged away.");
+        assertTrue(schemaNames.contains("CurrencyExchangeArrangement"),
+            "The properly named (PascalCase) schema should be kept as the canonical one.");
+
+        String responseRef = bundled.getPaths().get("/currency-exchange-arrangements").getGet()
+            .getResponses().get("200").getContent().get("application/json").getSchema().get$ref();
+        assertEquals("#/components/schemas/CurrencyExchangeArrangement", responseRef,
+            "The response schema $ref should be rewritten to point at the canonical schema.");
+    }
+
+    @Test
+    @SneakyThrows
+    void testBundleFolder_keepsDuplicateSchemasWhenOptedOut() {
+        File output = new File("target/test-bundle-duplicate-schema-no-dedup.yaml");
+
+        BundleMojo mojo = new BundleMojo();
+        mojo.setInput(getFile("/bundler/duplicate-schema/api.yaml"));
+        mojo.setOutput(output);
+        mojo.setDeduplicateSchemas(false);
+        mojo.execute();
+
+        OpenAPI bundled = OpenAPILoader.load(output);
+        Set<String> schemaNames = bundled.getComponents().getSchemas().keySet();
+
+        assertEquals(2, schemaNames.size(),
+            "With deduplication opted out, both the canonical and the synthesized duplicate should remain.");
+        assertTrue(schemaNames.contains("CurrencyExchangeArrangement"));
     }
 
     @Test

--- a/boat-maven-plugin/src/test/resources/bundler/duplicate-schema/api.yaml
+++ b/boat-maven-plugin/src/test/resources/bundler/duplicate-schema/api.yaml
@@ -1,0 +1,19 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Duplicate Schema Test
+paths:
+  '/currency-exchange-arrangements':
+    get:
+      operationId: getCurrencyExchangeArrangement
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "./arrangement.yaml"
+components:
+  schemas:
+    CurrencyExchangeArrangement:
+      $ref: "./arrangement.yaml"

--- a/boat-maven-plugin/src/test/resources/bundler/duplicate-schema/arrangement.yaml
+++ b/boat-maven-plugin/src/test/resources/bundler/duplicate-schema/arrangement.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  id:
+    type: string
+    description: The id of this currency exchange arrangement.
+  rate:
+    type: number
+    description: The exchange rate.


### PR DESCRIPTION
## Summary
- Fixes DEVIN-705: `boat:bundle`/`boat:generate` could register the same external schema file under two different names when it's reachable both via its canonical component name and a direct `$ref` to the file, producing field-for-field identical models that show up as duplicate classes/doc pages downstream (e.g. duplicate model tabs on the developer portal).
- Adds `DeduplicateSchemasTransformer`, wired in right after bundling, to merge such duplicates and rewrite every `$ref` pointing at the discarded duplicate to the canonical entry.
- **Breaking change** for generated clients (Java/Angular-TS/Swift/Android-Kotlin): whichever duplicate name is dropped disappears from generated models. Documented in the README release notes.
- Added a `deduplicateSchemas` plugin parameter (default `true`) on `boat:bundle` and `boat:generate` to opt out while consumers migrate.

## Test plan
- [x] New unit tests `DeduplicateSchemasTransformerTests` (merge + ref rewrite, and no-op for distinct schemas) — `boat-engine`
- [x] New integration tests in `BundleMojoTest` against a new fixture (`bundler/duplicate-schema`) reproducing the ticket's scenario, covering both the default (dedup on) and opt-out (`deduplicateSchemas=false`) behavior
- [x] Full `boat-engine` test suite passes (33/33)
- [x] `boat-maven-plugin`'s `BundleMojoTest` (17/17) and `GeneratorTests` (8/8) pass

Fixes DEVIN-705

🤖 Generated with [Claude Code](https://claude.com/claude-code)