### PR TITLE
fix(ci): revert kotlin.version to 2.4.10 to unbreak CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
+    ignore:
+      # CodeQL 2.27.0's Kotlin interceptor only supports versions below 2.4.20;
+      # bumping past that breaks the CodeQL Analyze (java) workflow.
+      - dependency-name: "org.jetbrains.kotlin:*"
+        versions: [ ">=2.4.20" ]
     groups:
       # Specific group for org.openapitools.* artifacts.
       # For Maven, patterns are matched against "groupId:artifactId",

--- a/boat-quay/boat-quay-lint/pom.xml
+++ b/boat-quay/boat-quay-lint/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
-        <kotlin.version>2.4.20</kotlin.version>
+        <kotlin.version>2.4.10</kotlin.version>
         <kotlin.compiler.incremental>false</kotlin.compiler.incremental>
     </properties>
 

--- a/boat-quay/pom.xml
+++ b/boat-quay/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
-        <kotlin.version>2.4.20</kotlin.version>
+        <kotlin.version>2.4.10</kotlin.version>
         <kotlin.compiler.incremental>false</kotlin.compiler.incremental>
         <auto-service.version>1.1.1</auto-service.version>
     </properties>


### PR DESCRIPTION
Dependabot bumped kotlin.version to 2.4.20 in #1287, but CodeQL CLI 2.27.0's Kotlin interceptor only supports versions below 2.4.20, causing the Analyze (java) job to fail on push to main. CodeQL only runs on push/schedule, not on PRs, so the dependabot PR build didn't catch it.

Also add a dependabot ignore rule so kotlin isn't bumped past 2.4.10 again until CodeQL adds support for newer versions.