### PR TITLE
feat: add single request parameter support for RestTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ It currently consists of
 # Release Notes
 BOAT is still under development and subject to change.
 
+## 0.18.5
+ * Java RestTemplate generator: added `useSingleRequestParameter` support to generate named `*Param` overloads for multi-parameter operations, see [boat-maven-plugin README](boat-maven-plugin/README.md#single-request-parameter).
+
 ## 0.18.3
 * **Breaking change**: `boat:bundle` and `boat:generate` (when `bundleSpecs` is enabled) now de-duplicate
   `components/schemas` entries that are structurally identical but were registered under different names

--- a/boat-maven-plugin/README.md
+++ b/boat-maven-plugin/README.md
@@ -123,6 +123,19 @@ Same with `generate` but with opinionated defaults for Rest Template Client
         </additionalProperties>
     </configuration>
 
+### Single request parameter
+
+When enabled, BOAT generates a `*Param` inner class for each multi-parameter API method alongside
+the existing positional-argument overloads. Callers can use named parameters instead of a positional
+argument list, reducing the risk of argument-order mistakes when APIs evolve.
+
+    <configuration>
+        ...
+        <configOptions>
+            <useSingleRequestParameter>true</useSingleRequestParameter>
+        </configOptions>
+    </configuration>
+
 ### Property & Enum Name Mappings (new)
 
 Two new optional parameters are supported by the BOAT plugin (mirroring OpenAPI Generator capabilities) to rename generated members without post-processing:

--- a/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/api.mustache
+++ b/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/api.mustache
@@ -157,6 +157,14 @@ public class {{classname}} extends BaseApi {
         {{#returnType}}ParameterizedTypeReference<{{#returnType}}{{#isResponseFile}}{{#useAbstractionForFiles}}org.springframework.core.io.Resource{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{.}}}{{/useAbstractionForFiles}}{{/isResponseFile}}{{^isResponseFile}}{{{.}}}{{/isResponseFile}}{{/returnType}}> localReturnType = new ParameterizedTypeReference<{{#returnType}}{{#isResponseFile}}{{#useAbstractionForFiles}}org.springframework.core.io.Resource{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{.}}}{{/useAbstractionForFiles}}{{/isResponseFile}}{{^isResponseFile}}{{{.}}}{{/isResponseFile}}{{/returnType}}>() {};{{/returnType}}{{^returnType}}ParameterizedTypeReference<Void> localReturnType = new ParameterizedTypeReference<Void>() {};{{/returnType}}
         return apiClient.invokeAPI("{{{path}}}", HttpMethod.{{httpMethod}}, {{#hasPathParams}}uriVariables{{/hasPathParams}}{{^hasPathParams}}Collections.<String, Object>emptyMap(){{/hasPathParams}}, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localReturnType);
     }
+    {{#singleRequestParameter}}
+      {{#hasParams}}
+        {{^hasSingleParam}}
+          {{>libraries/resttemplate/singleRequestParameter}}
+        {{/hasSingleParam}}
+      {{/hasParams}}
+    {{/singleRequestParameter}}
+
     {{#-last}}
 
     @Override

--- a/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/singleRequestParameter.mustache
+++ b/boat-scaffold/src/main/templates/boat-java/libraries/resttemplate/singleRequestParameter.mustache
@@ -1,0 +1,146 @@
+/**
+* Parameters for the {@link #{{operationId}}({{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Param)}
+* operation.
+*/
+public static class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Param {
+{{#allParams}}
+  private {{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.core.io.Resource>{{/collectionFormat}}{{^collectionFormat}}org.springframework.core.io.Resource{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}};
+{{/allParams}}
+
+  public {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Param() {
+  }
+
+{{#allParams}}
+    public {{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.core.io.Resource>{{/collectionFormat}}{{^collectionFormat}}org.springframework.core.io.Resource{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} get{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}}() {
+    return this.{{paramName}};
+    }
+
+    public {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Param {{paramName}}(
+  {{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.core.io.Resource>{{/collectionFormat}}{{^collectionFormat}}org.springframework.core.io.Resource{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}}
+    ) {
+    this.{{paramName}} = {{paramName}};
+    return this;
+    }
+
+{{/allParams}}
+  @Override
+  public boolean equals(Object o) {
+  if (this == o) {
+  return true;
+  }
+
+  if (o == null || getClass() != o.getClass()) {
+  return false;
+  }
+
+{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Param param =
+  ({{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Param) o;
+
+  return {{#allParams}}{{#isByteArray}}java.util.Arrays.equals(this.{{paramName}}, param.{{paramName}}){{/isByteArray}}{{^isByteArray}}java.util.Objects.equals(this.{{paramName}}, param.{{paramName}}){{/isByteArray}}{{^-last}}
+    && {{/-last}}{{/allParams}};
+  }
+
+  @Override
+  public int hashCode() {
+  return java.util.Objects.hash(
+{{#allParams}}
+  {{#isByteArray}}java.util.Arrays.hashCode({{paramName}}){{/isByteArray}}{{^isByteArray}}{{paramName}}{{/isByteArray}}{{^-last}},{{/-last}}
+{{/allParams}}
+  );
+  }
+
+  @Override
+  public String toString() {
+  StringBuilder sb = new StringBuilder();
+
+  sb.append(
+  "class {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Param {\n"
+  );
+{{#allParams}}
+    sb.append("    {{paramName}}: ")
+    .append(toIndentedString({{paramName}}))
+    .append("\n");
+{{/allParams}}
+  sb.append("}");
+
+  return sb.toString();
+  }
+
+  private String toIndentedString(Object value) {
+  if (value == null) {
+  return "null";
+  }
+
+  return value.toString().replace("\n", "\n    ");
+  }
+  }
+
+  /**
+  * {{summary}}
+  * {{notes}}
+{{#responses}}
+    * <p><b>{{code}}</b>{{#message}} - {{.}}{{/message}}
+{{/responses}}
+  *
+  * @param params parameters for the {{operationId}} operation
+{{#returnType}}
+    * @return {{.}}
+{{/returnType}}
+  * @throws RestClientException if an error occurs while attempting to invoke the API
+{{#externalDocs}}
+    * {{description}}
+    * @see <a href="{{url}}">{{summary}} Documentation</a>
+{{/externalDocs}}
+{{#isDeprecated}}
+    * @deprecated
+{{/isDeprecated}}
+  */
+{{#isDeprecated}}
+    @Deprecated
+{{/isDeprecated}}
+  public {{#returnType}}{{#isResponseFile}}{{#useAbstractionForFiles}}org.springframework.core.io.Resource{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{.}}}{{/useAbstractionForFiles}}{{/isResponseFile}}{{^isResponseFile}}{{{.}}}{{/isResponseFile}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}(
+{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Param params
+  ) throws RestClientException {
+{{#returnType}}
+    return {{operationId}}WithHttpInfo(params).getBody();
+{{/returnType}}
+{{^returnType}}
+  {{operationId}}WithHttpInfo(params);
+{{/returnType}}
+  }
+
+  /**
+  * {{summary}}
+  * {{notes}}
+{{#responses}}
+    * <p><b>{{code}}</b>{{#message}} - {{.}}{{/message}}
+{{/responses}}
+  *
+  * @param params parameters for the {{operationId}} operation
+  * @return ResponseEntity&lt;{{returnType}}{{^returnType}}Void{{/returnType}}&gt;
+  * @throws RestClientException if an error occurs while attempting to invoke the API
+{{#externalDocs}}
+    * {{description}}
+    * @see <a href="{{url}}">{{summary}} Documentation</a>
+{{/externalDocs}}
+{{#isDeprecated}}
+    * @deprecated
+{{/isDeprecated}}
+  */
+{{#isDeprecated}}
+    @Deprecated
+{{/isDeprecated}}
+  public ResponseEntity<{{#returnType}}{{#isResponseFile}}{{#useAbstractionForFiles}}org.springframework.core.io.Resource{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{.}}}{{/useAbstractionForFiles}}{{/isResponseFile}}{{^isResponseFile}}{{{.}}}{{/isResponseFile}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo(
+  {{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}Param params
+  ) throws RestClientException {
+  java.util.Objects.requireNonNull(
+  params,
+  "params must not be null"
+  );
+
+  return {{operationId}}WithHttpInfo(
+  {{#allParams}}
+    params.get{{#lambda.titlecase}}{{paramName}}{{/lambda.titlecase}}(){{^-last}},{{/-last}}
+  {{/allParams}}
+  );
+  }

--- a/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatJavaCodeGenTests.java
+++ b/boat-scaffold/src/test/java/com/backbase/oss/codegen/java/BoatJavaCodeGenTests.java
@@ -7,30 +7,41 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openapitools.codegen.languages.JavaClientCodegen.GENERATE_CLIENT_AS_BEAN;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.stmt.Statement;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
 
 class BoatJavaCodeGenTests {
 
     static final String PROP_BASE = BoatJavaCodeGenTests.class.getSimpleName() + ".";
     static final String TEST_OUTPUT = System.getProperty(PROP_BASE + "output", "target/boat-java-codegen-tests");
+
     @Test
     void clientOptsUnicity() {
         final BoatJavaCodeGen gen = new BoatJavaCodeGen();
@@ -167,5 +178,119 @@ class BoatJavaCodeGenTests {
         assertThat("Expect Valid annotation.", getPojosMethod.getParameter(0).getType().toString().contains("@Valid"), is(useBeanValidation));
         assertThat("Expect jakarta Valid import", compilationUnit.getImports().stream().anyMatch(
                 id -> id.getNameAsString().equals("jakarta.validation.Valid")), is(useBeanValidation));
+    }
+
+    @Test
+    void shouldGenerateBackwardCompatibleSingleRequestParameterOverloads(@TempDir Path temporaryDirectory) throws FileNotFoundException {
+        ClassOrInterfaceDeclaration api = generateRestTemplateClient(
+            temporaryDirectory.resolve("generated-enabled"),
+            true
+        );
+
+        ClassOrInterfaceDeclaration parameters = findNestedClass(api, "ListPetsParam").orElseThrow();
+        assertTrue(parameters.isStatic());
+        assertTrue(findNestedClass(api, "ShowPetByIdParam").isEmpty());
+
+        findMethod(api, "listPets", "Integer", "String");
+        findMethod(api, "listPetsWithHttpInfo", "Integer", "String");
+
+        MethodDeclaration listPets = findMethod(api, "listPets", "ListPetsParam");
+        assertEquals("listPetsWithHttpInfo(params).getBody()", returnExpression(listPets));
+
+        MethodDeclaration listPetsWithHttpInfo = findMethod(api, "listPetsWithHttpInfo", "ListPetsParam");
+        assertEquals(
+            "listPetsWithHttpInfo(params.getLimit(), params.getStatus())",
+            returnExpression(listPetsWithHttpInfo)
+        );
+    }
+
+    @Test
+    void shouldNotGenerateSingleRequestParameterOverloadsByDefault(
+        @TempDir Path temporaryDirectory
+    ) throws FileNotFoundException {
+        ClassOrInterfaceDeclaration api = generateRestTemplateClient(
+            temporaryDirectory.resolve("generated-disabled"),
+            false
+        );
+
+        assertFalse(findNestedClass(api, "ListPetsParam").isPresent());
+        assertEquals(1, api.getMethodsByName("listPets").size());
+        assertEquals(1, api.getMethodsByName("listPetsWithHttpInfo").size());
+        findMethod(api, "listPets", "Integer", "String");
+        findMethod(api, "listPetsWithHttpInfo", "Integer", "String");
+    }
+
+    private ClassOrInterfaceDeclaration generateRestTemplateClient(Path outputDirectory, boolean useSingleRequestParameter)
+        throws FileNotFoundException {
+        CodegenConfigurator configurator = getCodegenConfigurator(outputDirectory);
+
+        if (useSingleRequestParameter) {
+            configurator.addAdditionalProperty("useSingleRequestParameter", true);
+        }
+
+        File generatedApi = new DefaultGenerator()
+            .opts(configurator.toClientOptInput())
+            .generate()
+            .stream()
+            .filter(file -> file.getName().equals("PetsApi.java"))
+            .findFirst()
+            .orElseThrow();
+
+        return StaticJavaParser.parse(generatedApi)
+            .getClassByName("PetsApi")
+            .orElseThrow();
+    }
+
+    private CodegenConfigurator getCodegenConfigurator(Path outputDirectory) {
+        CodegenConfigurator configurator = new CodegenConfigurator();
+        configurator.setGeneratorName("boat-java");
+        configurator.setLibrary("resttemplate");
+        configurator.setInputSpec(
+            getFile("/boat-java/petstore-single-request-parameter.yaml")
+                .getAbsolutePath()
+        );
+        configurator.setOutputDir(outputDirectory.toAbsolutePath().toString());
+        configurator.setApiPackage("com.example.api");
+        configurator.setModelPackage("com.example.model");
+        return configurator;
+    }
+
+    private static MethodDeclaration findMethod(ClassOrInterfaceDeclaration api, String name, String... parameterTypes) {
+        List<MethodDeclaration> methods = api.getMethodsBySignature(name, parameterTypes);
+
+        assertEquals(1, methods.size(),
+            () -> "Expected exactly one method " + name + List.of(parameterTypes) + ", but found " + methods.size()
+        );
+
+        return methods.get(0);
+    }
+
+    private static Optional<ClassOrInterfaceDeclaration> findNestedClass(ClassOrInterfaceDeclaration api, String name) {
+        return api.getMembers()
+            .stream()
+            .filter(BodyDeclaration::isClassOrInterfaceDeclaration)
+            .map(BodyDeclaration::asClassOrInterfaceDeclaration)
+            .filter(type -> type.getNameAsString().equals(name))
+            .findFirst();
+    }
+
+    private static String returnExpression(MethodDeclaration method) {
+        return method.getBody()
+            .orElseThrow()
+            .getStatements()
+            .stream()
+            .filter(Statement::isReturnStmt)
+            .map(Statement::asReturnStmt)
+            .map(ReturnStmt::getExpression)
+            .flatMap(Optional::stream)
+            .map(Object::toString)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(
+                "No direct return statement found in " + method.getSignature()
+            ));
+    }
+
+    private File getFile(String fileName) {
+        return new File(getClass().getResource(fileName).getFile());
     }
 }

--- a/boat-scaffold/src/test/resources/boat-java/petstore-single-request-parameter.yaml
+++ b/boat-scaffold/src/test/resources/boat-java/petstore-single-request-parameter.yaml
@@ -1,0 +1,153 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: status
+          in: query
+          description: Status of pets to return
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+            text/csv:
+              schema:
+                type: string
+        500:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: InternalServerError
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /no-schema:
+    get:
+      summary: No Schema
+      operationId: getNoSchema
+      tags:
+        - pets
+      responses:
+        200:
+          description: A response that does not specify a schema
+          content:
+            application/json: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+        size:
+          $ref: '#/components/schemas/Size'
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Size:
+      type: string
+      description: Size of the pet
+      enum:
+        - SMALL
+        - MEDIUM
+        - LARGE
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    InternalServerError:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string


### PR DESCRIPTION
## Summary

Adds `useSingleRequestParameter` support to the Java RestTemplate generator.

When enabled, BOAT generates a static `*Param` inner class and corresponding overloads for operations with multiple parameters. Existing positional-argument methods are preserved for backward compatibility.

## Changes

* Add RestTemplate template support for `useSingleRequestParameter`
* Generate `*Param` classes for multi-parameter operations
* Keep existing positional overloads unchanged
* Do not generate parameter objects for operations with zero or one parameter
* Add regression tests for enabled and disabled configurations
* Document the option in the Maven plugin README

Example configuration:

```xml
<configOptions>
    <useSingleRequestParameter>true</useSingleRequestParameter>
</configOptions>
```

## Testing

* `mvn clean verify -Dgpg.skip`
* Validated the generated RestTemplate client with the option enabled and disabled
* Verified that existing positional methods remain unchanged
* Verified that `*Param` overloads are generated for multi-parameter operations
* Verified that single-parameter operations remain unchanged
